### PR TITLE
Add methods for getting Unit and Dimension of a quantity by path

### DIFF
--- a/src/OSPSuite.R/Services/ContainerTask.cs
+++ b/src/OSPSuite.R/Services/ContainerTask.cs
@@ -115,7 +115,8 @@ namespace OSPSuite.R.Services
 
       public string[] AllStateVariableParameterPathsIn(IModelCoreSimulation simulation) => AllStateVariableParameterPathsIn(simulation?.Model?.Root);
 
-      public String[] BaseUnitNameFromPath(IModelCoreSimulation simulation, string path)
+      // Return names of base units of entities with given path (may contain wildcards) 
+      public string[] BaseUnitNamesFromPath(IModelCoreSimulation simulation, string path)
       {
          var unitNames = new List<string>();
          var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
@@ -125,15 +126,40 @@ namespace OSPSuite.R.Services
          }
          return unitNames.ToArray();
       }
-      public String[] DimensionNameFromPath(IModelCoreSimulation simulation, string path)
+
+      // Return names of dimension of entities with given path (may contain wildcards) 
+      public string[] DimensionNamesFromPath(IModelCoreSimulation simulation, string path)
       {
-         var unitNames = new List<string>();
+         var dimensionNames = new List<string>();
          var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
          foreach (var quantity in allQuantities)
          {
-            unitNames.Add(WithDimensionExtensions.DimensionName(quantity));
+            dimensionNames.Add(WithDimensionExtensions.DimensionName(quantity));
          }
-         return unitNames.ToArray();
+         return dimensionNames.ToArray();
+      }
+
+      // Return if the start values of entities with given path (may contain wildcards) are defined by an explicit formula
+      public Boolean[] IsExplicitFormulaFromPath(IModelCoreSimulation simulation, string path)
+      {
+         var isFormulas = new List<bool>();
+         var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
+         foreach (var quantity in allQuantities)
+         {
+            isFormulas.Add(Core.Domain.Formulas.FormulaExtensions.IsExplicit(quantity.Formula));
+         }
+         return isFormulas.ToArray();
+      }
+
+      // Add quantities with given path (may contain wildcards) to output selections of the simulation.
+      public void AddQuantitiesToSimulationOutputFromPath(IModelCoreSimulation simulation, string path)
+      {
+         var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
+         var outputSelections = simulation.OutputSelections;
+         foreach (var quantity in allQuantities)
+         {
+            outputSelections.AddQuantity(quantity);
+         }
       }
 
       private string[] allEntityPathIn<T>(IContainer container, Func<T, bool> filterFunc = null) where T : class, IEntity

--- a/src/OSPSuite.R/Services/ContainerTask.cs
+++ b/src/OSPSuite.R/Services/ContainerTask.cs
@@ -115,6 +115,27 @@ namespace OSPSuite.R.Services
 
       public string[] AllStateVariableParameterPathsIn(IModelCoreSimulation simulation) => AllStateVariableParameterPathsIn(simulation?.Model?.Root);
 
