### PR TITLE
Null check

### DIFF
--- a/src/OSPSuite.Core/Domain/Data/DataRespositoryExtensions.cs
+++ b/src/OSPSuite.Core/Domain/Data/DataRespositoryExtensions.cs
@@ -44,7 +44,7 @@ namespace OSPSuite.Core.Domain.Data
       private static string valueMapper(IEnumerable<IExtendedProperty> properties, IExtendedProperty value)
       {
          if (value.ValueAsObject == null)
-            return "";
+            return string.Empty;
          return valueMapper(properties, value.ValueAsObject.ToString());
       }
 

--- a/src/OSPSuite.Core/Domain/Data/DataRespositoryExtensions.cs
+++ b/src/OSPSuite.Core/Domain/Data/DataRespositoryExtensions.cs
@@ -43,6 +43,8 @@ namespace OSPSuite.Core.Domain.Data
 
       private static string valueMapper(IEnumerable<IExtendedProperty> properties, IExtendedProperty value)
       {
+         if (value.ValueAsObject == null)
+            return "";
          return valueMapper(properties, value.ValueAsObject.ToString());
       }
 

--- a/tests/OSPSuite.Core.Tests/Domain/DataRepositoryExtensionsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/DataRepositoryExtensionsSpecs.cs
@@ -73,6 +73,30 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_retrieving_intersecting_metadata_with_null_values : concern_for_DataRepositoryExtensions
+   {
+      private IEnumerable<IExtendedProperty> _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         var repository = new DataRepository();
+         repository.ExtendedProperties.Add(GenerateExtendedProperty("key1", null));
+         sut.Add(repository);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.IntersectingMetaData();
+      }
+
+      [Observation]
+      public void should_not_crash()
+      {
+         _result.ToList().ShouldNotBeNull();
+      }
+   }
+
    public class When_retrieving_intersecting_metadata_from_one_repository : concern_for_DataRepositoryExtensions
    {
       private List<IExtendedProperty> _metaDataList;


### PR DESCRIPTION
Fixes #1286 (Should not crash when editing observed data with null values on extended properties)