### PR TITLE
Fixes #137 - Crash setting Max = 0 for log scale

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1418,6 +1418,23 @@ namespace OSPSuite.Assets
          var separator = "\n\t- ";
          return $"A circular reference was found in formula of {entityType.ToLower()} '{entity}' with path '{entityPath}'\nPlease check the direct or indirect references:{separator}{references.ToString(separator)}";
       }
+
+      public static string AxisMaxMustBeGreaterThanOrEqualToAxisMin(float? axisMinimumValue)
+      {
+         var preamble = "The axis maximum value should be greater than or equal to the axis minimum value";
+         return axisMinimumValue.HasValue ? $"{preamble} '{axisMinimumValue}'" : preamble;
+      }
+
+      public static string AxisMinMustBeLessThanOrEqualToAxisMax(float? axisMaximumValue)
+      {
+         var preamble = "The axis minimum value should be less than or equal to the axis maximum value";
+         return axisMaximumValue.HasValue ? $"{preamble} '{axisMaximumValue}'" : preamble;
+      }
+
+      public static string AxisMaxMustBeGreaterThanZero()
+      {
+         return "The axis maximum must be greater than 0";
+      }
    }
 
    public static class Rules

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1431,10 +1431,7 @@ namespace OSPSuite.Assets
          return axisMaximumValue.HasValue ? $"{preamble} '{axisMaximumValue}'" : preamble;
       }
 
-      public static string AxisMaxMustBeGreaterThanZero()
-      {
-         return "The axis maximum must be greater than 0";
-      }
+      public static readonly string LogAxisMaxMustBeGreaterThanZero = "Loagarithmic axis maximum must be greater than 0";
    }
 
    public static class Rules

--- a/src/OSPSuite.Core/Chart/Axis.cs
+++ b/src/OSPSuite.Core/Chart/Axis.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Utility.Validation;
 
 namespace OSPSuite.Core.Chart
 {
@@ -20,7 +23,7 @@ namespace OSPSuite.Core.Chart
       Relative
    }
 
-   public class Axis : MyNotifier, IWithDimension
+   public class Axis : MyNotifier, IWithDimension, IValidatable
    {
       private IDimension _dimension;
       private bool _gridLines;
@@ -34,6 +37,7 @@ namespace OSPSuite.Core.Chart
       private Color _defaultColor;
       private bool _visible;
       public AxisTypes AxisType { get; }
+      public virtual IBusinessRuleSet Rules { get; }
 
       [Obsolete("For serialization")]
       public Axis() : this(AxisTypes.X)
@@ -54,6 +58,45 @@ namespace OSPSuite.Core.Chart
          Visible = true;
          _defaultLineStyle = defaultLineStyleForAxisType();
          _defaultColor = Color.White;
+         Rules = new BusinessRuleSet(ValidationRules.AllRules());
+      }
+
+      private static class ValidationRules
+      {
+         internal static IEnumerable<IBusinessRule> AllRules()
+         {
+            yield return maxGreaterThanOrEqualToMin;
+            yield return minLessThanOrEqualToMax;
+            yield return maxGreaterThanZero;
+         }
+
+         private static IBusinessRule maxGreaterThanOrEqualToMin { get; } = maxGreaterThanOrEqualToMinForAxis();
+         private static IBusinessRule minLessThanOrEqualToMax { get; } = minLessThanOrEqualToMaxForAxis();
+         private static IBusinessRule maxGreaterThanZero { get; } = maxGreaterThanZeroForLogarithmicAxis();
+
+         private static IBusinessRule minLessThanOrEqualToMaxForAxis()
+         {
+            return CreateRule.For<Axis>()
+               .Property(axis => axis.Min)
+               .WithRule((axis, value) => !value.HasValue || !axis.Max.HasValue || axis.Max >= value)
+               .WithError((axis, value) => Validation.AxisMinMustBeLessThanOrEqualToAxisMax(axis.Max));
+         }
+
+         private static IBusinessRule maxGreaterThanZeroForLogarithmicAxis()
+         {
+            return CreateRule.For<Axis>()
+               .Property(axis => axis.Max)
+               .WithRule((axis, value) => !value.HasValue || axis.Scaling != Scalings.Log || value > 0F)
+               .WithError((axis, value) => Validation.AxisMaxMustBeGreaterThanZero());
+         }
+
+         private static IBusinessRule maxGreaterThanOrEqualToMinForAxis()
+         {
+            return CreateRule.For<Axis>()
+               .Property(axis => axis.Max)
+               .WithRule((axis, value) => !value.HasValue || !axis.Min.HasValue || value >= axis.Min)
+               .WithError((axis, value) => Validation.AxisMaxMustBeGreaterThanOrEqualToAxisMin(axis.Min));
+         }
       }
 
       private LineStyles defaultLineStyleForAxisType()