+      public String[] BaseUnitNameFromPath(IModelCoreSimulation simulation, string path)
+      {
+         var unitNames = new List<string>();
+         var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
+         foreach (var quantity in allQuantities)
+         {
+            unitNames.Add(WithDimensionExtensions.BaseUnitName(quantity));
+         }
+         return unitNames.ToArray();
+      }
+      public String[] DimensionNameFromPath(IModelCoreSimulation simulation, string path)
+      {
+         var unitNames = new List<string>();
+         var allQuantities = AllQuantitiesMatching(simulation?.Model?.Root, path);
+         foreach (var quantity in allQuantities)
+         {
+            unitNames.Add(WithDimensionExtensions.DimensionName(quantity));
+         }
+         return unitNames.ToArray();
+      }
+
       private string[] allEntityPathIn<T>(IContainer container, Func<T, bool> filterFunc = null) where T : class, IEntity
       {
          return _coreContainerTask.CacheAllChildrenSatisfying(container, filterFunc ?? (x => true)).Keys.ToArray();

--- a/tests/OSPSuite.R.Tests/Services/ContainerTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/ContainerTaskSpecs.cs
@@ -46,6 +46,7 @@ namespace OSPSuite.R.Services
          _liverIntracellular = new Container().WithName(INTRACELLULAR);
          _kidneyIntracellular = new Container().WithName(INTRACELLULAR);
          _volumeLiver = DomainHelperForSpecs.ConstantParameterWithValue(10).WithName(Constants.Parameters.VOLUME);
+         _volumeLiver.Formula = new ExplicitFormula("1+2");
          _volumeOrganism = DomainHelperForSpecs.ConstantParameterWithValue(20).WithName(Constants.Parameters.VOLUME);
          _volumeLiverCell = DomainHelperForSpecs.ConstantParameterWithValue(5).WithName(Constants.Parameters.VOLUME);
          _liverIntracellularSubContainer = new Container().WithName("Intracellular Sub Container");
@@ -70,7 +71,7 @@ namespace OSPSuite.R.Services
          _liverIntracellularMoleculeAmount = new MoleculeAmount().WithName("Drug");
          _liverIntracellular.Add(_liverIntracellularMoleculeAmount);
 
-         _simulation= A.Fake<ISimulation>();
+         _simulation = A.Fake<ISimulation>();
          _simulation.Model.Root = _organism;
       }
 
@@ -245,7 +246,6 @@ namespace OSPSuite.R.Services
          var parameters = new[]
          {
             _volumeLiver, _volumeOrganism, _volumeLiverCell, _volumeKidneyCell, _gfr, _volumeKidney, _height, _weight, _clearance, _gfr.MeanParameter, _gfr.DeviationParameter, _gfr.PercentileParameter, _paramWithRHS
-
          };
          var expected = parameters.Select(x => x.EntityPath()).ToArray();
          _result.ShouldOnlyContain(expected);
@@ -303,6 +303,39 @@ namespace OSPSuite.R.Services
          var parameters = new[] {_paramWithRHS};
          var expected = parameters.Select(x => x.EntityPath()).ToArray();
          _result.ShouldOnlyContain(expected);
+      }
+   }
+
+   public class When_retrieving_the_is_formula_flag_for_a_given_path : concern_for_ContainerTask
+   {
+      [Observation]
+      public void should_return_the_expected_entries()
+      {
+         sut.IsExplicitFormulasFromPath(_simulation, pathFrom(_liver.Name, INTRACELLULAR, $"Vol{Constants.WILD_CARD}")).ShouldOnlyContain(false);
+
+         sut.IsExplicitFormulasFromPath(_simulation, pathFrom(_liver.Name, INTRACELLULAR, $"{Constants.WILD_CARD}Vol")).ShouldBeEmpty();
+
+         sut.IsExplicitFormulasFromPath(_simulation, pathFrom(Constants.WILD_CARD_RECURSIVE, Constants.WILD_CARD, Constants.Parameters.VOLUME)).ShouldOnlyContainInOrder(
+            true, false, false, false);
+      }
+   }
+
+
+   public class When_retrieving_the_base_unit_names_for_a_given_path : concern_for_ContainerTask
+   {
+      [Observation]
+      public void should_return_the_expected_entries()
+      {
+         sut.BaseUnitNamesFromPath(_simulation, pathFrom(_liver.Name, INTRACELLULAR, $"Vol{Constants.WILD_CARD}")).ShouldOnlyContain(_volumeLiverCell.Dimension.BaseUnit.Name);
+      }
+   }
+
+   public class When_retrieving_the_base_dimensions_names_for_a_given_path : concern_for_ContainerTask
+   {
+      [Observation]
+      public void should_return_the_expected_entries()
+      {
+         sut.DimensionNamesFromPath(_simulation, pathFrom(_liver.Name, INTRACELLULAR, $"Vol{Constants.WILD_CARD}")).ShouldOnlyContain(_volumeLiverCell.Dimension.Name);
       }
    }
 }


### PR DESCRIPTION
Sorry, I still cannot write tests (I simply don't know how it works in .NET).


This is insane, getting output values for my use case now takes 1 second as compared to 13 second through direct .net-objects access, and 34 seconds using R6 objects.