### PR TITLE
Truncating lines on csv to avoid enlarging the view

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Importer/ICsvSeparatorSelectorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ICsvSeparatorSelectorPresenter.cs
@@ -17,6 +17,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
    public class CsvSeparatorSelectorPresenter : AbstractDisposablePresenter<ICsvSeparatorSelectorView, ICsvSeparatorSelectorPresenter>,
       ICsvSeparatorSelectorPresenter
    {
+      private const int LINE_LENGTH = 100;
       public char SelectedSeparator { get; set; }
       public CsvSeparatorSelectorPresenter(ICsvSeparatorSelectorView view) : base(view)
       {
@@ -34,7 +35,14 @@ namespace OSPSuite.Presentation.Presenters.Importer
          text.AppendLine(Captions.Importer.CsvSeparatorDescription(fileName));
          foreach (var line in File.ReadLines(fileName).Take(3))
          {
-            text.AppendLine(line);
+            if (line.Length > LINE_LENGTH)
+            {
+               text.AppendLine(line.Substring(0, LINE_LENGTH) + "...");
+            }
+            else
+            {
+               text.AppendLine(line);
+            }
          }
          text.Append("...");
          return text.ToString();

--- a/src/OSPSuite.Presentation/Presenters/Importer/ICsvSeparatorSelectorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ICsvSeparatorSelectorPresenter.cs
@@ -3,6 +3,7 @@ using OSPSuite.Presentation.Views.Importer;
 using System.Text;
 using System.IO;
 using System.Linq;
+using System;
 
 namespace OSPSuite.Presentation.Presenters.Importer
 {
@@ -35,14 +36,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
          text.AppendLine(Captions.Importer.CsvSeparatorDescription(fileName));
          foreach (var line in File.ReadLines(fileName).Take(3))
          {
-            if (line.Length > LINE_LENGTH)
-            {
-               text.AppendLine(line.Substring(0, LINE_LENGTH) + "...");
-            }
-            else
-            {
-               text.AppendLine(line);
-            }
+            text.AppendLine(line.Substring(0, Math.Min(line.Length, LINE_LENGTH)) + (line.Length > LINE_LENGTH ? "..." : ""));
          }
          text.Append("...");
          return text.ToString();


### PR DESCRIPTION
Fixes #1181 (Truncating lines on csv to avoid enlarging the CsvSeparatorSelectrView)