--- a/src/OSPSuite.Core/Chart/Axis.cs
+++ b/src/OSPSuite.Core/Chart/Axis.cs
@@ -70,33 +70,24 @@ namespace OSPSuite.Core.Chart
             yield return maxGreaterThanZero;
          }
 
-         private static IBusinessRule maxGreaterThanOrEqualToMin { get; } = maxGreaterThanOrEqualToMinForAxis();
-         private static IBusinessRule minLessThanOrEqualToMax { get; } = minLessThanOrEqualToMaxForAxis();
-         private static IBusinessRule maxGreaterThanZero { get; } = maxGreaterThanZeroForLogarithmicAxis();
+         private static IBusinessRule maxGreaterThanOrEqualToMin { get; } = createMaxGreaterThanOrEqualToMinRuleForAxis();
+         private static IBusinessRule minLessThanOrEqualToMax { get; } = createMinLessThanOrEqualToMaxRuleForAxis();
+         private static IBusinessRule maxGreaterThanZero { get; } = createMaxGreaterThanZeroRuleForLogarithmicAxis();
 
-         private static IBusinessRule minLessThanOrEqualToMaxForAxis()
-         {
-            return CreateRule.For<Axis>()
+         private static IBusinessRule createMinLessThanOrEqualToMaxRuleForAxis() => CreateRule.For<Axis>()
                .Property(axis => axis.Min)
                .WithRule((axis, value) => !value.HasValue || !axis.Max.HasValue || axis.Max >= value)
                .WithError((axis, value) => Validation.AxisMinMustBeLessThanOrEqualToAxisMax(axis.Max));
-         }
-
-         private static IBusinessRule maxGreaterThanZeroForLogarithmicAxis()
-         {
-            return CreateRule.For<Axis>()
+      
+         private static IBusinessRule createMaxGreaterThanZeroRuleForLogarithmicAxis() => CreateRule.For<Axis>()
                .Property(axis => axis.Max)
                .WithRule((axis, value) => !value.HasValue || axis.Scaling != Scalings.Log || value > 0F)
-               .WithError((axis, value) => Validation.AxisMaxMustBeGreaterThanZero());
-         }
-
-         private static IBusinessRule maxGreaterThanOrEqualToMinForAxis()
-         {
-            return CreateRule.For<Axis>()
+               .WithError((axis, value) => Validation.LogAxisMaxMustBeGreaterThanZero);
+      
+         private static IBusinessRule createMaxGreaterThanOrEqualToMinRuleForAxis() => CreateRule.For<Axis>()
                .Property(axis => axis.Max)
                .WithRule((axis, value) => !value.HasValue || !axis.Min.HasValue || value >= axis.Min)
                .WithError((axis, value) => Validation.AxisMaxMustBeGreaterThanOrEqualToAxisMin(axis.Min));
-         }
       }
 
       private LineStyles defaultLineStyleForAxisType()

--- a/src/OSPSuite.UI/Binders/AxisBinder.cs
+++ b/src/OSPSuite.UI/Binders/AxisBinder.cs
@@ -163,10 +163,14 @@ namespace OSPSuite.UI.Binders
          else // somebody inserted a limit...
          {
             if (!Axis.Min.HasValue)
-               Axis.Min = Convert.ToSingle(_axisView.WholeRange.MinValue);
+            {
+               var rangeMin = Convert.ToSingle(_axisView.WholeRange.MinValue);
+               Axis.Min = Axis.Max.HasValue ? Math.Min(Axis.Max.Value, rangeMin) :  rangeMin;
+            }
 
             if (!Axis.Max.HasValue)
-               Axis.Max = Convert.ToSingle(_axisView.WholeRange.MaxValue);
+               Axis.Max = Math.Max(Axis.Min.Value, Convert.ToSingle(_axisView.WholeRange.MaxValue));
+               
          }
          _explicitRange = !_explicitRange;
       }

