### PR TITLE
Fixes #271 output selection hidden

### DIFF
--- a/src/OSPSuite.UI/Binders/OptimizedParametersBinder.cs
+++ b/src/OSPSuite.UI/Binders/OptimizedParametersBinder.cs
@@ -23,7 +23,6 @@ namespace OSPSuite.UI.Binders
       private GridViewBinder<OptimizedParameterDTO> _gridViewBinder;
       private readonly ValueDTOFormatter _valueFormatter = new ValueDTOFormatter();
       private readonly RepositoryItemPictureEdit _rangeRepository = new RepositoryItemPictureEdit();
-      private UxRepositoryItemImageComboBox _nameRepository;
       private IGridViewBoundColumn<OptimizedParameterDTO, Image> _imageColumn;
 
       public OptimizedParametersBinder(IImageListRetriever imageListRetriever, IToolTipCreator toolTipCreator)
@@ -38,8 +37,6 @@ namespace OSPSuite.UI.Binders
       public void InitializeBinding(GridViewBinder<OptimizedParameterDTO> gridViewBinder)
       {
          _gridViewBinder = gridViewBinder;
-
-         _nameRepository = new UxRepositoryItemImageComboBox(_gridViewBinder.GridView,_imageListRetriever);
 
          var col = _gridViewBinder.AutoBind(x => x.Name)
             .WithCaption(Captions.Name)
@@ -73,9 +70,8 @@ namespace OSPSuite.UI.Binders
 
       private RepositoryItem nameRepositoryFor(OptimizedParameterDTO optimizedParameterDTO)
       {
-         _nameRepository.Items.Clear();
-         _nameRepository.Items.Add(new ImageComboBoxItem(optimizedParameterDTO.Name, _imageListRetriever.ImageIndex(optimizedParameterDTO.BoundaryCheckIcon.IconName)));
-         return _nameRepository;
+         var nameRepository = new UxRepositoryItemImageComboBox(_gridViewBinder.GridView, _imageListRetriever);
+         return nameRepository.AddItem(optimizedParameterDTO.Name, optimizedParameterDTO.BoundaryCheckIcon);
       }
 
       private IGridViewAutoBindColumn<OptimizedParameterDTO, T> bind<T>(Expression<Func<OptimizedParameterDTO, T>> expression, string caption)

--- a/src/OSPSuite.UI/RepositoryItems/UxRepositoryItemImageComboBox.cs
+++ b/src/OSPSuite.UI/RepositoryItems/UxRepositoryItemImageComboBox.cs
@@ -1,23 +1,44 @@
 using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraGrid.Views.Base;
+using OSPSuite.Assets;
 using OSPSuite.UI.Services;
 
 namespace OSPSuite.UI.RepositoryItems
 {
    /// <summary>
-   ///   Simple wrapper over repository item image combo box that ensure that 
-   ///   1-the change event is fired as soon as the combo box selection is changed, and not only after the row loses the focus
-   ///   2-The editor is read only (default for PKSim Combo Boxes)
+   ///    Simple wrapper over repository item image combo box that ensure that
+   ///    1-the change event is fired as soon as the combo box selection is changed, and not only after the row loses the
+   ///    focus
+   ///    2-The editor is read only (default for PKSim Combo Boxes)
    /// </summary>
    public class UxRepositoryItemImageComboBox : RepositoryItemImageComboBox
    {
+      private readonly IImageListRetriever _imageListRetriever;
+
       public UxRepositoryItemImageComboBox(BaseView view, IImageListRetriever imageListRetriever)
       {
+         _imageListRetriever = imageListRetriever;
          TextEditStyle = TextEditStyles.DisableTextEditor;
          EditValueChanged += (o, e) => view.PostEditor();
-         SmallImages = imageListRetriever.AllImages16x16;
-         LargeImages = imageListRetriever.AllImages32x32;
+         SmallImages = _imageListRetriever.AllImages16x16;
+         LargeImages = _imageListRetriever.AllImages32x32;
+      }
+
+      public UxRepositoryItemImageComboBox AddItem(object value, ApplicationIcon icon)
+      {
+         return AddItem(value, _imageListRetriever.ImageIndex(icon));
+      }
+
+      public UxRepositoryItemImageComboBox AddItem(object value, string iconName)
+      {
+         return AddItem(value, _imageListRetriever.ImageIndex(iconName));
+      }
+
+      public UxRepositoryItemImageComboBox AddItem(object value, int iconIndex)
+      {
+         Items.Add(new ImageComboBoxItem(value, iconIndex));
+         return this;
       }
    }
 }

--- a/src/OSPSuite.UI/Views/Journal/JournalView.cs
+++ b/src/OSPSuite.UI/Views/Journal/JournalView.cs
@@ -42,7 +42,6 @@ namespace OSPSuite.UI.Views.Journal
       private readonly DateTimeFormatter _dateTimeFormatter;
       private readonly RepositoryItemRichTextEdit _descriptionRepository;
       private IGridViewColumn _columnTags;
-      private readonly UxRepositoryItemImageComboBox _titleWithImageRepository;
       private readonly RepositoryItemTextEdit _titleRepository;
       public BarManager PopupBarManager { get; private set; }
 
@@ -69,7 +68,6 @@ namespace OSPSuite.UI.Views.Journal
          gridView.ShowFilterPopupListBox += (o, e) => OnEvent(onShowFilterPopupListBox, e);
          gridView.MeasurePreviewHeight += (o, e) => OnEvent(onMeasurePreviewHeight, e);
 
-         _titleWithImageRepository = new UxRepositoryItemImageComboBox(gridView, imageListRetriever);
          _titleRepository = new RepositoryItemTextEdit();
 
          _dateTimeFormatter = new DateTimeFormatter();
@@ -112,12 +110,12 @@ namespace OSPSuite.UI.Views.Journal
 
       private string getFilterString(string fieldName, string tag)
       {
-         return string.Format("[{0}] LIKE '%{1}%'", fieldName, tag);
+         return $"[{fieldName}] LIKE '%{tag}%'";
       }
 
       private string getFilterDisplayText(string tag)
       {
-         return string.Format("Is tagged with '{0}'", tag);
+         return $"Is tagged with '{tag}'";
       }
 
       private void onGridViewDoubleClicked(EventArgs e)
@@ -214,9 +212,8 @@ namespace OSPSuite.UI.Views.Journal
          if (_presenter.AllItemsHaveTheSameOrigin)
             return _titleRepository;
 
-         _titleWithImageRepository.Items.Clear();
-         _titleWithImageRepository.Items.Add(new ImageComboBoxItem(dto.Title, _imageListRetriever.ImageIndex(dto.Origin.Icon)));
-         return _titleWithImageRepository;
+         var titleWithImageRepository = new UxRepositoryItemImageComboBox(gridView, _imageListRetriever);
+         return titleWithImageRepository.AddItem(dto.Title, dto.Origin.Icon);
       }
 
       private IGridViewAutoBindColumn<JournalPageDTO, T> bind<T>(Expression<Func<JournalPageDTO, T>> expression)

