### PR TITLE
Adding a test logger button on the starter

### DIFF
--- a/src/OSPSuite.Infrastructure/Services/LoggingBuilderExtensions.cs
+++ b/src/OSPSuite.Infrastructure/Services/LoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Serilog.Events;
 
 namespace OSPSuite.Infrastructure.Services
 {

--- a/tests/OSPSuite.Starter/Bootstrapping/ApplicationStartup.cs
+++ b/tests/OSPSuite.Starter/Bootstrapping/ApplicationStartup.cs
@@ -9,6 +9,7 @@ using DevExpress.XtraBars;
 using DevExpress.XtraBars.Ribbon;
 using DevExpress.XtraEditors;
 using DevExpress.XtraTabbedMdi;
+using Microsoft.Extensions.Logging;
 using OSPSuite.Core;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
@@ -25,6 +26,7 @@ using OSPSuite.Infrastructure.Container.Castle;
 using OSPSuite.Infrastructure.Export;
 using OSPSuite.Infrastructure.Import;
 using OSPSuite.Infrastructure.Serialization;
+using OSPSuite.Infrastructure.Services;
 using OSPSuite.Presentation;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters.Importer;
@@ -46,6 +48,19 @@ namespace OSPSuite.Starter.Bootstrapping
          initializeDependency();
          fillDimensions(IoC.Resolve<IDimensionFactory>());
          loadPKParameterRepository(IoC.Container);
+         configureLogger(IoC.Container, LogLevel.Information);
+      }
+
+      private static void configureLogger(IContainer container, LogLevel logLevel)
+      {
+         var loggerCreator = container.Resolve<ILoggerCreator>();
+
+         loggerCreator
+            .AddLoggingBuilderConfiguration(builder =>
+               builder
+                  .SetMinimumLevel(logLevel)
+                  .AddFile("log.txt")
+            );
       }
 
       private static void loadPKParameterRepository(IContainer container)

--- a/tests/OSPSuite.Starter/Presenters/TestPresenter.cs
+++ b/tests/OSPSuite.Starter/Presenters/TestPresenter.cs
@@ -31,6 +31,7 @@ namespace OSPSuite.Starter.Presenters
       void StartHistogramTest();
       void StartMatrixTest();
       void StartEmptyFormTest();
+      void StartLoggerTest();
    }
 
    public class TestPresenter : AbstractPresenter<ITestView, ITestPresenter>, ITestPresenter
@@ -41,13 +42,12 @@ namespace OSPSuite.Starter.Presenters
       private readonly ISensitivityAnalysisStarter _sensitivityAnalysisStarter;
       private readonly ICommandBrowserStarter _commandBrowserStarter;
       private readonly ISimpleUIStarter _simpleUIStarter;
-      private readonly IImporterConfigurationDataGenerator _dataGenerator;
-
-
+      private readonly IOSPSuiteLogger _logger;
+      
       public TestPresenter(ITestView view, IGridTestStarter girdTestStarter,
          IShellPresenter shellPresenter, IOptimizationStarter optimizationStarter, ISensitivityAnalysisStarter sensitivityAnalysisStarter,
          ICommandBrowserStarter commandBrowserStarter, ISimpleUIStarter simpleUIStarter, IImporterConfigurationDataGenerator dataGenerator,
-         IDialogCreator dialogCreator) : base(view)
+         IOSPSuiteLogger logger) : base(view)
       {
          _girdTestStarter = girdTestStarter;
          _shellPresenter = shellPresenter;
@@ -55,7 +55,13 @@ namespace OSPSuite.Starter.Presenters
          _sensitivityAnalysisStarter = sensitivityAnalysisStarter;
          _commandBrowserStarter = commandBrowserStarter;
          _simpleUIStarter = simpleUIStarter;
-         _dataGenerator = dataGenerator;
+         _logger = logger;
+      }
+
+      public void StartLoggerTest()
+      {
+         _logger.AddCriticalError("Critical");
+         _logger.AddInfo("Info");
       }
 
       private void start<T>(int width = 0, int height = 0) where T : IPresenter

