### PR TITLE
Fixes #97 - Cannot zoom-out after zoom-in simulated-plot

### DIFF
--- a/src/OSPSuite.UI/Controls/UxChartControl.cs
+++ b/src/OSPSuite.UI/Controls/UxChartControl.cs
@@ -32,10 +32,11 @@ namespace OSPSuite.UI.Controls
          _clipboardTask = new ClipboardTask();
          _barManager = new BarManager {Form = this};
          _popupMenu = new PopupMenu(_barManager);
-         _barManager.SetPopupContextMenu(this, _popupMenu);
 
-         if (addDefaultPopup)
-            initializePopup();
+         if (!addDefaultPopup) return;
+
+         _barManager.SetPopupContextMenu(this, _popupMenu);
+         initializePopup();
       }
 
       /// <summary>

--- a/src/OSPSuite.UI/Controls/UxChartControl.cs
+++ b/src/OSPSuite.UI/Controls/UxChartControl.cs
@@ -33,10 +33,8 @@ namespace OSPSuite.UI.Controls
          _barManager = new BarManager {Form = this};
          _popupMenu = new PopupMenu(_barManager);
 
-         if (!addDefaultPopup) return;
-
-         _barManager.SetPopupContextMenu(this, _popupMenu);
-         initializePopup();
+         if (addDefaultPopup)
+            initializePopup();
       }
 
       /// <summary>
@@ -104,6 +102,7 @@ namespace OSPSuite.UI.Controls
 
       private void initializePopup()
       {
+         _barManager.SetPopupContextMenu(this, _popupMenu);
          AddPopupMenu(Captions.CopyAsImage, CopyToClipboard, ApplicationIcons.Paste);
       }
 

--- a/src/OSPSuite.UI/Views/Charts/ChartDisplayView.Designer.cs
+++ b/src/OSPSuite.UI/Views/Charts/ChartDisplayView.Designer.cs
@@ -55,7 +55,7 @@ namespace OSPSuite.UI.Views.Charts
          this.barDockControlBottom = new DevExpress.XtraBars.BarDockControl();
          this.barDockControlLeft = new DevExpress.XtraBars.BarDockControl();
          this.barDockControlRight = new DevExpress.XtraBars.BarDockControl();
-         this.chartControl = new UxChartControl();
+         this.chartControl = new UxChartControl(addDefaultPopup: false);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._barManager)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.chartControl)).BeginInit();


### PR DESCRIPTION
the barManager.SetPopupContextMenu is apparently disabling the click handler from the UxChartControl for right click.