### PR TITLE
#1293 fixed

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
@@ -715,6 +715,8 @@ namespace OSPSuite.Presentation.Presenters.Importer
          {
             OnMappingCompleted(this, new EventArgs());
          }
+
+         //at the end refresh the data in the columnMappingView grid, to ensure consistency 
          View.RefreshData();
       }
 

--- a/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
@@ -205,7 +205,6 @@ namespace OSPSuite.Presentation.Presenters.Importer
          mappingSource.ColumnName = _metaDataParameterEditorPresenter.Input;
          mappingSource.IsColumn = false;
          ValidateMapping();
-         _view.RefreshData();
          _view.CloseEditor();
       }
 
@@ -234,7 +233,6 @@ namespace OSPSuite.Presentation.Presenters.Importer
          if (model.ColumnInfo.IsBase())
          {
             ValidateMapping();
-            _view.RefreshData();
             _view.CloseEditor();
             return;
          }
@@ -256,8 +254,6 @@ namespace OSPSuite.Presentation.Presenters.Importer
          }
 
          ValidateMapping();
-
-         _view.RefreshData();
          _view.CloseEditor();
       }
 
@@ -622,7 +618,6 @@ namespace OSPSuite.Presentation.Presenters.Importer
          }
 
          ValidateMapping();
-         View.RefreshData();
       }
 
       public void AddGroupBy(AddGroupByFormatParameter source)
@@ -720,6 +715,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
          {
             OnMappingCompleted(this, new EventArgs());
          }
+         View.RefreshData();
       }
 
       public event EventHandler OnMappingCompleted = delegate { };


### PR DESCRIPTION
The issue #1293 arises because the grid does not get refreshed after the cell value gets changed. The event subscription is in line 53 in the ColumnMappingView

columnMappingGridView.CellValueChanged += (o, e) => OnEvent(_presenter.ValidateMapping);

Incorporating the refreshing of the data in the validateMapping solves the issue, but I am not sure it is optimal design - although the do get called together most of the time and refreshing the data after validation does make sense. @msevestre do you think I should create a new function in the presenter for these two calls or keep the changes the way they are now? 