### PR TITLE
Do not update dimension when it already supports unit to avoid fraction/dimensionless collision

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
@@ -185,9 +185,11 @@ namespace OSPSuite.Presentation.Presenters.Importer
             //has the selected unit.
             column.Unit = _mappingParameterEditorPresenter.Unit;
             if (column.Dimension != null && !column.Dimension.HasUnit(column.Unit.SelectedUnit))
+            {
                column.Dimension = _columnInfos[model.MappingName]
                   .SupportedDimensions
                   .FirstOrDefault(x => x.HasUnit(column.Unit.SelectedUnit));
+            }
          }
 
          if (model.ColumnInfo.IsBase())

--- a/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
@@ -184,10 +184,11 @@ namespace OSPSuite.Presentation.Presenters.Importer
             //The dimension is the first from the supported dimension which
             //has the selected unit.
             column.Unit = _mappingParameterEditorPresenter.Unit;
-            column.Dimension = _columnInfos
-               .First(x => x.DisplayName == model.MappingName)
-               .SupportedDimensions
-               .FirstOrDefault(x => x.HasUnit(column.Unit.SelectedUnit));
+            if (column.Dimension != null && !column.Dimension.HasUnit(column.Unit.SelectedUnit))
+               column.Dimension = _columnInfos
+                  .First(x => x.DisplayName == model.MappingName)
+                  .SupportedDimensions
+                  .FirstOrDefault(x => x.HasUnit(column.Unit.SelectedUnit));
          }
 
          if (model.ColumnInfo.IsBase())

--- a/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ColumnMappingPresenter.cs
@@ -185,8 +185,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
             //has the selected unit.
             column.Unit = _mappingParameterEditorPresenter.Unit;
             if (column.Dimension != null && !column.Dimension.HasUnit(column.Unit.SelectedUnit))
-               column.Dimension = _columnInfos
-                  .First(x => x.DisplayName == model.MappingName)
+               column.Dimension = _columnInfos[model.MappingName]
                   .SupportedDimensions
                   .FirstOrDefault(x => x.HasUnit(column.Unit.SelectedUnit));
          }

--- a/tests/OSPSuite.HelpersForTests/DomainHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/DomainHelperForSpecs.cs
@@ -44,18 +44,7 @@ namespace OSPSuite.Helpers
 
       public static IEnumerable<IDimension> ExtendedDimensionsForSpecs()
       {
-         var dimensions = new List<IDimension>();
-         var dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
-         dimension.AddUnit(new Unit("mol/l", 1E6, 0));
-         dimensions.Add(dimension);
-
-         dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.DIMENSIONLESS, "");
-         dimensions.Add(dimension);
-
-         dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.FRACTION, "");
-         dimension.AddUnit(new Unit("%", 1E6, 0));
-         dimensions.Add(dimension);
-         return dimensions;
+         return new [] { ConcentrationDimensionForSpecs(), Constants.Dimension.NO_DIMENSION, FractionDimensionForSpecs() };
       }
 
       public static IDimension LengthDimensionForSpecs()

--- a/tests/OSPSuite.HelpersForTests/DomainHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/DomainHelperForSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OSPSuite.Core.Domain;
@@ -39,6 +40,22 @@ namespace OSPSuite.Helpers
          }
 
          return _concentrationDimension;
