### PR TITLE
Could also load from an already existing configuration object

### DIFF
--- a/src/OSPSuite.R/Services/DataImporterTask.cs
+++ b/src/OSPSuite.R/Services/DataImporterTask.cs
@@ -13,8 +13,11 @@ namespace OSPSuite.R.Services
 {
    public interface IDataImporterTask
    {
+      ImporterConfiguration GetConfiguration(string fileName);
       IReadOnlyList<DataRepository> ImportXslxFromConfiguration(string configurationFileName, string dataFileName);
+      IReadOnlyList<DataRepository> ImportXslxFromConfiguration(ImporterConfiguration configuration, string dataFileName);
       IReadOnlyList<DataRepository> ImportCsvFromConfiguration(string configurationFileName, string dataFileName, char columnSeparator);
+      IReadOnlyList<DataRepository> ImportCsvFromConfiguration(ImporterConfiguration configuration, string dataFileName, char columnSeparator);
    }
 
    public class DataImporterTask : IDataImporterTask
@@ -56,10 +59,23 @@ namespace OSPSuite.R.Services
          string dataFileName)
       {
          return _dataImporter.ImportFromConfiguration(
-            getConfiguration(configurationFileName), 
+            GetConfiguration(configurationFileName), 
             _metaDataCategories, 
             _columnInfos, 
             _dataImporterSettings, 
+            dataFileName
+         );
+      }
+
+      public IReadOnlyList<DataRepository> ImportXslxFromConfiguration(
+         ImporterConfiguration configuration,
+         string dataFileName)
+      {
+         return _dataImporter.ImportFromConfiguration(
+            configuration,
+            _metaDataCategories,
+            _columnInfos,
+            _dataImporterSettings,
             dataFileName
          );
       }
@@ -71,7 +87,7 @@ namespace OSPSuite.R.Services
       {
          _csvSeparatorSelector.CsvSeparator = columnSeparator;
          return _dataImporter.ImportFromConfiguration(
-            getConfiguration(configurationFileName),
+            GetConfiguration(configurationFileName),
             _metaDataCategories,
             _columnInfos,
             _dataImporterSettings,
@@ -79,7 +95,22 @@ namespace OSPSuite.R.Services
          );
       }
 
-      private ImporterConfiguration getConfiguration(string fileName)
+      public IReadOnlyList<DataRepository> ImportCsvFromConfiguration(
+         ImporterConfiguration configuration,
+         string dataFileName,
+         char columnSeparator)
+      {
+         _csvSeparatorSelector.CsvSeparator = columnSeparator;
+         return _dataImporter.ImportFromConfiguration(
+            configuration,
+            _metaDataCategories,
+            _columnInfos,
+            _dataImporterSettings,
+            dataFileName
+         );
+      }
+
+      public ImporterConfiguration GetConfiguration(string fileName)
       {
          using (var serializationContext = SerializationTransaction.Create(_container, _dimensionFactory))
          {

--- a/tests/OSPSuite.R.Tests/Services/DataImporterTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/DataImporterTaskSpecs.cs
@@ -24,6 +24,7 @@ namespace OSPSuite.R.Services
          sut.ImportXslxFromConfiguration(getFileFullName("importerConfiguration1.xml"), getFileFullName("sample1.xlsx")).Count.ShouldBeEqualTo(1);
       }
 
+
       [Observation]
       public void should_import_simple_data_from_csv()
       {
@@ -34,6 +35,25 @@ namespace OSPSuite.R.Services
       public void should_return_empty_on_invalid_file_name()
       {
          sut.ImportXslxFromConfiguration(getFileFullName("importerConfiguration1.xml"), "").Count.ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_read_configuration()
+      {
+         sut.GetConfiguration(getFileFullName("importerConfiguration1.xml")).ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_import_simple_data_with_configuration_object()
+      {
+         sut.ImportXslxFromConfiguration(sut.GetConfiguration(getFileFullName("importerConfiguration1.xml")), getFileFullName("sample1.xlsx")).Count.ShouldBeEqualTo(1);
+      }
+
+
+      [Observation]
+      public void should_import_simple_data_from_csv_with_configuration_object()
+      {
+         sut.ImportCsvFromConfiguration(sut.GetConfiguration(getFileFullName("importerConfiguration1.csv.xml")), getFileFullName("sample1.csv"), ';').Count.ShouldBeEqualTo(1);
       }
    }
 }


### PR DESCRIPTION
Fixes #1174 (Also possible to obtain the configuration, maybe edit it, and use it to load a data set)