--- a/src/OSPSuite.UI/Views/Journal/RelatedItemsView.cs
+++ b/src/OSPSuite.UI/Views/Journal/RelatedItemsView.cs
@@ -30,7 +30,6 @@ namespace OSPSuite.UI.Views.Journal
       private readonly PopupContainerControl _popupControl = new PopupContainerControl();
       private readonly RepositoryItemPopupContainerEdit _repositoryCompareRelatedItem = new RepositoryItemPopupContainerEdit();
       private readonly GridViewBinder<RelatedItem> _gridViewBinder;
-      private readonly RepositoryItemImageComboBox _itemTypeRepository;
       private IGridViewColumn _compareColumn;
       private IGridViewColumn _reloadColumn;
       private IGridViewColumn _deleteColumn;
@@ -40,7 +39,6 @@ namespace OSPSuite.UI.Views.Journal
          _imageListRetriever = imageListRetriever;
          _toolTipCreator = toolTipCreator;
          InitializeComponent();
-         _itemTypeRepository = new UxRepositoryItemImageComboBox(gridView, imageListRetriever);
          _repositoryCompareRelatedItem.PopupControl = _popupControl;
          _repositoryCompareRelatedItem.EditValueChanged += (o, e) => gridView.PostEditor();
          _gridViewBinder = new GridViewBinder<RelatedItem>(gridView);
