### PR TITLE
953 enable s imulation batch with simulation concurrent runner

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1213,6 +1213,7 @@ namespace OSPSuite.Assets
       public static readonly string UnsupportedFileFormat = "The file format is not supported";
       public static readonly string InconsistenMoleculeAndMoleWeightException = "Molecule and Molecular Weight do not match. Please either edit your Molecule or your Molecular Weight in your project or remove the Molecular Weight from your mappings";
       public static readonly string InvalidMixOfSimulationAndSimulationBatch = "You already have Simulation and SimulationBatch objects and should not mix, please invoke Clear to start adding objects from a fresh start";
+      public static readonly string InvalidSimulationBatchRunValuesId = "The Id for the SimulationBatchRunValues is invalid. Use a non empty id that has not been used so far.";
 
       public static string LinkedParameterIsNotValidInIdentificationParameter(string identificationParameterName) => $"At least one linked parameter is invalid in identification paramter '{identificationParameterName}'";
 

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1213,7 +1213,6 @@ namespace OSPSuite.Assets
       public static readonly string UnsupportedFileFormat = "The file format is not supported";
       public static readonly string InconsistenMoleculeAndMoleWeightException = "Molecule and Molecular Weight do not match. Please either edit your Molecule or your Molecular Weight in your project or remove the Molecular Weight from your mappings";
       public static readonly string InvalidMixOfSimulationAndSimulationBatch = "You already have Simulation and SimulationBatch objects and should not mix, please invoke Clear to start adding objects from a fresh start";
-      public static readonly string InvalidSimulationBatchRunValuesId = "The Id for the SimulationBatchRunValues is invalid. Use a non empty id that has not been used so far.";
 
       public static string LinkedParameterIsNotValidInIdentificationParameter(string identificationParameterName) => $"At least one linked parameter is invalid in identification paramter '{identificationParameterName}'";
 