+      }
+
+      public static IEnumerable<IDimension> ExtendedDimensionsForSpecs()
+      {
+         var dimensions = new List<IDimension>();
+         var dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
+         dimension.AddUnit(new Unit("mol/l", 1E6, 0));
+         dimensions.Add(dimension);
+
+         dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.DIMENSIONLESS, "");
+         dimensions.Add(dimension);
+
+         dimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 3, LengthExponent = -1 }, Constants.Dimension.FRACTION, "");
+         dimension.AddUnit(new Unit("%", 1E6, 0));
+         dimensions.Add(dimension);
+         return dimensions;
       }
 
       public static IDimension LengthDimensionForSpecs()

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
@@ -18,6 +18,8 @@ namespace OSPSuite.Presentation.Importer.Presenters
 {
    public abstract class concern_for_ColumnMappingPresenter : ContextSpecification<ColumnMappingPresenter>
    {
+      protected const int GEOMETRIC_ERROR = 0;
+      protected const int ARITMETIC_ERROR = 1;
       protected IDataFormat _basicFormat;
       protected IColumnMappingView _view;
       protected IImporter _importer;
@@ -168,7 +170,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
       {
          base.Context();
          A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription(""));
-         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(0);
+         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(GEOMETRIC_ERROR);
          UpdateSettings();
       }
 
@@ -198,7 +200,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
       {
          base.Context();
          A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription(""));
-         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(1);
+         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(ARITMETIC_ERROR);
          UpdateSettings();
       }
 
@@ -335,7 +337,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
          base.Context();
          _mappingSource = _parameters[2] as MappingDataFormatParameter;
          A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription("µmol/l"));
-         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(1);
+         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(ARITMETIC_ERROR);
          UpdateSettings();
       }
 
@@ -468,7 +470,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
          _mappingSource = _parameters[2] as MappingDataFormatParameter;
          _mappingSource.MappedColumn.Dimension = supportedDimensions.First(x => x.Name == Constants.Dimension.FRACTION);
          A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription(""));
-         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(1);
+         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(ARITMETIC_ERROR);
          UpdateSettings();
       }
 

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
@@ -462,10 +462,11 @@ namespace OSPSuite.Presentation.Importer.Presenters
       protected override void Context()
       {
          base.Context();
-         _columnInfos[2].SupportedDimensions.Clear();
-         _columnInfos[2].SupportedDimensions.AddRange(DomainHelperForSpecs.ExtendedDimensionsForSpecs());
+         var supportedDimensions = _columnInfos["Error"].SupportedDimensions;
+         supportedDimensions.Clear();
+         supportedDimensions.AddRange(DomainHelperForSpecs.ExtendedDimensionsForSpecs());
          _mappingSource = _parameters[2] as MappingDataFormatParameter;
-         _mappingSource.MappedColumn.Dimension = _columnInfos[2].SupportedDimensions.First(x => x.Name == Constants.Dimension.FRACTION);
+         _mappingSource.MappedColumn.Dimension = supportedDimensions.First(x => x.Name == Constants.Dimension.FRACTION);
          A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription(""));
          A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(1);
          UpdateSettings();

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ColumnMappingPresenterSpecs.cs
@@ -454,4 +454,32 @@ namespace OSPSuite.Presentation.Importer.Presenters
             mappedColumn.Dimension.HasUnit(mappedColumn.Unit.SelectedUnit).ShouldBeTrue();
       }
    }
+
+   public class When_unit_is_manually_set_to_fraction_empty : concern_for_ColumnMappingPresenter
+   {
+      protected MappingDataFormatParameter _mappingSource;
+
+      protected override void Context()
+      {
+         base.Context();
+         _columnInfos[2].SupportedDimensions.Clear();
+         _columnInfos[2].SupportedDimensions.AddRange(DomainHelperForSpecs.ExtendedDimensionsForSpecs());
+         _mappingSource = _parameters[2] as MappingDataFormatParameter;
+         _mappingSource.MappedColumn.Dimension = _columnInfos[2].SupportedDimensions.First(x => x.Name == Constants.Dimension.FRACTION);
+         A.CallTo(() => _mappingParameterEditorPresenter.Unit).Returns(new UnitDescription(""));
+         A.CallTo(() => _mappingParameterEditorPresenter.SelectedErrorType).Returns(1);
+         UpdateSettings();
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateDescriptionForModel(_mappingSource);
+      }
+
+      [Observation]
+      public void the_dimension_is_not_changed()
+      {
+         _mappingSource.MappedColumn.Dimension.ShouldNotBeNull();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #1499 (Do not update dimension when it already supports unit to avoid fraction/dimensionless collision)