@@ -124,9 +122,8 @@ namespace OSPSuite.UI.Views.Journal
 
       private RepositoryItem configureItemTypeRepository(RelatedItem relatedItem)
       {
-         _itemTypeRepository.Items.Clear();
-         _itemTypeRepository.Items.Add(new ImageComboBoxItem(relatedItem.ItemType, _imageListRetriever.ImageIndex(relatedItem.IconName)));
-         return _itemTypeRepository;
+         var itemTypeRepository = new UxRepositoryItemImageComboBox(gridView, _imageListRetriever);
+         return itemTypeRepository.AddItem(relatedItem.ItemType, relatedItem.IconName);
       }
 
       public override void InitializeResources()

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationFeedbackView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationFeedbackView.cs
@@ -20,7 +20,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       private IMultipleParameterIdentificationFeedbackPresenter _presenter;
       private readonly GridViewBinder<MultiOptimizationRunResultDTO> _gridViewBinder;
       private readonly RepositoryItemMemoEdit _repositoryItemDescription;
-      private readonly UxRepositoryItemImageComboBox _statusRepositoryItem;
 
       public MultipleParameterIdentificationFeedbackView(IImageListRetriever imageListRetriever)
       {
@@ -28,7 +27,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          InitializeComponent();
          _gridViewBinder = new GridViewBinder<MultiOptimizationRunResultDTO>(gridView);
          _repositoryItemDescription = new RepositoryItemMemoEdit();
-         _statusRepositoryItem = new UxRepositoryItemImageComboBox(gridView, imageListRetriever);
          gridView.AllowsFiltering = false;
          gridView.ShouldUseColorForDisabledCell = false;
          gridView.MultiSelect = true;
@@ -86,9 +84,8 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
 
       private RepositoryItem statusRepositoryFor(MultiOptimizationRunResultDTO runResultDTO)
       {
-         _statusRepositoryItem.Items.Clear();
-         _statusRepositoryItem.Items.Add(new ImageComboBoxItem(runResultDTO.Status, _imageListRetriever.ImageIndex(runResultDTO.StatusIcon.IconName)));
-         return _statusRepositoryItem;
+         var statusRepositoryItem = new UxRepositoryItemImageComboBox(gridView, _imageListRetriever);
+         return statusRepositoryItem.AddItem(runResultDTO.Status, runResultDTO.StatusIcon);
       }
 
       private void addMessageInEmptyArea(CustomDrawEventArgs e)

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
@@ -3,18 +3,15 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
-using OSPSuite.DataBinding;
-using OSPSuite.DataBinding.DevExpress;
-using OSPSuite.DataBinding.DevExpress.XtraGrid;
-using OSPSuite.Utility.Collections;
-using OSPSuite.Utility.Extensions;
 using DevExpress.Utils;
-using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraGrid;
 using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraGrid.Views.Grid;
 using OSPSuite.Assets;
+using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.Presentation.DTO.ParameterIdentifications;
 using OSPSuite.Presentation.Presenters.ParameterIdentifications;
 using OSPSuite.Presentation.Services;
@@ -24,6 +21,8 @@ using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.RepositoryItems;
 using OSPSuite.UI.Services;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.UI.Views.ParameterIdentifications
 {
@@ -36,8 +35,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       private readonly Cache<DevExpress.XtraGrid.Views.Base.BaseView, OptimizedParametersBinder> _optimizedParametersBinderCache = new Cache<DevExpress.XtraGrid.Views.Base.BaseView, OptimizedParametersBinder>();
       private readonly UxRepositoryItemButtonEdit _repositoryItemTransferToSimulations;
       private readonly RepositoryItemMemoEdit _repositoryItemDescription;
-      private readonly UxRepositoryItemImageComboBox _statusRepositoryItem;
-      private readonly UxRepositoryItemImageComboBox _indexRepositoryItem;
       private IGridViewColumn _colTranfer;
       private readonly TimeSpanFormatter _timeSpanFormatter;
 
@@ -49,10 +46,8 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          _gridViewBinder = new GridViewBinder<ParameterIdentificationRunResultDTO>(mainView);
 
          _repositoryItemTransferToSimulations = new UxRepositoryItemButtonImage(ApplicationIcons.Commit, Captions.ParameterIdentification.TransferToSimulation);
-         _statusRepositoryItem = new UxRepositoryItemImageComboBox(mainView, imageListRetriever);
-         _indexRepositoryItem = new UxRepositoryItemImageComboBox(mainView, imageListRetriever);
          _timeSpanFormatter = new TimeSpanFormatter();
-         
+
          _repositoryItemDescription = new RepositoryItemMemoEdit
          {
             AutoHeight = true
@@ -217,7 +212,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
             .WithCaption(Captions.ParameterIdentification.NumberOfEvaluations);
 
          bind(x => x.Duration)
-            .WithFormat(x=>_timeSpanFormatter)
+            .WithFormat(x => _timeSpanFormatter)
             .WithCaption(Captions.ParameterIdentification.Duration);
 
          bind(x => x.Status)
@@ -225,27 +220,25 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
             .WithRepository(statusRepositoryFor)
             .AsReadOnly();
 
-         _colTranfer=_gridViewBinder.AddUnboundColumn()
+         _colTranfer = _gridViewBinder.AddUnboundColumn()
             .WithCaption(UIConstants.EMPTY_COLUMN)
             .WithFixedWidth(UIConstants.Size.EMBEDDED_BUTTON_WIDTH)
             .WithRepository(x => _repositoryItemTransferToSimulations)
             .WithShowButton(ShowButtonModeEnum.ShowAlways);
 
-          _repositoryItemTransferToSimulations.ButtonClick += (o, e) => OnEvent(transferToSimulation);
+         _repositoryItemTransferToSimulations.ButtonClick += (o, e) => OnEvent(transferToSimulation);
       }
 
       private RepositoryItem indexRepositoryFor(ParameterIdentificationRunResultDTO runResultDTO)
       {
-         _indexRepositoryItem.Items.Clear();
-         _indexRepositoryItem.Items.Add(new ImageComboBoxItem(runResultDTO.Index, _imageListRetriever.ImageIndex(runResultDTO.BoundaryCheckIcon.IconName)));
-         return _indexRepositoryItem;
+         var indexRepositoryItem = new UxRepositoryItemImageComboBox(mainView, _imageListRetriever);
+         return indexRepositoryItem.AddItem(runResultDTO.Index, runResultDTO.BoundaryCheckIcon);
       }
 
       private RepositoryItem statusRepositoryFor(ParameterIdentificationRunResultDTO runResultDTO)
       {
-         _statusRepositoryItem.Items.Clear();
-         _statusRepositoryItem.Items.Add(new ImageComboBoxItem(runResultDTO.Status, _imageListRetriever.ImageIndex(runResultDTO.StatusIcon.IconName)));
-         return _statusRepositoryItem;
+         var statusRepositoryItem = new UxRepositoryItemImageComboBox(mainView, _imageListRetriever);
+         return statusRepositoryItem.AddItem(runResultDTO.Status, runResultDTO.StatusIcon);
       }
 
       private void transferToSimulation()

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationParametersFeedbackView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationParametersFeedbackView.cs
@@ -22,9 +22,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       private readonly GridViewBinder<ParameterFeedbackDTO> _parametersBinder;
       private readonly GridViewBinder<IRunPropertyDTO> _runPropertiesBinder;
       private readonly ValueDTOFormatter _valueDTOFormatter;
-      private readonly RepositoryItemImageComboBox _nameRepository;
       private readonly RepositoryItemTextEdit _textRepositoryItem;
-      private readonly UxRepositoryItemImageComboBox _textIconRepositoryItem;
 
       public ParameterIdentificationParametersFeedbackView(IImageListRetriever imageListRetriever)
       {
@@ -37,9 +35,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          gridViewProperties.ShowRowIndicator = false;
          gridViewProperties.ShowColumnHeaders = false;
          _valueDTOFormatter = new ValueDTOFormatter();
-         _nameRepository = new UxRepositoryItemImageComboBox(gridViewParameters, _imageListRetriever);
          _textRepositoryItem = new RepositoryItemTextEdit();
-         _textIconRepositoryItem = new UxRepositoryItemImageComboBox(gridViewProperties, imageListRetriever);
       }
 
       private void initGridView(UxGridView gridView)
@@ -73,7 +69,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
             btnExportParametersHistory.Enabled = value;
             layoutItemExportParametersHistory.Enabled = value;
          }
-         get { return layoutItemExportParametersHistory.Enabled; }
+         get => layoutItemExportParametersHistory.Enabled;
       }
 
       public override void InitializeBinding()