--- a/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
+++ b/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
@@ -23,17 +23,20 @@ namespace OSPSuite.Core.Domain.Services
 
    public class ConcurrencyManager : IConcurrencyManager
    {
-      private readonly ICoreUserSettings _coreUserSettings;
-
+      //private readonly ICoreUserSettings _coreUserSettings;
+      private int _maximumNumberOfCoresToUse = 2;
+      //TODO: Check with Michael why ICoreUserSettings is not available through container on Core
+      /*
       public ConcurrencyManager(ICoreUserSettings coreUserSettings)
       {
          _coreUserSettings = coreUserSettings;
       }
-
+      */
       public async Task<IReadOnlyDictionary<TData, TResult>> RunAsync<TData, TResult>(int numberOfCoresToUse, CancellationToken cancellationToken, IReadOnlyList<TData> data, Func<int, CancellationToken, TData, Task<TResult>> action)
       {
          if (numberOfCoresToUse <= 0)
-            numberOfCoresToUse = _coreUserSettings.MaximumNumberOfCoresToUse;
+            //    numberOfCoresToUse = _coreUserSettings.MaximumNumberOfCoresToUse;
+            numberOfCoresToUse = _maximumNumberOfCoresToUse;
          var concurrentData = new ConcurrentQueue<TData>(data);
          numberOfCoresToUse = Math.Min(numberOfCoresToUse, concurrentData.Count);
 

--- a/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
+++ b/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
@@ -23,7 +23,7 @@ namespace OSPSuite.Core.Domain.Services
 
    public class ConcurrencyManager : IConcurrencyManager
    {
-      private int _maximumNumberOfCoresToUse = Math.Max(1, Environment.ProcessorCount - 1);
+      private readonly int _maximumNumberOfCoresToUse = Math.Max(1, Environment.ProcessorCount - 1);
       public async Task<IReadOnlyDictionary<TData, TResult>> RunAsync<TData, TResult>(int numberOfCoresToUse, CancellationToken cancellationToken, IReadOnlyList<TData> data, Func<int, CancellationToken, TData, Task<TResult>> action)
       {
          if (numberOfCoresToUse <= 0)
@@ -49,6 +49,7 @@ namespace OSPSuite.Core.Domain.Services
          await Task.WhenAll(tasks);
          //all tasks are completed. Can return results
 
+         var tt = results.Values;
          return results;
       }
    }

--- a/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
+++ b/src/OSPSuite.Core/Domain/Services/ConcurrencyManager.cs
@@ -23,19 +23,10 @@ namespace OSPSuite.Core.Domain.Services
 
    public class ConcurrencyManager : IConcurrencyManager
    {
-      //private readonly ICoreUserSettings _coreUserSettings;
-      private int _maximumNumberOfCoresToUse = 2;
-      //TODO: Check with Michael why ICoreUserSettings is not available through container on Core
-      /*
-      public ConcurrencyManager(ICoreUserSettings coreUserSettings)
-      {
-         _coreUserSettings = coreUserSettings;
-      }
-      */
+      private int _maximumNumberOfCoresToUse = Math.Max(1, Environment.ProcessorCount - 1);
       public async Task<IReadOnlyDictionary<TData, TResult>> RunAsync<TData, TResult>(int numberOfCoresToUse, CancellationToken cancellationToken, IReadOnlyList<TData> data, Func<int, CancellationToken, TData, Task<TResult>> action)
       {
          if (numberOfCoresToUse <= 0)
-            //    numberOfCoresToUse = _coreUserSettings.MaximumNumberOfCoresToUse;
             numberOfCoresToUse = _maximumNumberOfCoresToUse;
          var concurrentData = new ConcurrentQueue<TData>(data);
          numberOfCoresToUse = Math.Min(numberOfCoresToUse, concurrentData.Count);

--- a/src/OSPSuite.R/Api.cs
+++ b/src/OSPSuite.R/Api.cs
@@ -57,6 +57,8 @@ namespace OSPSuite.R
 
       public static IOSPSuiteLogger GetLogger() => resolveTask<IOSPSuiteLogger>();
 
+      public static IConcurrentSimulationRunner GetConcurrentSimulationRunner() => resolveTask<IConcurrentSimulationRunner>();
+
       private static T resolveTask<T>()
       {
          try

--- a/src/OSPSuite.R/Api.cs
+++ b/src/OSPSuite.R/Api.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Services;

--- a/src/OSPSuite.R/Domain/SimulationBatch.cs
+++ b/src/OSPSuite.R/Domain/SimulationBatch.cs
@@ -48,17 +48,6 @@ namespace OSPSuite.R.Domain
       public double[] MoleculeValues => InitialValues.ToNetArray(InitialValue);
    }
 
-   public class SimulationBatchRunConcurrentlyOptions
-   {
-      private List<SimulationBatchRunValues> _simulationBatchRunValues = new List<SimulationBatchRunValues>();
-      public IReadOnlyList<SimulationBatchRunValues> SimulationBatchRunValues { get => _simulationBatchRunValues; }
-
-      public void AddSimulationBatchRunValues(SimulationBatchRunValues runValues)
-      {
-         _simulationBatchRunValues.Add(runValues);
-      }
-   }
-
    public class SimulationBatch : IDisposable
    {
       private readonly ISimModelBatch _simModelBatch;

--- a/src/OSPSuite.R/Domain/SimulationBatch.cs
+++ b/src/OSPSuite.R/Domain/SimulationBatch.cs
@@ -31,6 +31,9 @@ namespace OSPSuite.R.Domain
 
    public class SimulationBatchRunValues
    {
+      //Id to recognize it when running concurrently
+      public string Id { get; set; }
+
       //Potentially null
       public double[] ParameterValues { get; set; }
 

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -130,7 +130,7 @@ namespace OSPSuite.R.Services
 
          if (_simulationBatches.Count > 0)
          {
-            return _concurrentManager.RunAsync<SimulationBatchRunOptions, ConcurrentSimulationResults>(
+            return _concurrentManager.RunAsync(
                NumberOfCores,
                _cancellationTokenSource.Token,
                _simulationBatches.SelectMany(sb => sb.SimulationBatchRunValues.Select(rv => new SimulationBatchRunOptions() { Simulation = sb.Simulation, SimulationBatchOptions = sb.SimulationBatchOptions, SimulationBatchRunValues = rv })).ToList(),

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -100,6 +100,9 @@ namespace OSPSuite.R.Services
 
       public void AddSimulationBatchOption(SimulationWithBatchOptions simulationWithBatchOptions)
       {
+         if (simulationWithBatchOptions.SimulationBatchRunValues.Any(value => string.IsNullOrEmpty(value.Id) || _simulationBatches.Any(simulationBatch => simulationBatch.SimulationBatchRunValues.Any(otherValue => otherValue.Id == value.Id))))
+            throw new OSPSuiteException(Error.InvalidSimulationBatchRunValuesId);
+
          _simulationBatches.Add(simulationWithBatchOptions);
       }
 

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -107,8 +107,7 @@ namespace OSPSuite.R.Services
       {
          _simulations.Clear();
          _simulationBatches.Clear();
-         if (_cancellationTokenSource != null)
-            _cancellationTokenSource.Cancel();
+         _cancellationTokenSource?.Cancel();
       }
 
       public ConcurrentSimulationResults[] RunConcurrently()

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -25,7 +25,7 @@ namespace OSPSuite.R.Services
          _simulationBatches.Enqueue(Api.GetSimulationBatchFactory().Create(Simulation, SimulationBatchOptions));
          return true;
       }
-      public IReadOnlyList<SimulationBatch> SimulationBatches { get => (IReadOnlyList<SimulationBatch>)_simulationBatches; }
+      public IEnumerable<SimulationBatch> SimulationBatches { get => _simulationBatches; }
       public string AddSimulationBatchRunValues(SimulationBatchRunValues simulationBatchRunValues)
       {
          var id = Guid.NewGuid().ToString();
@@ -174,7 +174,7 @@ namespace OSPSuite.R.Services
                _listOfSettingsForConcurrentRunSimulationBatch.SelectMany(sb => sb.SimulationBatchRunValues.Select((rv, i) => new SimulationBatchRunOptions()
                {
                   Simulation = sb.Simulation,
-                  SimulationBatch = sb.SimulationBatches[i],
+                  SimulationBatch = sb.SimulationBatches.ElementAt(i),
                   SimulationBatchOptions = sb.SimulationBatchOptions,
                   SimulationBatchRunValues = rv
                })).ToList(),
@@ -192,7 +192,7 @@ namespace OSPSuite.R.Services
 
 
       public ConcurrentSimulationResults[] RunConcurrently() => RunConcurrentlyAsync().Result.ToArray();
-
+            
       private async Task<ConcurrentSimulationResults> runSimulation(int coreIndex, CancellationToken cancellationToken, IModelCoreSimulation simulation)
       {
          //We want a new instance every time that's why we are not injecting SimulationRunner in constructor

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -135,11 +135,14 @@ namespace OSPSuite.R.Services
          (
             NumberOfCores,
             _cancellationTokenSource.Token,
+            //The batch creation is expensive so we store the created batches from one RunConcurrently call
+            //to the next one. It might happen though that the later call needs more batches than the former
+            //so for each needed batch, we create a new one.
+            //The iteration occurs on the list of _listOfSettingsForConcurrentRunSimulationBatch (over different
+            //simulation objects), taking for each settings (or simulation) a list with the missing batches 
+            //(one for each MissingBatchesCount) to add a new batch on such a settings object
             _listOfSettingsForConcurrentRunSimulationBatch.SelectMany
             (
-               //The batch creation is expensive so we store the created batches from one RunConcurrently call
-               //to the next one. It might happen though that the later call needs more batches than the former
-               //so for each needed batch, we create a new one.
                settings => Enumerable.Range(0, settings.MissingBatchesCount).Select(_ => settings)
             ).ToList(),
             (core, ct, settings) => Task.FromResult(settings.AddNewBatch())

--- a/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
+++ b/src/OSPSuite.R/Services/ConcurrentSimulationRunner.cs
@@ -39,9 +39,9 @@ namespace OSPSuite.R.Services
          SimulationResults = results;
          AdditionalId = additionalId;
       }
-      public string SimulationId { get; private set; }
-      public string AdditionalId { get; private set; }
-      public SimulationResults SimulationResults { get; private set; }
+      public string SimulationId { get; }
+      public string AdditionalId { get; }
+      public SimulationResults SimulationResults { get; }
    }
 
    public interface IConcurrentSimulationRunner : IDisposable

--- a/tests/OSPSuite.R.Tests/Services/ConcurrentSimulationRunnerSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/ConcurrentSimulationRunnerSpecs.cs
@@ -1,8 +1,10 @@
 ﻿using NUnit.Framework;
 using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core;
-using OSPSuite.Core.Domain.Data;
-using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Extensions;
+using OSPSuite.R.Domain;
 using System.Linq;
 
 namespace OSPSuite.R.Services
@@ -17,14 +19,14 @@ namespace OSPSuite.R.Services
    public class When_running_simulations_concurrently : ContextForIntegration<IConcurrentSimulationRunner>
    {
       private ISimulationPersister _simulationPersister;
-      private SimulationResults[] _results;
+      private ConcurrentSimulationResults[] _results;
 
       protected override void Context()
       {
          base.Context();
 
          _simulationPersister = Api.GetSimulationPersister();
-         sut = new ConcurrentSimulationRunner(new ConcurrencyManager(new CoreUserSettings()));
+         sut = Api.GetConcurrentSimulationRunner();
          sut.AddSimulation(_simulationPersister.LoadSimulation(HelperForSpecs.DataFile("S1.pkml")));
          sut.AddSimulation(_simulationPersister.LoadSimulation(HelperForSpecs.DataFile("simple.pkml")));
          sut.AddSimulation(_simulationPersister.LoadSimulation(HelperForSpecs.DataFile("simple.pkml")));
@@ -40,7 +42,82 @@ namespace OSPSuite.R.Services
       public void should_run_the_simulations()
       {
          Assert.IsNotNull(_results);
-         Assert.IsTrue(_results.All(r => r.ElementAt(0).AllValues.SelectMany(v => v.Values).Count() > 0));
+         Assert.IsTrue(_results.All(r => r.SimulationResults.ElementAt(0).AllValues.SelectMany(v => v.Values).Count() > 0));
+      }
+   }
+
+   public class When_running_a_batch_simulation_run_concurrently : ContextForIntegration<IConcurrentSimulationRunner>
+   {
+      private SimulationWithBatchOptions _simulationWithBatchOptions;
+      private ISimulationPersister _simulationPersister;
+      private ConcurrentSimulationResults[] _results;
+      private IModelCoreSimulation _simulation;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _simulationPersister = Api.GetSimulationPersister();
+         _simulation = _simulationPersister.LoadSimulation(HelperForSpecs.DataFile("S1.pkml"));
+
+         _simulationWithBatchOptions = new SimulationWithBatchOptions()
+         {
+            Simulation = _simulation,
+            SimulationBatchOptions = new SimulationBatchOptions
+               {
+                  VariableMolecules = new[]
+               {
+                  new[] {"Organism", "Kidney", "Intracellular", "Caffeine"}.ToPathString()
+               },
+
+                  VariableParameters = new[]
+               {
+                  new[] {"Organism", "Liver", "Volume"}.ToPathString(),
+                  new[] {"Organism", "Hematocrit"}.ToPathString(),
+               }
+            }
+         };
+         _simulationWithBatchOptions.AddSimulationBatchRunValues(new SimulationBatchRunValues
+         {
+            InitialValues = new[] { 10.0 },
+            ParameterValues = new[] { 3.5, 0.53 },
+            Id = "A"
+         });
+         _simulationWithBatchOptions.AddSimulationBatchRunValues(new SimulationBatchRunValues
+         {
+            InitialValues = new[] { 9.0 },
+            ParameterValues = new[] { 3.4, 0.50 },
+            Id = "B"
+         });
+         _simulationWithBatchOptions.AddSimulationBatchRunValues(new SimulationBatchRunValues
+         {
+            InitialValues = new[] { 10.5 },
+            ParameterValues = new[] { 3.6, 0.55 },
+            Id = "C"
+         });
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+
+         sut = Api.GetConcurrentSimulationRunner();
+         sut.AddSimulationBatchOption(_simulationWithBatchOptions);
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunConcurrently();
+      }
+
+      [Observation]
+      public void should_be_able_to_simulate_the_simulation_for_multiple_runes()
+      {
+         for (var i = 0; i < _results.Length; i++)
+         {
+            var result = Api.GetSimulationBatchFactory().Create(_simulation, _simulationWithBatchOptions.SimulationBatchOptions).Run(_simulationWithBatchOptions.SimulationBatchRunValues.FirstOrDefault(v => v.Id == _results[i].AdditionalId));
+            result.Time.Values.ShouldBeEqualTo(_results[i].SimulationResults.Time.Values);
+            result.ResultsFor(0).ValuesAsArray().Select(qv => qv.Values).ShouldBeEqualTo(_results[i].SimulationResults.ResultsFor(0).ValuesAsArray().Select(qv => qv.Values));
+         }
       }
    }
 }

--- a/tests/OSPSuite.R.Tests/Services/ConcurrentSimulationRunnerSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/ConcurrentSimulationRunnerSpecs.cs
@@ -49,7 +49,7 @@ namespace OSPSuite.R.Services
 
    public class When_running_a_batch_simulation_run_concurrently : ContextForIntegration<IConcurrentSimulationRunner>
    {
-      private SettingsForConcurrentltyRunSimulationBatch _simulationWithBatchOptions;
+      private SettingsForConcurrentRunSimulationBatch _simulationWithBatchOptions;
       private ISimulationPersister _simulationPersister;
       private ConcurrentSimulationResults[] _results;
       private IModelCoreSimulation _simulation;
@@ -62,7 +62,7 @@ namespace OSPSuite.R.Services
          _simulationPersister = Api.GetSimulationPersister();
          _simulation = _simulationPersister.LoadSimulation(HelperForSpecs.DataFile("S1.pkml"));
 
-         _simulationWithBatchOptions = new SettingsForConcurrentltyRunSimulationBatch()
+         _simulationWithBatchOptions = new SettingsForConcurrentRunSimulationBatch()
          {
             Simulation = _simulation,
             SimulationBatchOptions = new SimulationBatchOptions


### PR DESCRIPTION
Check with @msevestre why ICoreUserSettings is not available through container on Core and restore ConcurrenceManager to use this settings instead of the hardcoded 2 on MaximumNumberOfCoresToUse