### PR TITLE
904 cannot calculate pk

### DIFF
--- a/src/OSPSuite.Core/Domain/Data/IndividualResults.cs
+++ b/src/OSPSuite.Core/Domain/Data/IndividualResults.cs
@@ -18,7 +18,7 @@ namespace OSPSuite.Core.Domain.Data
       public virtual int Id { get; set; }
 
       /// <summary>
-      ///    Id of the individual for which the results were calculated
+      ///    Id of the individual for which the results were calculated (0-based)
       /// </summary>
       public virtual int IndividualId { get; set; }
 

--- a/src/OSPSuite.Core/Domain/Data/SimulationResults.cs
+++ b/src/OSPSuite.Core/Domain/Data/SimulationResults.cs
@@ -93,7 +93,7 @@ namespace OSPSuite.Core.Domain.Data
             foreach (var id in ids)
             {
                var individualResults = ResultsFor(id);
-               values.AddRange(individualResults?.ValuesFor(quantityPath)?? new float[numberOfValuesPerIndividual].InitializeWith(float.NaN));
+               values.AddRange(individualResults?.ValuesFor(quantityPath) ?? new float[numberOfValuesPerIndividual].InitializeWith(float.NaN));
             }
 
             return values.ToArray();
@@ -129,6 +129,17 @@ namespace OSPSuite.Core.Domain.Data
          lock (_locker)
          {
             return AllIndividualResults.Select(x => x.IndividualId).ToArray();
+         }
+      }
+
+      public virtual int NumberOfIndividuals
+      {
+         get
+         {
+            var allIndividualsIds = AllIndividualIds();
+            //+1 because individual ids are typically 0 based
+            var maxNumberOfIndividuals = allIndividualsIds.Any() ? allIndividualsIds.Max() + 1 : 0;
+            return Math.Max(Count, maxNumberOfIndividuals);
          }
       }
 

--- a/src/OSPSuite.R/Services/PKAnalysisTask.cs
+++ b/src/OSPSuite.R/Services/PKAnalysisTask.cs
@@ -16,7 +16,6 @@ namespace OSPSuite.R.Services
    public class CalculatePKAnalysisArgs
    {
       public IModelCoreSimulation Simulation { get; set; }
-      public int NumberOfIndividuals { get; set; }
       public SimulationResults SimulationResults { get; set; }
    }
 
@@ -66,7 +65,8 @@ namespace OSPSuite.R.Services
 
       public PopulationSimulationPKAnalyses CalculateFor(CalculatePKAnalysisArgs args)
       {
-         return _corePKAnalysesTask.CalculateFor(args.Simulation, args.NumberOfIndividuals, args.SimulationResults);
+         var numberOfIndividuals = args.SimulationResults.NumberOfIndividuals;
+         return _corePKAnalysesTask.CalculateFor(args.Simulation, numberOfIndividuals, args.SimulationResults);
       }
 
       public DataTable ConvertToDataTable(PopulationSimulationPKAnalyses pkAnalyses, IModelCoreSimulation simulation)

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/UnitXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/UnitXmlSerializerSpecs.cs
@@ -63,8 +63,7 @@ namespace OSPSuite.Core.Serializers
       protected override void Context()
       {
          base.Context();
-         _unit = new Unit("unit", 1.0/60, -1);
-         _unit.FactorFormula = "1/60";
+         _unit = new Unit("unit", 1.0 / 60, -1) {FactorFormula = "1/60"};
       }
 
       protected override void Because()

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationResultsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationResultsSpecs.cs
@@ -119,6 +119,38 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_return_the_max_individual_id_defined_in_the_results : concern_for_SimulationResults
+   {
+      protected override void Context()
+      {
+         base.Context();
+
+         sut.Add(new IndividualResults { IndividualId = 1 });
+         sut.Add(new IndividualResults { IndividualId = 3 });
+      }
+
+      [Observation]
+      public void should_return_the_expected_value_if_the_number_of_individual_plus_one_is_less_than_the_max_individual_id()
+      {
+         sut.NumberOfIndividuals.ShouldBeEqualTo(4);
+      }
+      
+      [Observation]
+      public void should_return_the_expected_value()
+      {
+         sut.Add(new IndividualResults { IndividualId = 0 });
+         sut.Add(new IndividualResults { IndividualId = 2 });
+         sut.Add(new IndividualResults { IndividualId = 4 });
+         sut.NumberOfIndividuals.ShouldBeEqualTo(5);
+      }
+
+      [Observation]
+      public void should_return_an_empty_list_if_the_results_are_empty()
+      {
+         new SimulationResults().NumberOfIndividuals.ShouldBeEqualTo(0);
+      }
+   }
+
    public class When_adding_a_range_of_results : concern_for_SimulationResults
    {
       protected override void Context()

--- a/tests/OSPSuite.HelpersForTests/DimensionFactoryForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/DimensionFactoryForSpecs.cs
@@ -13,7 +13,7 @@ namespace OSPSuite.Helpers
 
          var amountDimension = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.MOLAR_AMOUNT, "Molar Volume");
          amountDimension.AddUnit(new Unit("mol", 1, 0));
-
+         amountDimension.DisplayName = "ZZZ_LAST";
          var massDimension = new Dimension(new BaseDimensionRepresentation(), DimensionNames.Mass, "g");
          massDimension.AddUnit(new Unit("kg", 1000, 0));
          massDimension.AddUnit(new Unit("mg", 0.001, 0));