@@ -101,8 +97,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          _runPropertiesBinder.Bind(x => x.FormattedValue)
             .WithRepository(propertyRepositoryFor)
             .AsReadOnly();
-
-
+         
          btnExportParametersHistory.Click += (o, e) => OnEvent(_presenter.ExportParametersHistory);
       }
 
@@ -111,16 +106,14 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          if (propertyDTO.Icon == null)
             return _textRepositoryItem;
 
-         _textIconRepositoryItem.Items.Clear();
-         _textIconRepositoryItem.Items.Add(new ImageComboBoxItem(propertyDTO.FormattedValue, _imageListRetriever.ImageIndex(propertyDTO.Icon.IconName)));
-         return _textIconRepositoryItem;
+         var textIconRepositoryItem = new UxRepositoryItemImageComboBox(gridViewProperties, _imageListRetriever);
+         return textIconRepositoryItem.AddItem(propertyDTO.FormattedValue, propertyDTO.Icon);
       }
 
       private RepositoryItem nameRepositoryFor(ParameterFeedbackDTO parameterFeedbackDTO)
       {
-         _nameRepository.Items.Clear();
-         _nameRepository.Items.Add(new ImageComboBoxItem(parameterFeedbackDTO.Name, _imageListRetriever.ImageIndex(parameterFeedbackDTO.BoundaryCheckIcon.IconName)));
-         return _nameRepository;
+         var nameRepository = new UxRepositoryItemImageComboBox(gridViewProperties, _imageListRetriever);
+         return nameRepository.AddItem(parameterFeedbackDTO.Name, parameterFeedbackDTO.BoundaryCheckIcon);
       }
 
       public override void InitializeResources()

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationRunPropertiesView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationRunPropertiesView.cs
@@ -21,7 +21,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       private readonly GridViewBinder<IRunPropertyDTO> _gridViewBinder;
       public event EventHandler<ViewResizedEventArgs> HeightChanged = delegate { };
       private readonly RepositoryItemTextEdit _textRepositoryItem;
