### PR TITLE
Remove unit from path when importing

### DIFF
--- a/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
+++ b/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
@@ -97,10 +97,11 @@ namespace OSPSuite.Core.Domain.Populations
          if (_parameterValuesCache.Contains(parameterPath))
             return parameterPath;
 
-         var matchingPath = Array.FindAll(AllParameterPaths(), x => x.StartsWith(parameterPath))
-            .FirstOrDefault(p => string.Equals(p.StripUnit(), parameterPath));
+         var parameterPathWithoutUnit = parameterPath.StripUnit();
+         if (_parameterValuesCache.Contains(parameterPathWithoutUnit))
+            return parameterPath;
 
-         return matchingPath ?? string.Empty;
+         return string.Empty;
       }
 
       public virtual ParameterValues GetOrAddParameterValuesFor(string parameterPath)
@@ -153,7 +154,7 @@ namespace OSPSuite.Core.Domain.Populations
       /// </summary>
       public double[] GetPercentiles(string parameterPath) => PercentilesFor(parameterPath)?.ToArray();
 
-      public virtual string[] AllParameterPaths() => _parameterValuesCache.Keys.Select(x=>x.StripUnit()).ToArray();
+      public virtual string[] AllParameterPaths() => _parameterValuesCache.Keys.ToArray();
 
       public virtual ParameterValuesCache Clone()
       {
@@ -231,10 +232,8 @@ namespace OSPSuite.Core.Domain.Populations
          if (indexOfIndividual < 0 || indexOfIndividual >= numberOfValuesPerPath)
             throw new ArgumentOutOfRangeException(nameof(indexOfIndividual));
 
-         //FOR Now: Strip units so that we have path without units. This should be changed
-
          return _parameterValuesCache.KeyValues.Select(kv =>
-               new ParameterValue(kv.Key.StripUnit(), kv.Value.Values[indexOfIndividual], kv.Value.Percentiles[indexOfIndividual]))
+               new ParameterValue(kv.Key, kv.Value.Values[indexOfIndividual], kv.Value.Percentiles[indexOfIndividual]))
             .ToArray();
       }
    }

--- a/src/OSPSuite.Infrastructure.Import/Services/IndividualValuesCacheImporter.cs
+++ b/src/OSPSuite.Infrastructure.Import/Services/IndividualValuesCacheImporter.cs
@@ -108,7 +108,7 @@ namespace OSPSuite.Infrastructure.Import.Services
 
          for (int i = 0; i < headers.Length; i++)
          {
-            var header = headers[i];
+            var header = headers[i].StripUnit();
             if (string.Equals(header, Constants.Population.INDIVIDUAL_ID_COLUMN))
             {
                indexIndividualId = i;
@@ -125,7 +125,7 @@ namespace OSPSuite.Infrastructure.Import.Services
          {
             for (int i = 0; i < fieldCount; i++)
             {
-               var header = headers[i];
+               var header = headers[i].StripUnit();
                if (i == indexIndividualId)
                   individualPropertiesCache.IndividualIds.Add(csv.IntAt(i));
 

--- a/tests/OSPSuite.Core.Tests/Domain/IndividualValuesCacheSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/IndividualValuesCacheSpecs.cs
@@ -147,7 +147,7 @@ namespace OSPSuite.Core.Domain
          //3 individuals to in original pop
          var ids = new List<int> {0, 1, 2};
 
-         var parameterValues1 = new ParameterValues("Path1 [ml]");
+         var parameterValues1 = new ParameterValues("Path1");
          parameterValues1.Add(new double[] {2, 3, 4});
 
          var parameterValues2 = new ParameterValues("Path2");

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCacheSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCacheSpecs.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Populations;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Helpers;
 
 namespace OSPSuite.Core.Domain
@@ -24,7 +25,7 @@ namespace OSPSuite.Core.Domain
       {
          base.Context();
          _parameterValue1 = new ParameterValue("PATH1", 11, 0.1);
-         _parameterValue2 = new ParameterValue("PATH2 [mg]", 21, 0.2);
+         _parameterValue2 = new ParameterValue("PATH2", 21, 0.2);
       }
 
       protected override void Because()
@@ -48,21 +49,23 @@ namespace OSPSuite.Core.Domain
 
 
       [Observation]
-      public void should_return_true_if_asked_if_it_contains_some_values_for_the_added_path_without_unit()
+      public void should_return_true_if_asked_if_it_contains_some_values_for_the_added_path_with_unit()
       {
-         sut.Has("PATH2").ShouldBeTrue();
+         sut.Has("PATH2 [mg]").ShouldBeTrue();
       }
 
       [Observation]
       public void should_be_able_to_retrieve_the_values_for_the_individual_path()
       {
          sut.ValuesFor(_parameterValue1.ParameterPath).ShouldOnlyContainInOrder(11, 12);
+         sut.ValuesFor(_parameterValue2.ParameterPath).ShouldOnlyContainInOrder(21, 22);
       }
 
       [Observation]
       public void should_be_able_to_retrieve_the_values_for_the_individual_path_as_array()
       {
          sut.GetValues(_parameterValue1.ParameterPath).ShouldOnlyContainInOrder(11, 12);
+         sut.GetValues(_parameterValue2.ParameterPath).ShouldOnlyContainInOrder(21, 22);
       }
 
       [Observation]
@@ -82,7 +85,7 @@ namespace OSPSuite.Core.Domain
       {
          base.Context();
          _parameterValue1 = new ParameterValue("PATH_P1", 11, 0.1);
-         _parameterValue2 = new ParameterValue("PATH_P [mg]", 21, 0.2);
+         _parameterValue2 = new ParameterValue("PATH_P", 21, 0.2);
       }
 
       protected override void Because()
@@ -94,7 +97,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_store_the_value_for_the_given_parameter_path_and_be_able_to_retrieve_the_parameter_paths_afterwards()
       {
-         sut.AllParameterPaths().ShouldOnlyContainInOrder(_parameterValue1.ParameterPath, _parameterValue2.ParameterPath);
+         sut.AllParameterPaths().ShouldOnlyContainInOrder(_parameterValue1.ParameterPath, _parameterValue2.ParameterPath.StripUnit());
       }
 
       [Observation]
@@ -106,9 +109,9 @@ namespace OSPSuite.Core.Domain
 
 
       [Observation]
-      public void should_return_true_if_asked_if_it_contains_some_values_for_the_added_path_without_unit()
+      public void should_return_true_if_asked_if_it_contains_some_values_for_the_added_path_with_unit()
       {
-         sut.Has("PATH_P").ShouldBeTrue();
+         sut.Has("PATH_P [mg]").ShouldBeTrue();
       }
 
       [Observation]
@@ -336,7 +339,7 @@ namespace OSPSuite.Core.Domain
       protected override void Context()
       {
          base.Context();
-         sut.SetValues("PATH1 [mg]", new double[] {1, 2, 3});
+         sut.SetValues("PATH1", new double[] {1, 2, 3});
          sut.SetValues("PATH2 [mg] REST", new double[] {1, 2, 3});
       }
 


### PR DESCRIPTION
@Yuri05 Executive decisions here. You wanted to think about it but this makes my life so much easier if I do it right.
When I import a parameter, I remove the unit it it's at the end. This is there just because we export like this.

Only issue would be for a parameter created in MoBi with a unit at the end of the name that is also added as variable in population etc.. so very very unlikely