--- a/src/OSPSuite.UI/Binders/AxisBinder.cs
+++ b/src/OSPSuite.UI/Binders/AxisBinder.cs
@@ -18,7 +18,7 @@ using OSPAxis = OSPSuite.Core.Chart.Axis;
 
 namespace OSPSuite.UI.Binders
 {
-  internal class AxisBinder : IAxisBinder
+   public class AxisBinder : IAxisBinder
    {
       private const int DEVEXPRESS_DEFAULT_Y_MINOR_TICKS = 4;
       private const int DEVEXPRESS_DEFAULT_X_MINOR_TICKS = 1;

--- a/tests/OSPSuite.Core.Tests/Core/AxisSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Core/AxisSpecs.cs
@@ -4,6 +4,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Helpers;
+using OSPSuite.Utility.Validation;
 
 namespace OSPSuite.Core
 {
@@ -12,19 +13,29 @@ namespace OSPSuite.Core
 
    }
 
-   public abstract class When_testing_axis_types_for_Y : concern_for_Axis
+   public class When_validating_axis_minimum_and_maximum : concern_for_Axis
    {
-      protected AxisTypes _axisType;
-      protected override void Context()
+      [Observation]
+      public void invalid_for_max_less_than_min()
       {
-         sut = new Axis(_axisType);
+         new Axis(AxisTypes.X)
+         {
+            Min = 0,
+            Max = -1
+         }.IsValid().ShouldBeEqualTo(false);
       }
 
       [Observation]
-      public void test_for_type_should_be_true()
+      public void invalid_for_log_max_equal_to_0()
       {
-         sut.IsYAxis.ShouldBeTrue();
+         new Axis(AxisTypes.X)
+         {
+            Scaling = Scalings.Log,
+            Min = 0,
+            Max = 0
+         }.IsValid().ShouldBeEqualTo(false);
       }
+
    }
 
    public class When_updating_an_axis_properties_from_another : concern_for_Axis
@@ -100,6 +111,21 @@ namespace OSPSuite.Core
       public void test_for_type_should_be_true()
       {
          sut.IsYAxis.ShouldBeFalse();
+      }
+   }
+
+   public abstract class When_testing_axis_types_for_Y : concern_for_Axis
+   {
+      protected AxisTypes _axisType;
+      protected override void Context()
+      {
+         sut = new Axis(_axisType);
+      }
+
+      [Observation]
+      public void test_for_type_should_be_true()
+      {
+         sut.IsYAxis.ShouldBeTrue();
       }
    }
 

--- a/tests/OSPSuite.Core.Tests/Core/AxisSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Core/AxisSpecs.cs
@@ -22,7 +22,7 @@ namespace OSPSuite.Core
          {
             Min = 0,
             Max = -1
-         }.IsValid().ShouldBeEqualTo(false);
+         }.IsValid().ShouldBeFalse();
       }
 
       [Observation]
@@ -33,7 +33,7 @@ namespace OSPSuite.Core
             Scaling = Scalings.Log,
             Min = 0,
             Max = 0
-         }.IsValid().ShouldBeEqualTo(false);
+         }.IsValid().ShouldBeFalse();
       }
 
    }