-      private readonly UxRepositoryItemImageComboBox _textIconRepositoryItem;
 
       public ParameterIdentificationRunPropertiesView(IImageListRetriever imageListRetriever)
       {
@@ -33,7 +32,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          gridView.ShowColumnHeaders = false;
          _gridViewBinder = new GridViewBinder<IRunPropertyDTO>(gridView);
          _textRepositoryItem = new RepositoryItemTextEdit();
-         _textIconRepositoryItem = new UxRepositoryItemImageComboBox(gridView, imageListRetriever);
       }
 
       public void BindTo(IEnumerable<IRunPropertyDTO> properties)
@@ -63,9 +61,8 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          if (propertyDTO.Icon == null)
             return _textRepositoryItem;
 
-         _textIconRepositoryItem.Items.Clear();
-         _textIconRepositoryItem.Items.Add(new ImageComboBoxItem(propertyDTO.FormattedValue, _imageListRetriever.ImageIndex(propertyDTO.Icon.IconName)));
-         return _textIconRepositoryItem;
+         var textIconRepositoryItem = new UxRepositoryItemImageComboBox(gridView, _imageListRetriever);
+         return textIconRepositoryItem.AddItem(propertyDTO.FormattedValue, propertyDTO.Icon);
       }
 
       public void AdjustHeight()