--- a/tests/OSPSuite.Starter/Views/TestView.Designer.cs
+++ b/tests/OSPSuite.Starter/Views/TestView.Designer.cs
@@ -29,6 +29,7 @@
       private void InitializeComponent()
       {
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.startImporterLoadTestButton = new DevExpress.XtraEditors.SimpleButton();
          this.startImporterReloadTestButton = new DevExpress.XtraEditors.SimpleButton();
          this.startEmptyFormButton = new DevExpress.XtraEditors.SimpleButton();
          this.startMatrixTestButton = new DevExpress.XtraEditors.SimpleButton();
@@ -66,8 +67,9 @@
          this.layoutControlItem16 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutControlItem17 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutControlItem18 = new DevExpress.XtraLayout.LayoutControlItem();
-         this.startImporterLoadTestButton = new DevExpress.XtraEditors.SimpleButton();
          this.layoutControlItem19 = new DevExpress.XtraLayout.LayoutControlItem();
+         this.startLoggerButton = new DevExpress.XtraEditors.SimpleButton();
+         this.layoutControlItem20 = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
@@ -91,11 +93,13 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem17)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem18)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem19)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem20)).BeginInit();
          this.SuspendLayout();
          // 
          // layoutControl
          // 
          this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.startLoggerButton);
          this.layoutControl.Controls.Add(this.startImporterLoadTestButton);
          this.layoutControl.Controls.Add(this.startImporterReloadTestButton);
          this.layoutControl.Controls.Add(this.startEmptyFormButton);
@@ -124,6 +128,15 @@
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl1";
          // 
+         // startImporterLoadTestButton
+         // 
+         this.startImporterLoadTestButton.Location = new System.Drawing.Point(12, 229);
+         this.startImporterLoadTestButton.Name = "startImporterLoadTestButton";
+         this.startImporterLoadTestButton.Size = new System.Drawing.Size(473, 27);
+         this.startImporterLoadTestButton.StyleController = this.layoutControl;
+         this.startImporterLoadTestButton.TabIndex = 22;
+         this.startImporterLoadTestButton.Text = "startImporterLoadTestButton";
+         // 
          // startImporterReloadTestButton
          // 
          this.startImporterReloadTestButton.Location = new System.Drawing.Point(12, 198);
@@ -135,7 +148,7 @@
          // 
          // startEmptyFormButton
          // 
-         this.startEmptyFormButton.Location = new System.Drawing.Point(12, 570);
+         this.startEmptyFormButton.Location = new System.Drawing.Point(12, 601);
          this.startEmptyFormButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
          this.startEmptyFormButton.Name = "startEmptyFormButton";
          this.startEmptyFormButton.Size = new System.Drawing.Size(473, 27);
@@ -326,7 +339,8 @@
             this.layoutControlItem16,
             this.layoutControlItem17,
             this.layoutControlItem18,
-            this.layoutControlItem19});
+            this.layoutControlItem19,
+            this.layoutControlItem20});
          this.layoutControlGroup1.Name = "layoutControlGroup1";
          this.layoutControlGroup1.Size = new System.Drawing.Size(497, 650);
          this.layoutControlGroup1.TextVisible = false;
@@ -478,9 +492,9 @@
          // layoutControlItem17
          // 
          this.layoutControlItem17.Control = this.startEmptyFormButton;
-         this.layoutControlItem17.Location = new System.Drawing.Point(0, 558);
+         this.layoutControlItem17.Location = new System.Drawing.Point(0, 589);
          this.layoutControlItem17.Name = "layoutControlItem17";
-         this.layoutControlItem17.Size = new System.Drawing.Size(477, 72);
+         this.layoutControlItem17.Size = new System.Drawing.Size(477, 41);
          this.layoutControlItem17.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem17.TextVisible = false;
          // 
@@ -493,15 +507,6 @@
          this.layoutControlItem18.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem18.TextVisible = false;
          // 