--- a/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
@@ -1,0 +1,124 @@
+﻿using System.Drawing;
+using System.Windows.Forms.VisualStyles;
+using DevExpress.XtraCharts;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.UI.Controls;
+using OSPSuite.Utility.Format;
+using Axis = OSPSuite.Core.Chart.Axis;
+
+namespace OSPSuite.UI.Binders
+{
+   public abstract class concern_for_AxisBinder : ContextSpecification<AxisBinder>
+   {
+      protected UxChartControl _uxChartControl;
+      protected Axis _axis;
+      private Series _series;
+
+      protected override void Context()
+      {
+         base.Context();
+         _uxChartControl = new UxChartControl();
+         _series = new Series("dummySeries", ViewType.ScatterLine);
+         _uxChartControl.Series.Add(_series);
+         _axis = new Axis(AxisTypes.Y);
+         _uxChartControl.XYDiagram.AxisY.VisualRange.Auto = true;
+         _uxChartControl.XYDiagram.AxisY.WholeRange.Auto = true;
+         sut = new AxisBinder(_axis, _uxChartControl, new NumericFormatterOptions());
+      }
+
+      protected float RangeMax()
+      {
+         return System.Convert.ToSingle(_uxChartControl.XYDiagram.AxisY.WholeRange.MaxValue);
+      }
+
+      protected float RangeMin()
+      {
+         return System.Convert.ToSingle(_uxChartControl.XYDiagram.AxisY.WholeRange.MinValue);
+      }
+   }
+
+   public class When_refreshing_adapter_and_an_axis_has_max_set_within_series_range : concern_for_AxisBinder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _axis.Max = 1.5F;
+      }
+
+      protected override void Because()
+      {
+         sut.RefreshRange(sideMarginsEnabled: true, diagramSize: new Size(100, 100));
+      }
+
+      [Observation]
+      public void the_min_should_be_set_to_equal_the_max()
+      {
+         _axis.Min.ShouldBeEqualTo(RangeMin());
+      }
+   }
+
+   public class When_refreshing_adapter_and_an_axis_has_min_set_within_series_range : concern_for_AxisBinder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _axis.Min = 1.5F;
+      }
+
+      protected override void Because()
+      {
+         sut.RefreshRange(sideMarginsEnabled: true, diagramSize: new Size(100, 100));
+      }
+
+      [Observation]
+      public void the_min_should_be_set_to_equal_the_max()
+      {
+         _axis.Max.ShouldBeEqualTo(RangeMax());
+      }
+   }
+
+
+
+   public class When_refreshing_adapter_and_an_axis_has_min_set_higher_than_max_of_series : concern_for_AxisBinder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _axis.Min = RangeMax() + 1.0F;
+      }
+
+      protected override void Because()
+      {
+         sut.RefreshRange(sideMarginsEnabled: true, diagramSize: new Size(100, 100));
+      }
+
+      [Observation]
+      public void the_min_should_be_set_to_equal_the_max()
+      {
+         _axis.Max.ShouldBeEqualTo(_axis.Min);
+      }
+   }
+
+   public class When_refreshing_adapter_and_an_axis_has_max_set_below_min_of_series : concern_for_AxisBinder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _axis.Max = RangeMin() - 1.0F;
+      }
+
+      protected override void Because()
+      {
+         sut.RefreshRange(sideMarginsEnabled:true, diagramSize:new Size(100,100));
+      }
+
+      [Observation]
+      public void the_min_should_be_set_to_equal_the_max()
+      {
+         _axis.Min.ShouldBeEqualTo(_axis.Max);
+      }
+   }
+}

--- a/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
@@ -1,7 +1,5 @@
 ﻿using System.Drawing;
-using System.Windows.Forms.VisualStyles;
 using DevExpress.XtraCharts;
-using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
@@ -79,8 +77,6 @@ namespace OSPSuite.UI.Binders
          _axis.Max.ShouldBeEqualTo(RangeMax());
       }
    }
-
-
 
    public class When_refreshing_adapter_and_an_axis_has_min_set_higher_than_max_of_series : concern_for_AxisBinder
    {

--- a/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Binders/AxisBinderSpecs.cs
@@ -54,7 +54,7 @@ namespace OSPSuite.UI.Binders
       }
 
       [Observation]
-      public void the_min_should_be_set_to_equal_the_max()
+      public void the_min_should_be_the_range_min()
       {
          _axis.Min.ShouldBeEqualTo(RangeMin());
       }
@@ -74,7 +74,7 @@ namespace OSPSuite.UI.Binders
       }
 
       [Observation]
-      public void the_min_should_be_set_to_equal_the_max()
+      public void the_max_should_be_the_range_max()
       {
          _axis.Max.ShouldBeEqualTo(RangeMax());
       }

--- a/tests/OSPSuite.UI.Tests/OSPSuite.UI.Tests.csproj
+++ b/tests/OSPSuite.UI.Tests/OSPSuite.UI.Tests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="..\..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Binders\AxisBinderSpecs.cs" />
     <Compile Include="ClipboardTaskSpecs.cs" />
     <Compile Include="ColumnMappingControlSpecs.cs" />
     <Compile Include="FormExtensionsSpecs.cs" />


### PR DESCRIPTION
That was formerly causing StackOverflowException in the event loops.

Now that we only respond to property changes once, the programs don't crash, but there was still an exception stack shown to the user because you cannot set a DevExpress Axis visual or whole range with the min > max. 

It should also not be possible to set the max to 0 for log scale. I thought about the same rule for min, but there's already an overriding behavior when you try to set min = 0 for log scale.