### PR TITLE
Fixes #345 Add FavoriteOrderChangedEvent to Core

### DIFF
--- a/src/OSPSuite.Core/Events/FavoriteEvents.cs
+++ b/src/OSPSuite.Core/Events/FavoriteEvents.cs
@@ -24,4 +24,9 @@ namespace OSPSuite.Core.Events
    {
       
    }
+
+   public class FavoritesOrderChangedEvent
+   {
+
+   }
 }

--- a/src/OSPSuite.Core/Services/FavoriteTask.cs
+++ b/src/OSPSuite.Core/Services/FavoriteTask.cs
@@ -1,10 +1,11 @@
-﻿using OSPSuite.Assets;
-using OSPSuite.Utility.Events;
+﻿using System.Collections.Generic;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Repositories;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization;
+using OSPSuite.Utility.Events;
 
 namespace OSPSuite.Core.Services
 {
@@ -13,6 +14,8 @@ namespace OSPSuite.Core.Services
       void SetParameterFavorite(IParameter parameter, bool isFavorite);
       void SaveToFile();
       void LoadFromFile();
+      void MoveUp(IEnumerable<string> entriesToMove);
+      void MoveDown(IEnumerable<string> entriesToMove);
    }
 
    public class FavoriteTask : IFavoriteTask
@@ -64,6 +67,18 @@ namespace OSPSuite.Core.Services
          _favoriteRepository.Clear();
          _favoriteRepository.AddFavorites(favoritesFromFiles);
          _eventPublisher.PublishEvent(new FavoritesLoadedEvent());
+      }
+
+      public void MoveUp(IEnumerable<string> entriesToMove)
+      {
+         _favoriteRepository.Favorites.MoveUp(entriesToMove);
+         _eventPublisher.PublishEvent(new FavoritesOrderChangedEvent());
+      }
+
+      public void MoveDown(IEnumerable<string> entriesToMove)
+      {
+         _favoriteRepository.Favorites.MoveDown(entriesToMove);
+         _eventPublisher.PublishEvent(new FavoritesOrderChangedEvent());
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Core/FavoriteTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Core/FavoriteTaskSpecs.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System.Collections.Generic;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Utility.Events;
 using FakeItEasy;
@@ -148,6 +149,62 @@ namespace OSPSuite.Core
       public void should_raise_the_favorites_loaded_event()
       {
          A.CallTo(() => _eventPublisher.PublishEvent(A<FavoritesLoadedEvent>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_reordering_favorites_by_moving_some_entries_up : concern_for_FavoriteTask
+   {
+      private readonly IReadOnlyList<string> _entriesToMove = new[] { "FAV1" };
+
+      protected override void Context()
+      {
+         base.Context();
+         _favorites.AddFavorites(new []{"FAV1", "FAV2" });
+      }
+
+      protected override void Because()
+      {
+         sut.MoveUp(_entriesToMove);
+      }
+
+      [Observation]
+      public void should_have_reordered_the_favorites()
+      {
+         _favorites.ShouldOnlyContainInOrder("FAV2", "FAV1");
+      }
+
+      [Observation]
+      public void should_raise_the_favorites_reordered_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<FavoritesOrderChangedEvent>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_reordering_favorites_by_moving_some_entries_down : concern_for_FavoriteTask
+   {
+      private readonly IReadOnlyList<string> _entriesToMove = new[] { "FAV1" };
+
+      protected override void Context()
+      {
+         base.Context();
+         _favorites.AddFavorites(new[] { "FAV1", "FAV2" });
+      }
+
+      protected override void Because()
+      {
+         sut.MoveDown(_entriesToMove);
+      }
+
+      [Observation]
+      public void should_have_reordered_the_favorites()
+      {
+         _favorites.ShouldOnlyContainInOrder("FAV2", "FAV1");
+      }
+
+      [Observation]
+      public void should_raise_the_favorites_reordered_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<FavoritesOrderChangedEvent>._)).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Encapsulating behavior so that MoBi and PKsim and react to changes when favorites are edited in different views