--- a/tests/OSPSuite.R.Tests/Services/PKAnalysisTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/PKAnalysisTaskSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.PKAnalyses;
+using OSPSuite.Core.Domain.Populations;
 using OSPSuite.R.Domain;
 
 namespace OSPSuite.R.Services
@@ -55,9 +56,7 @@ namespace OSPSuite.R.Services
          var c_max = _result.PKParameterFor(_outputPath, "C_max");
          c_max.Dimension.Name.ShouldBeEqualTo(Constants.Dimension.MOLAR_CONCENTRATION);
       }
-
    }
-
 
    public class When_exporting_the_pk_analysis_to_data_frame_with_value_in_another_unit : concern_for_PKAnalysisTask
    {
@@ -70,13 +69,14 @@ namespace OSPSuite.R.Services
       {
          base.Context();
          _result = _simulationRunner.Run(_simulation);
-         _userDefinedPKParameter = _pkParameterTask.CreateUserDefinedPKParameter("MyCmax", StandardPKParameter.C_max, displayName : null, displayUnit : "mg/l");
+         _userDefinedPKParameter =
+            _pkParameterTask.CreateUserDefinedPKParameter("MyCmax", StandardPKParameter.C_max, displayName: null, displayUnit: "mg/l");
          _pkParameterTask.AddUserDefinedPKParameter(_userDefinedPKParameter);
-
       }
+
       protected override void Because()
       {
-         _pkAnalysis= sut.CalculateFor(new CalculatePKAnalysisArgs{NumberOfIndividuals = 1, Simulation = _simulation, SimulationResults = _result});
+         _pkAnalysis = sut.CalculateFor(new CalculatePKAnalysisArgs {Simulation = _simulation, SimulationResults = _result});
          _table = sut.ConvertToDataTable(_pkAnalysis, _simulation);
       }
 
@@ -86,7 +86,7 @@ namespace OSPSuite.R.Services
          _table.Columns.Count.ShouldBeEqualTo(5);
          var mw = _simulation.MolWeightFor(_outputPath).GetValueOrDefault(double.NaN);
          var c_max = _table.Select($"QuantityPath = '\"{_outputPath}\"' AND Parameter = '\"C_max\"'");
-         var my_cmax =  _table.Select($"QuantityPath = '\"{_outputPath}\"' AND Parameter = '\"MyCmax\"'");
+         var my_cmax = _table.Select($"QuantityPath = '\"{_outputPath}\"' AND Parameter = '\"MyCmax\"'");
          var c_max_value = double.Parse(c_max[0]["Value"].ToString());
          var my_cmax_value = double.Parse(my_cmax[0]["Value"].ToString());
          //kg/l => mg/l
@@ -112,11 +112,11 @@ namespace OSPSuite.R.Services
          var simulationPersister = Api.GetSimulationPersister();
          _simulation = simulationPersister.LoadSimulation(simulationFile);
          _result = _simulationRunner.Run(_simulation);
-
       }
+
       protected override void Because()
       {
-         _pkAnalysis = sut.CalculateFor(new CalculatePKAnalysisArgs { NumberOfIndividuals = 1, Simulation = _simulation, SimulationResults = _result });
+         _pkAnalysis = sut.CalculateFor(new CalculatePKAnalysisArgs {Simulation = _simulation, SimulationResults = _result});
       }
 
       [Observation]
@@ -124,6 +124,39 @@ namespace OSPSuite.R.Services
       {
          var pkParameter = _pkAnalysis.PKParameterFor("Organism|PeripheralVenousBlood|C1|Plasma (Peripheral Venous Blood)", "C_max_tD1_tD2_norm");
          pkParameter.Values[0].ShouldBeGreaterThan(0);
+      }
+   }
+
+   public class
+      When_calculating_the_pk_analysis_for_a_population_simulation_run_for_which_one_or_more_individual_did_not_succeed : concern_for_PKAnalysisTask
+   {
+      private PopulationSimulationPKAnalyses _pkAnalysis;
+      private IndividualValuesCache _population;
+      private SimulationResults _result;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var populationFile = HelperForSpecs.DataFile("pop_5.csv");
+         var populationTask = Api.GetPopulationTask();
+         _population = populationTask.ImportPopulation(populationFile);
+         //negative volumes ensures that we have one simulation crashing
+         _population.SetValues("Organism|Liver|Volume", new[] {2.3, 2.3, 2.3, -10, 2.3});
+         _result = _simulationRunner.Run(_simulation, _population);
+      }
+
+      protected override void Because()
+      {
+         _pkAnalysis = sut.CalculateFor(new CalculatePKAnalysisArgs {Simulation = _simulation, SimulationResults = _result});
+      }
+
+      [Observation]
+      public void should_be_able_to_calculate_the_pk_parameters_for_the_successful_simulations()
+      {
+         _pkAnalysis.ShouldNotBeNull();
+         var values = _pkAnalysis.PKParameterFor(_outputPath, "C_max");
+         values.Count.ShouldBeEqualTo(5);
+         float.IsNaN(values.Values[3]).ShouldBeTrue();
       }
    }
 }

--- a/tests/OSPSuite.R.Tests/Services/PopulationTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/PopulationTaskSpecs.cs
@@ -202,4 +202,6 @@ namespace OSPSuite.R.Services
          _result.Each(FileHelper.DeleteFile);
       }
    }
+
+ 
 }


### PR DESCRIPTION
Idea: Instead of throwing an error, we make sure that we resize the Array of PK-Parameters using the max `IndividualId` in the population

so id = 0,1,2,3 => we return 4
so id = 0,1,5=> we return 6 and 2 3 4 will be fill with NaN