### PR TITLE
WIP 1262

### DIFF
--- a/src/OSPSuite.Infrastructure.Import/Core/Mappers/DataSetToDataRepositoryMapper.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/Mappers/DataSetToDataRepositoryMapper.cs
@@ -115,12 +115,12 @@ namespace OSPSuite.Infrastructure.Import.Core.Mappers
             if (double.IsNaN(adjustedValue))
                values[i++] = float.NaN;
             else if (unit != null && !string.IsNullOrEmpty(value.Unit))
-               values[i++] = (float)dataColumn.Dimension.UnitValueToBaseUnitValue(dimension.FindUnit(value.Unit, true), adjustedValue);
+               values[i++] = (float)dataColumn.Dimension.UnitValueToBaseUnitValue(dimension?.FindUnit(value.Unit, true), adjustedValue);
             else
                values[i++] = (float) adjustedValue;
          }
          if (lloqValue != null)
-            dataInfo.LLOQ = Convert.ToSingle(dimension.UnitValueToBaseUnitValue(dimension.FindUnit(lloqValue.Unit), lloqValue.Lloq));
+            dataInfo.LLOQ = Convert.ToSingle(dimension?.UnitValueToBaseUnitValue(dimension.FindUnit(lloqValue.Unit), lloqValue.Lloq));
 
          dataColumn.Values = values;
 


### PR DESCRIPTION
Just adding some null checks suggested by ReSharper, although not sure the error came form those. 

The way that error occured, it seems that by clicking from one field to another in the columnMappingView, the transformation to data repository was called with a null unit. I discussed with Abdel adding a check for that and triggering an error, but we decided against it: this should never really happen, and if it does it means something in the functionality before went terribly wrong. In that case it would actualy be better to get the exception, instead of an error message.