### PR TITLE
1209 add error column uses dimensionless on geometric error

### DIFF
--- a/src/OSPSuite.R/Services/DataRepositoryTask.cs
+++ b/src/OSPSuite.R/Services/DataRepositoryTask.cs
@@ -66,7 +66,7 @@ namespace OSPSuite.R.Services
                errorColumn.DisplayUnit = column.DisplayUnit;
                break;
             case AuxiliaryType.GeometricStdDev:
-               errorColumn = new DataColumn(name, _dimensionTask.DimensionByName("Fraction"), column.BaseGrid);
+               errorColumn = new DataColumn(name, _dimensionTask.DimensionByName("Dimensionless"), column.BaseGrid);
                break;
             default:
                throw new OSPSuiteException(Error.InvalidAuxiliaryType);

--- a/src/OSPSuite.R/Services/DataRepositoryTask.cs
+++ b/src/OSPSuite.R/Services/DataRepositoryTask.cs
@@ -20,10 +20,12 @@ namespace OSPSuite.R.Services
    public class DataRepositoryTask : IDataRepositoryTask
    {
       private readonly IPKMLPersistor _pkmlPersistor;
+      private readonly IDimensionTask _dimensionTask;
 
-      public DataRepositoryTask(IPKMLPersistor pkmlPersistor)
+      public DataRepositoryTask(IPKMLPersistor pkmlPersistor, IDimensionTask dimensionTask)
       {
          _pkmlPersistor = pkmlPersistor;
+         _dimensionTask = dimensionTask;
       }
 
       public DataRepository LoadDataRepository(string fileName)
@@ -49,17 +51,28 @@ namespace OSPSuite.R.Services
 
       public DataColumn AddErrorColumn(DataColumn column, string name, string errorType)
       {
-         var errorColumn = new DataColumn(name, column.Dimension, column.BaseGrid);
-
          if (string.IsNullOrEmpty(errorType))
             errorType = AuxiliaryType.ArithmeticStdDev.ToString();
 
          AuxiliaryType auxiliaryType;
          if (!Enum.TryParse(errorType, out auxiliaryType))
             throw new OSPSuiteException(Error.InvalidAuxiliaryType);
-            
+
+         DataColumn errorColumn = null;
+         switch (auxiliaryType)
+         {
+            case AuxiliaryType.ArithmeticStdDev:
+               errorColumn = new DataColumn(name, column.Dimension, column.BaseGrid);
+               errorColumn.DisplayUnit = column.DisplayUnit;
+               break;
+            case AuxiliaryType.GeometricStdDev:
+               errorColumn = new DataColumn(name, _dimensionTask.DimensionByName("Fraction"), column.BaseGrid);
+               break;
+            default:
+               throw new OSPSuiteException(Error.InvalidAuxiliaryType);
+         }
+         
          errorColumn.DataInfo.AuxiliaryType = auxiliaryType;
-         errorColumn.DisplayUnit = column.DisplayUnit;
          errorColumn.DataInfo.Origin = ColumnOrigins.ObservationAuxiliary;
          column.AddRelatedColumn(errorColumn);
 	      return errorColumn;

--- a/tests/OSPSuite.R.Tests/Services/DataRepositoryTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/DataRepositoryTaskSpecs.cs
@@ -103,6 +103,20 @@ namespace OSPSuite.R.Services
       }
 
       [Observation]
+      public void should_create_error_column_with_geometric_error()
+      {
+         var col = _loadedRepository.ObservationColumns().First();
+         var name = new ShortGuid().ToString();
+         var errorColumn = sut.AddErrorColumn(col, name, AuxiliaryType.GeometricStdDev.ToString());
+         errorColumn.Name.ShouldBeEqualTo(name);
+         errorColumn.Dimension.ShouldBeEqualTo(Api.GetDimensionTask().DimensionByName("Fraction"));
+         errorColumn.BaseGrid.ShouldBeEqualTo(_loadedRepository.BaseGrid);
+         errorColumn.DataInfo.AuxiliaryType.ShouldBeEqualTo(AuxiliaryType.GeometricStdDev);
+         errorColumn.DataInfo.Origin.ShouldBeEqualTo(ColumnOrigins.ObservationAuxiliary);
+         col.RelatedColumns.ShouldContain(errorColumn);
+      }
+
+      [Observation]
       public void should_throw_on_bad_error_type()
       {
          var col = _loadedRepository.ObservationColumns().First();

--- a/tests/OSPSuite.R.Tests/Services/DataRepositoryTaskSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/DataRepositoryTaskSpecs.cs
@@ -109,7 +109,7 @@ namespace OSPSuite.R.Services
          var name = new ShortGuid().ToString();
          var errorColumn = sut.AddErrorColumn(col, name, AuxiliaryType.GeometricStdDev.ToString());
          errorColumn.Name.ShouldBeEqualTo(name);
-         errorColumn.Dimension.ShouldBeEqualTo(Api.GetDimensionTask().DimensionByName("Fraction"));
+         errorColumn.Dimension.ShouldBeEqualTo(Api.GetDimensionTask().DimensionByName("Dimensionless"));
          errorColumn.BaseGrid.ShouldBeEqualTo(_loadedRepository.BaseGrid);
          errorColumn.DataInfo.AuxiliaryType.ShouldBeEqualTo(AuxiliaryType.GeometricStdDev);
          errorColumn.DataInfo.Origin.ShouldBeEqualTo(ColumnOrigins.ObservationAuxiliary);


### PR DESCRIPTION
Fixes #1209 (When using geometric error, the dimension should not match the observation column's)