### PR TITLE
Update ParameterIdentificationFeedbackViewVisibilityUICommand.cs

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
@@ -33,6 +33,8 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
       ISingleStartPresenter<ParameterIdentificationFeedback>
    {
       bool ShouldRefreshFeedback { get; set; }
+
+      ParameterIdentification ParameterIdentification { get; }
    }
 
    public class ParameterIdentificationFeedbackPresenter : AbstractToggleablePresenter<IParameterIdentificationFeedbackView, IParameterIdentificationFeedbackPresenter>, IParameterIdentificationFeedbackPresenter

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
@@ -33,8 +33,6 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
       ISingleStartPresenter<ParameterIdentificationFeedback>
    {
       bool ShouldRefreshFeedback { get; set; }
-
-      ParameterIdentification ParameterIdentification { get; }
    }
 
    public class ParameterIdentificationFeedbackPresenter : AbstractToggleablePresenter<IParameterIdentificationFeedbackView, IParameterIdentificationFeedbackPresenter>, IParameterIdentificationFeedbackPresenter
@@ -249,7 +247,5 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
 
       //Used as an id to check if the subject already has a presenter associated
       public object Subject => _parameterIdentificationFeedback;
-
-      public ParameterIdentification ParameterIdentification => _parameterIdentificationFeedback.ParameterIdentification;
    }
 }

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationFeedbackPresenter.cs
@@ -249,5 +249,7 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
 
       //Used as an id to check if the subject already has a presenter associated
       public object Subject => _parameterIdentificationFeedback;
+
+      public ParameterIdentification ParameterIdentification => _parameterIdentificationFeedback.ParameterIdentification;
    }
 }

--- a/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
@@ -5,7 +5,7 @@ using OSPSuite.Presentation.Services;
 
 namespace OSPSuite.Presentation.UICommands
 {
-   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ActiveObjectUICommand<IParameterIdentificationFeedbackPresenter>
+   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ActiveObjectUICommand<ParameterIdentification>
    {
       private readonly ISingleStartPresenterTask _singleStartPresenterTask;
       private readonly IParameterIdentificationFeedbackManager _parameterIdentificationFeedbackManager;
@@ -18,7 +18,7 @@ namespace OSPSuite.Presentation.UICommands
 
       protected override void PerformExecute()
       {
-         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(Subject.ParameterIdentification));
+         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(Subject));
       }
    }
 }

--- a/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
@@ -1,31 +1,26 @@
 ﻿using OSPSuite.Core.Domain.ParameterIdentifications;
-using OSPSuite.Core.Events;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters.ParameterIdentifications;
 using OSPSuite.Presentation.Services;
-using OSPSuite.Utility.Events;
 
 namespace OSPSuite.Presentation.UICommands
 {
-   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ObjectUICommand<IParameterIdentificationFeedbackPresenter>, IListener<ParameterIdentificationSelectedEvent>
+   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ObjectUICommand<IParameterIdentificationFeedbackPresenter>
    {
       private readonly ISingleStartPresenterTask _singleStartPresenterTask;
-      private ParameterIdentification _parameterIdentification;
       private readonly IParameterIdentificationFeedbackManager _parameterIdentificationFeedbackManager;
+      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
 
-      public ParameterIdentificationFeedbackViewVisibilityUICommand(ISingleStartPresenterTask singleStartPresenterTask, IParameterIdentificationFeedbackManager parameterIdentificationFeedbackManager)
+      public ParameterIdentificationFeedbackViewVisibilityUICommand(ISingleStartPresenterTask singleStartPresenterTask, IParameterIdentificationFeedbackManager parameterIdentificationFeedbackManager, IActiveSubjectRetriever activeSubjectRetriever)
       {
          _singleStartPresenterTask = singleStartPresenterTask;
          _parameterIdentificationFeedbackManager = parameterIdentificationFeedbackManager;
-      }
-
-      public void Handle(ParameterIdentificationSelectedEvent eventToHandle)
-      {
-         _parameterIdentification = eventToHandle.ParameterIdentification;
+         _activeSubjectRetriever = activeSubjectRetriever;
       }
 
       protected override void PerformExecute()
       {
-         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(_parameterIdentification));
+         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(_activeSubjectRetriever.Active<ParameterIdentification>()));
       }
    }
 }

--- a/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/ParameterIdentificationFeedbackViewVisibilityUICommand.cs
@@ -5,22 +5,20 @@ using OSPSuite.Presentation.Services;
 
 namespace OSPSuite.Presentation.UICommands
 {
-   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ObjectUICommand<IParameterIdentificationFeedbackPresenter>
+   public class ParameterIdentificationFeedbackViewVisibilityUICommand : ActiveObjectUICommand<IParameterIdentificationFeedbackPresenter>
    {
       private readonly ISingleStartPresenterTask _singleStartPresenterTask;
       private readonly IParameterIdentificationFeedbackManager _parameterIdentificationFeedbackManager;
-      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
 
-      public ParameterIdentificationFeedbackViewVisibilityUICommand(ISingleStartPresenterTask singleStartPresenterTask, IParameterIdentificationFeedbackManager parameterIdentificationFeedbackManager, IActiveSubjectRetriever activeSubjectRetriever)
+      public ParameterIdentificationFeedbackViewVisibilityUICommand(ISingleStartPresenterTask singleStartPresenterTask, IParameterIdentificationFeedbackManager parameterIdentificationFeedbackManager, IActiveSubjectRetriever activeSubjectRetriever) : base(activeSubjectRetriever)
       {
          _singleStartPresenterTask = singleStartPresenterTask;
          _parameterIdentificationFeedbackManager = parameterIdentificationFeedbackManager;
-         _activeSubjectRetriever = activeSubjectRetriever;
       }
 
       protected override void PerformExecute()
       {
-         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(_activeSubjectRetriever.Active<ParameterIdentification>()));
+         _singleStartPresenterTask.StartForSubject(_parameterIdentificationFeedbackManager.GetFeedbackFor(Subject.ParameterIdentification));
       }
    }
 }


### PR DESCRIPTION
Fixes #1372 (Using ActiveSubjectRetriever to retrieve the active parameter identification instead of listening to events)