--- a/src/OSPSuite.UI/Views/QuantitySelectionView.cs
+++ b/src/OSPSuite.UI/Views/QuantitySelectionView.cs
@@ -25,31 +25,31 @@ namespace OSPSuite.UI.Views
 
       public override void InitializeBinding()
       {
-         btnDeselectAll.Click += (o, e) => this.DoWithinExceptionHandler(() => _presenter.DeselectAll());
+         btnDeselectAll.Click += (o, e) => OnEvent(_presenter.DeselectAll);
       }
 
       public string Info
       {
-         set { txtInfo.Text = value; }
-         get { return txtInfo.Text; }
+         set => txtInfo.Text = value;
+         get => txtInfo.Text;
       }
 
       public string InfoError
       {
-         set { errorProvider.SetError(txtInfo, value); }
-         get { return errorProvider.GetError(txtInfo); }
+         set => errorProvider.SetError(txtInfo, value);
+         get => errorProvider.GetError(txtInfo);
       }
 
       public bool DeselectAllEnabled
       {
-         get { return btnDeselectAll.Enabled; }
-         set { btnDeselectAll.Enabled = value; }
+         get => btnDeselectAll.Enabled;
+         set => btnDeselectAll.Enabled = value;
       }
 
       public string Description
       {
-         get { return lblDescription.Text; }
-         set { lblDescription.Text = value; }
+         get => lblDescription.Text;
+         set => lblDescription.Text = value;
       }
 
       public void SetQuantityListView(IView view)

--- a/src/OSPSuite.UI/Views/ValidationMessagesView.cs
+++ b/src/OSPSuite.UI/Views/ValidationMessagesView.cs
@@ -19,7 +19,6 @@ namespace OSPSuite.UI.Views
       private readonly IToolTipCreator _toolTipCreator;
       private GridViewBinder<ValidationMessageDTO> _gridViewBinder;
       private readonly RepositoryItemMemoEdit _messageRepositoryItem;
-      private readonly UxRepositoryItemImageComboBox _statusRepositoryItem;
 
       public ValidationMessagesView(IShell shell, IImageListRetriever imageListRetriever, IToolTipCreator toolTipCreator) : base(shell)
       {
@@ -29,7 +28,6 @@ namespace OSPSuite.UI.Views
          gridView.ShouldUseColorForDisabledCell = false;
          _messageRepositoryItem = new RepositoryItemMemoEdit {AutoHeight = true};
          gridView.OptionsView.RowAutoHeight = true;
-         _statusRepositoryItem = new UxRepositoryItemImageComboBox(gridView, imageListRetriever);
          var toolTipController = new ToolTipController {ImageList = imageListRetriever.AllImages16x16};
          toolTipController.GetActiveObjectInfo += onToolTipControllerGetActiveObjectInfo;
          gridControl.ToolTipController = toolTipController;
@@ -80,9 +78,8 @@ namespace OSPSuite.UI.Views
 
       private RepositoryItem statusRepositoryFor(ValidationMessageDTO runResultDTO)
       {
-         _statusRepositoryItem.Items.Clear();
-         _statusRepositoryItem.Items.Add(new ImageComboBoxItem(runResultDTO.Status, _imageListRetriever.ImageIndex(runResultDTO.Icon.IconName)));
-         return _statusRepositoryItem;
+         var statusRepositoryItem = new UxRepositoryItemImageComboBox(gridView, _imageListRetriever);
+         return statusRepositoryItem.AddItem(runResultDTO.Status, runResultDTO.Icon);
       }
    }
 }


### PR DESCRIPTION
@Yuri05 Thsoe Repository Items cannot be created once and used all the time anymore since DevExpress update. This actually makes sense and not sure why it worked like that before.
To avoid code repetition, I created a few extra method in the `UxRepositoryItemImageComboBox` class