-         // startImporterLoadTestButton
-         // 
-         this.startImporterLoadTestButton.Location = new System.Drawing.Point(12, 229);
-         this.startImporterLoadTestButton.Name = "startImporterLoadTestButton";
-         this.startImporterLoadTestButton.Size = new System.Drawing.Size(473, 27);
-         this.startImporterLoadTestButton.StyleController = this.layoutControl;
-         this.startImporterLoadTestButton.TabIndex = 22;
-         this.startImporterLoadTestButton.Text = "startImporterLoadTestButton";
-         // 
          // layoutControlItem19
          // 
          this.layoutControlItem19.Control = this.startImporterLoadTestButton;
@@ -510,6 +515,24 @@
          this.layoutControlItem19.Size = new System.Drawing.Size(477, 31);
          this.layoutControlItem19.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem19.TextVisible = false;
+         // 
+         // startLoggerButton
+         // 
+         this.startLoggerButton.Location = new System.Drawing.Point(12, 570);
+         this.startLoggerButton.Name = "startLoggerButton";
+         this.startLoggerButton.Size = new System.Drawing.Size(473, 27);
+         this.startLoggerButton.StyleController = this.layoutControl;
+         this.startLoggerButton.TabIndex = 23;
+         this.startLoggerButton.Text = "startLoggerButton";
+         // 
+         // layoutControlItem20
+         // 
+         this.layoutControlItem20.Control = this.startLoggerButton;
+         this.layoutControlItem20.Location = new System.Drawing.Point(0, 558);
+         this.layoutControlItem20.Name = "layoutControlItem20";
+         this.layoutControlItem20.Size = new System.Drawing.Size(477, 31);
+         this.layoutControlItem20.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem20.TextVisible = false;
          // 
          // TestView
          // 
@@ -542,6 +565,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem17)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem18)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem19)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem20)).EndInit();
          this.ResumeLayout(false);
 
       }
@@ -587,5 +611,7 @@
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem18;
       private DevExpress.XtraEditors.SimpleButton startImporterLoadTestButton;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem19;
+      private DevExpress.XtraEditors.SimpleButton startLoggerButton;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItem20;
    }
 }

--- a/tests/OSPSuite.Starter/Views/TestView.cs
+++ b/tests/OSPSuite.Starter/Views/TestView.cs
@@ -58,7 +58,7 @@ namespace OSPSuite.Starter.Views
          startHistogramTestButton.Text = "Start Histogram Test";
          startMatrixTestButton.Text = "Start Matrix Test";
          startEmptyFormButton.Text = "Start Empty Form";
-         startLoggerButton.Text = "Strt Logger Test";
+         startLoggerButton.Text = "Start Logger Test";
       }
 
       public void AttachPresenter(ITestPresenter presenter)

--- a/tests/OSPSuite.Starter/Views/TestView.cs
+++ b/tests/OSPSuite.Starter/Views/TestView.cs
@@ -33,6 +33,7 @@ namespace OSPSuite.Starter.Views
          startHistogramTestButton.Click += (sender, args) => OnEvent(_presenter.StartHistogramTest);
          startMatrixTestButton.Click += (sender, args) => OnEvent(_presenter.StartMatrixTest);
          startEmptyFormButton.Click += (sender, args) => OnEvent(_presenter.StartEmptyFormTest);
+         startLoggerButton.Click += (sender, args) => OnEvent(_presenter.StartLoggerTest);
       }
 
       public override void InitializeResources()
@@ -57,6 +58,7 @@ namespace OSPSuite.Starter.Views
          startHistogramTestButton.Text = "Start Histogram Test";
          startMatrixTestButton.Text = "Start Matrix Test";
          startEmptyFormButton.Text = "Start Empty Form";
+         startLoggerButton.Text = "Strt Logger Test";
       }
 
       public void AttachPresenter(ITestPresenter presenter)


### PR DESCRIPTION
@msevestre I have created the issue on Core since the implementation for the logger is here. I am adding the test logger to the starter. I added a button to trigger a log creation. You should notice that before clicking the button there is no log.txt file at all. Only when creating the logs, the file is created. Also, I have committed a fix. Serilog was not respecting the MinimumLogLevel. I fixed this but now we need to update PKSim and Mobi to add this change. I would think that either there is no log from the CLI (so no need for a file) or the log level was not high enough since default will filter debug and trace.