### PR TITLE
DataImporterTask should not cast to ICsvDynamicSeparatorSelector but rely on the DI mechanism

### DIFF
--- a/src/OSPSuite.R/RRegister.cs
+++ b/src/OSPSuite.R/RRegister.cs
@@ -32,6 +32,7 @@ namespace OSPSuite.R
 
             // This will be registered as singleton
             scan.ExcludeType<RGroupRepository>();
+            scan.ExcludeType<CsvSeparatorSelector>();
             scan.WithConvention<OSPSuiteRegistrationConvention>();
          });
 

--- a/src/OSPSuite.R/RRegister.cs
+++ b/src/OSPSuite.R/RRegister.cs
@@ -44,7 +44,7 @@ namespace OSPSuite.R
          container.Register<IOSPSuiteExecutionContext, RExecutionContext>(LifeStyle.Singleton);
          container.Register<IOSPSuiteLogger, RLogger, RLogger>(LifeStyle.Singleton);
          container.Register<IEventPublisher, EventPublisher>(LifeStyle.Singleton);
-         container.Register<ICsvSeparatorSelector, CsvSeparatorSelector>(LifeStyle.Singleton);
+         container.Register<ICsvDynamicSeparatorSelector, ICsvSeparatorSelector, CsvSeparatorSelector>(LifeStyle.Singleton);
       }
    }
 }

--- a/src/OSPSuite.R/Services/DataImporterTask.cs
+++ b/src/OSPSuite.R/Services/DataImporterTask.cs
@@ -38,7 +38,7 @@ namespace OSPSuite.R.Services
       public DataImporterTask(
          IDataImporter dataImporter, 
          IOSPSuiteXmlSerializerRepository modelingXmlSerializerRepository,
-         ICsvSeparatorSelector csvSeparatorSelector,
+         ICsvDynamicSeparatorSelector csvSeparatorSelector,
          IDimensionFactory dimensionFactory, 
          IContainer container
       )
@@ -56,7 +56,7 @@ namespace OSPSuite.R.Services
          //Should actually ask for ICsvDynamicSeparatorSelector as a dependency but I do not currently know
          //how to serve two interfaces with the same singleton. If there is no way to do it with the current
          //implementation, then we need to extend but first I need to check if there is no support for it.
-         _csvSeparatorSelector = csvSeparatorSelector as ICsvDynamicSeparatorSelector;
+         _csvSeparatorSelector = csvSeparatorSelector;
       }
 
       public bool IgnoreSheetNamesAtImport {

--- a/src/OSPSuite.R/Services/DataImporterTask.cs
+++ b/src/OSPSuite.R/Services/DataImporterTask.cs
@@ -53,9 +53,6 @@ namespace OSPSuite.R.Services
          _dataImporterSettings.NameOfMetaDataHoldingMolecularWeightInformation = "Molecular Weight";
          _dataImporterSettings.IgnoreSheetNamesAtImport = true;
          _columnInfos = ((DataImporter)_dataImporter).DefaultPKSimImportConfiguration();
-         //Should actually ask for ICsvDynamicSeparatorSelector as a dependency but I do not currently know
-         //how to serve two interfaces with the same singleton. If there is no way to do it with the current
-         //implementation, then we need to extend but first I need to check if there is no support for it.
          _csvSeparatorSelector = csvSeparatorSelector;
       }
 


### PR DESCRIPTION
Fixes #1213 (DataImporterTask should not cast to ICsvDynamicSeparatorSelector but rely on the DI mechanism)