### PR TITLE
Fixes #1909 Gridview dark mode is hard to use

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2458,8 +2458,6 @@ namespace OSPSuite.Assets
       /// </summary>
       public static Color ChartDiagramBack = Color.White;
 
-      public static Color Disabled = Color.FromArgb(255, 247, 247, 249);
-
       public static Color BelowLLOQ => Color.LightSkyBlue;
       public static Color DefaultRowColor => Color.White;
 

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/WeightedDataRepositoryDataPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/WeightedDataRepositoryDataPresenter.cs
@@ -55,7 +55,9 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
 
       public void DisableRepositoryColumns()
       {
-         if (_dataTable == null) return;
+         if (_dataTable == null) 
+            return;
+         
          foreach (DataColumn column in _dataTable.Columns)
          {
             if (ColumnIsInDataRepository(column))

--- a/src/OSPSuite.UI/Controls/PKAnalysisPivotGridControl.cs
+++ b/src/OSPSuite.UI/Controls/PKAnalysisPivotGridControl.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Drawing;
-using OSPSuite.Utility.Exceptions;
-using DevExpress.Utils;
 using DevExpress.XtraPivotGrid;
-using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
+using OSPSuite.Utility.Exceptions;
 
 namespace OSPSuite.UI.Controls
 {
@@ -49,7 +46,7 @@ namespace OSPSuite.UI.Controls
       {
          //added null checks to prevent the editor to crash when editting the view
          //e.g. GlobalPKAnalysisView@PKSim
-         if (e == null || e.Value  == null || e.Field != ParameterField) return;
+         if (e == null || e.Value == null || e.Field != ParameterField) return;
          e.DisplayText = _parameterDisplayFunc(e.Value.ToString());
       }
 
@@ -57,13 +54,7 @@ namespace OSPSuite.UI.Controls
       {
          if (e.DataField != ValueField) return;
          if (e.Value == null)
-            updateAppearanceBackColor(e.Appearance, Colors.Disabled);
-      }
-
-      private void updateAppearanceBackColor(AppearanceObject appearance, Color color)
-      {
-         appearance.BackColor = color;
-         appearance.BackColor2 = color;
+            e.Appearance.UpdateAppearanceColors(UIConstants.BackgroundDisabled, UIConstants.TextDisabled);
       }
 
       private void onCustomSummary(PivotGridCustomSummaryEventArgs e)

--- a/src/OSPSuite.UI/Controls/UxGridView.cs
+++ b/src/OSPSuite.UI/Controls/UxGridView.cs
@@ -21,6 +21,7 @@ using DevExpress.XtraGrid.Views.Grid;
 using DevExpress.XtraGrid.Views.Grid.ViewInfo;
 using OSPSuite.Assets;
 using OSPSuite.Core.Extensions;
+using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Mappers;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Extensions;
@@ -40,10 +41,6 @@ namespace OSPSuite.UI.Controls
 
       protected override string ViewName => "UxGridView";
 
-      /// <summary>
-      ///    Color used for cell that are locked/disabled (End of gradient)
-      /// </summary>
-      protected Color _colorDisabled = Colors.Disabled;
 
       public UxGridView(GridControl gridControl) : base(gridControl)
       {
@@ -61,14 +58,6 @@ namespace OSPSuite.UI.Controls
          var r = new Rectangle(e.Bounds.Left + 5, e.Bounds.Top + 5, e.Bounds.Width - 5, e.Bounds.Height - 5);
          e.Graphics.DrawString(message, font, Brushes.Black, r);
       }
-
-      /// <summary>
-      ///    True if the grid view should use the  color "_colorDisabled" to display the color in lock cells otherwise false
-      ///    Default is true
-      /// </summary>
-      [Browsable(false)]
-      [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-      public bool ShouldUseColorForDisabledCell { get; set; }
 
       /// <summary>
       ///    True if the grid view should show the column chooser
@@ -100,7 +89,6 @@ namespace OSPSuite.UI.Controls
 
       protected virtual void DoInit()
       {
-         ShouldUseColorForDisabledCell = true;
          ShowColumnChooser = false;
          ShowArrowInRowIndicator = false;
          KeyDown += onKeyDownDefaultBehavior;
@@ -111,7 +99,6 @@ namespace OSPSuite.UI.Controls
          OptionsSelection.EnableAppearanceFocusedCell = false;
          OptionsSelection.EnableAppearanceFocusedRow = false;
          OptionsNavigation.AutoFocusNewRow = true;
-         RowCellStyle += onRowCellStyle;
          PopupMenuShowing += disableColumnChooser;
          _clipboardCopyTask = new ClipboardTask();
          _gridViewToDataTableMapper = new GridViewToDataTableMapper();
@@ -122,16 +109,6 @@ namespace OSPSuite.UI.Controls
          OptionsSelection.MultiSelectMode = GridMultiSelectMode.CellSelect;
       }
 
-      private void onRowCellStyle(object sender, RowCellStyleEventArgs e)
-      {
-         if (!ShouldUseColorForDisabledCell) return;
-         if (e.Column == null) return;
-         if (e.Column.OptionsColumn.AllowEdit) return;
-         if (!e.Column.OptionsColumn.ReadOnly) return;
-
-         //column is readonly
-         AdjustAppearance(e, false);
-      }
 
       /// <summary>
       ///    If the row is enabled, use the default color for enabled, otherwise set the back color to disabled
@@ -140,18 +117,12 @@ namespace OSPSuite.UI.Controls
       {
          if (isEnabled)
             e.CombineAppearance(Appearance.Row);
-         else
-         {
-            AdjustAppearance(e, _colorDisabled);
-         }
       }
 
       public void AdjustAppearance(RowCellStyleEventArgs e, bool isEnabled)
       {
          if (isEnabled)
             e.CombineAppearance(Appearance.Row);
-         else
-            AdjustAppearance(e, _colorDisabled);
       }
 
       public void AdjustAppearance(RowCellStyleEventArgs e, Color color)
@@ -167,7 +138,7 @@ namespace OSPSuite.UI.Controls
          if (rowHasFocus(e.RowHandle))
             e.CombineAppearance(Appearance.FocusedRow);
          else
-            UpdateAppearanceBackColor(e.Appearance, color);
+            e.Appearance.UpdateAppearanceColors(backGround:color, foreGround:e.Appearance.ForeColor);
       }
 
       public void UpdateAppearanceBackColor(AppearanceObject appearance, Color color)

--- a/src/OSPSuite.UI/Extensions/AppearanceObjectExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/AppearanceObjectExtensions.cs
@@ -1,0 +1,15 @@
+﻿using DevExpress.Utils;
+using System.Drawing;
+
+namespace OSPSuite.UI.Extensions
+{
+   public static class AppearanceObjectExtensions
+   {
+      public static void UpdateAppearanceColors(this AppearanceObject appearance, Color backGround, Color foreGround)
+      {
+         appearance.BackColor = backGround;
+         appearance.BackColor2 = backGround;
+         appearance.ForeColor = foreGround;
+      }
+   }
+}

--- a/src/OSPSuite.UI/UIConstants.cs
+++ b/src/OSPSuite.UI/UIConstants.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using DevExpress.Skins;
 using OSPSuite.Assets;
 
 namespace OSPSuite.UI
@@ -128,6 +129,15 @@ namespace OSPSuite.UI
             DARK_SIDE,
             HIGH_CONTRAST
          };
+      }
+
+      public static Color BackgroundDisabled => skinColorFor("ReadOnly");
+      public static Color TextDisabled => skinColorFor("DisabledText");
+      
+      
+      private static Color skinColorFor(string state)
+      {
+         return CommonSkins.GetSkin(DevExpress.LookAndFeel.UserLookAndFeel.Default).Colors[state];
       }
    }
 }

--- a/src/OSPSuite.UI/Views/Charts/AxisSettingsView.cs
+++ b/src/OSPSuite.UI/Views/Charts/AxisSettingsView.cs
@@ -43,7 +43,6 @@ namespace OSPSuite.UI.Views.Charts
          gridView.OptionsCustomization.AllowGroup = false;
          gridView.OptionsView.ShowGroupPanel = false;
          gridView.ShowColumnChooser = true;
-         gridView.ShouldUseColorForDisabledCell = false;
 
          _dimensionRepository = new UxRepositoryItemComboBox(gridView);
          _unitRepository = new UxRepositoryItemComboBox(gridView);

--- a/src/OSPSuite.UI/Views/Charts/CurveSettingsView.cs
+++ b/src/OSPSuite.UI/Views/Charts/CurveSettingsView.cs
@@ -71,7 +71,6 @@ namespace OSPSuite.UI.Views.Charts
 
          gridView.AllowsFiltering = true;
          gridView.ShowColumnChooser = true;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.OptionsView.ShowGroupPanel = false;
          gridView.PopupMenuShowing += onPopupMenuShowing;
 

--- a/src/OSPSuite.UI/Views/Charts/DataBrowserView.cs
+++ b/src/OSPSuite.UI/Views/Charts/DataBrowserView.cs
@@ -31,7 +31,6 @@ namespace OSPSuite.UI.Views.Charts
 
          gridView.AllowsFiltering = true;
          gridView.ShowColumnChooser = true;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.OptionsView.ShowGroupPanel = true;
          gridView.MultiSelect = true;
          gridView.MouseDown += (o, e) => OnEvent(viewMouseDown, e);

--- a/src/OSPSuite.UI/Views/Comparisons/ComparisonView.cs
+++ b/src/OSPSuite.UI/Views/Comparisons/ComparisonView.cs
@@ -28,7 +28,6 @@ namespace OSPSuite.UI.Views.Comparisons
       {
          _pathElementsBinder = pathElementsBinder;
          InitializeComponent();
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.MultiSelect = true;
 
          _gridViewBinder = new GridViewBinder<DiffItemDTO>(gridView);

--- a/src/OSPSuite.UI/Views/ExtendedPropertiesView.cs
+++ b/src/OSPSuite.UI/Views/ExtendedPropertiesView.cs
@@ -143,14 +143,7 @@ namespace OSPSuite.UI.Views
          AdjustHeight();
       }
 
-      public bool ReadOnly
-      {
-         set
-         {
-            _valueColumn.ReadOnly = value;
-            gridView.ShouldUseColorForDisabledCell = !value;
-         }
-      }
+      public bool ReadOnly { set => _valueColumn.ReadOnly = value; }
 
       public void AdjustHeight()
       {

--- a/src/OSPSuite.UI/Views/Journal/JournalView.cs
+++ b/src/OSPSuite.UI/Views/Journal/JournalView.cs
@@ -49,7 +49,6 @@ namespace OSPSuite.UI.Views.Journal
          _imageListRetriever = imageListRetriever;
          InitializeComponent();
          _gridViewBinder = new GridViewBinder<JournalPageDTO>(gridView);
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.ShowColumnChooser = true;
          _rowFontSize = AppearanceObject.DefaultFont.Size;
          PopupBarManager = new BarManager {Form = this, Images = imageListRetriever.AllImagesForContextMenu};

--- a/src/OSPSuite.UI/Views/Journal/RelatedItemsView.cs
+++ b/src/OSPSuite.UI/Views/Journal/RelatedItemsView.cs
@@ -40,7 +40,6 @@ namespace OSPSuite.UI.Views.Journal
          InitializeComponent();
          _gridViewBinder = new GridViewBinder<RelatedItem>(gridView);
          gridView.AllowsFiltering = false;
-         gridView.ShouldUseColorForDisabledCell = false;
 
          var toolTipController = new ToolTipController();
          toolTipController.GetActiveObjectInfo += onToolTipControllerGetActiveObjectInfo;

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationFeedbackView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationFeedbackView.cs
@@ -32,7 +32,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          _gridViewBinder = new GridViewBinder<MultiOptimizationRunResultDTO>(gridView);
          _repositoryItemDescription = new RepositoryItemMemoEdit();
          gridView.AllowsFiltering = false;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.MultiSelect = true;
          gridView.OptionsView.RowAutoHeight = true;
          var toolTipController = new ToolTipController();

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
@@ -73,14 +73,12 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       {
          optimizedParametersView.AllowsFiltering = false;
          optimizedParametersView.SynchronizeClones = false;
-         optimizedParametersView.ShouldUseColorForDisabledCell = false;
          optimizedParametersView.OptionsCustomization.AllowSort = true;
       }
 
       private void initializeMainView()
       {
          mainView.AllowsFiltering = false;
-         mainView.ShouldUseColorForDisabledCell = false;
          mainView.MultiSelect = true;
          mainView.OptionsDetail.AllowExpandEmptyDetails = false;
          mainView.MasterRowGetChildList += mainViewMasterRowGetChildList;

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationConfidenceIntervalView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationConfidenceIntervalView.cs
@@ -18,7 +18,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
       {
          InitializeComponent();
          _gridViewBinder = new GridViewBinder<ParameterConfidenceIntervalDTO>(gridView);
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.AllowsFiltering = false;
          gridView.MultiSelect = true;
       }

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationLinkedParametersView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationLinkedParametersView.cs
@@ -31,7 +31,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          gridView.AllowsFiltering = false;
          _gridViewBinder = new GridViewBinder<LinkedParameterDTO>(gridView);
          _pathElementsBinder = new PathElementsBinder<LinkedParameterDTO>(imageListRetriever);
-         gridView.ShouldUseColorForDisabledCell = false;
          _disableRemoveButtonRepository.Buttons[0].Enabled = false;
          _disabledUnlinkButtonRepository.Buttons[0].Enabled = false;
       }

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationParametersFeedbackView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationParametersFeedbackView.cs
@@ -39,7 +39,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
 
       private void initGridView(UxGridView gridView)
       {
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.AllowsFiltering = false;
          gridView.MultiSelect = true;
       }

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationRunPropertiesView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/ParameterIdentificationRunPropertiesView.cs
@@ -28,7 +28,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          InitializeComponent();
          gridView.AllowsFiltering = false;
          gridView.MultiSelect = true;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.ShowColumnHeaders = false;
          _gridViewBinder = new GridViewBinder<IRunPropertyDTO>(gridView);
          _textRepositoryItem = new RepositoryItemTextEdit();

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/SingleParameterIdentificationResultsView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/SingleParameterIdentificationResultsView.cs
@@ -25,7 +25,6 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          _gridViewBinder = new GridViewBinder<OptimizedParameterDTO>(gridView);
          _optimizedParametersBinder = new OptimizedParametersBinder(imageListRetriever, toolTipCreator);
          gridView.AllowsFiltering = false;
-         gridView.ShouldUseColorForDisabledCell = false;
       }
 
       public void AttachPresenter(ISingleParameterIdentificationResultsPresenter presenter)

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/WeightedDataRepositoryDataView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/WeightedDataRepositoryDataView.cs
@@ -8,6 +8,7 @@ using DevExpress.XtraLayout.Utils;
 using OSPSuite.Assets;
 using OSPSuite.Presentation.Presenters.ParameterIdentifications;
 using OSPSuite.Presentation.Views.ParameterIdentifications;
+using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
 using OSPSuite.UI.Views.ObservedData;
 using OSPSuite.Utility.Extensions;
@@ -79,7 +80,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          if (gridViewColumn == null)
             return;
          gridViewColumn.OptionsColumn.AllowEdit = false;
-         gridViewColumn.AppearanceCell.BackColor = Colors.Disabled;
+         gridViewColumn.AppearanceCell.UpdateAppearanceColors(UIConstants.BackgroundDisabled, UIConstants.TextDisabled);
       }
 
       private GridColumn gridViewColumnFromDataColumn(DataColumn column)

--- a/src/OSPSuite.UI/Views/QuantityListView.cs
+++ b/src/OSPSuite.UI/Views/QuantityListView.cs
@@ -39,7 +39,6 @@ namespace OSPSuite.UI.Views
          gridView.GroupFormat = "[#image]{1}";
          _gridViewBinder = new GridViewBinder<QuantitySelectionDTO>(gridView);
          _pathElementsBinder = pathElementsBinder;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.OptionsSelection.EnableAppearanceFocusedRow = true;
          gridView.ShowColumnChooser = true;
          gridView.EndGrouping += (o, e) => OnEvent(gridViewEndGrouping);

--- a/src/OSPSuite.UI/Views/SimulationParametersView.cs
+++ b/src/OSPSuite.UI/Views/SimulationParametersView.cs
@@ -12,7 +12,6 @@ using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Binders;
 using OSPSuite.UI.Controls;
-using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Format;
 
@@ -34,7 +33,6 @@ namespace OSPSuite.UI.Views
          _pathElementsBinder = new PathElementsBinder<SimulationParameterSelectionDTO>(imageListRetriever);
          gridView.AllowsFiltering = true;
          gridView.MultiSelect = true;
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.OptionsFind.ShowCloseButton = false;
          gridView.OptionsFind.AlwaysVisible = true;
          gridView.GroupFormat = "[#image]{1}";

--- a/src/OSPSuite.UI/Views/ValidationMessagesView.cs
+++ b/src/OSPSuite.UI/Views/ValidationMessagesView.cs
@@ -24,7 +24,6 @@ namespace OSPSuite.UI.Views
          InitializeComponent();
          _imageListRetriever = imageListRetriever;
          _toolTipCreator = toolTipCreator;
-         gridView.ShouldUseColorForDisabledCell = false;
          _messageRepositoryItem = new RepositoryItemMemoEdit {AutoHeight = true};
          gridView.OptionsView.RowAutoHeight = true;
          var toolTipController = new ToolTipController {ImageList = imageListRetriever.AllImages16x16};

--- a/tests/OSPSuite.Starter/Forms/GridViewForm.cs
+++ b/tests/OSPSuite.Starter/Forms/GridViewForm.cs
@@ -17,14 +17,12 @@ namespace OSPSuite.Starter.Forms
    {
       private readonly ValueOriginBinder<ParameterDTO> _valueOriginBinder;
       private readonly GridViewBinder<ParameterDTO> _gridViewBinder;
-      private List<ParameterDTO> _allParameters;
-      private ParameterDTO _firstParmaeter;
+      private readonly ParameterDTO _firstParameter;
 
       public GridViewForm(ValueOriginBinder<ParameterDTO> valueOriginBinder)
       {
          _valueOriginBinder = valueOriginBinder;
          InitializeComponent();
-         gridView.ShouldUseColorForDisabledCell = false;
          gridView.OptionsSelection.MultiSelectMode = GridMultiSelectMode.CellSelect;
          gridView.OptionsSelection.EnableAppearanceFocusedRow = true;
          gridView.OptionsSelection.EnableAppearanceFocusedCell = true;
@@ -34,11 +32,11 @@ namespace OSPSuite.Starter.Forms
 
          initializeBinding();
 
-         _allParameters = generateDummyContent().ToList();
-         _gridViewBinder.BindToSource(_allParameters.ToBindingList());
+         var allParameters = generateDummyContent().ToList();
+         _gridViewBinder.BindToSource(allParameters.ToBindingList());
 
-         _firstParmaeter = _allParameters[0];
-         _firstParmaeter.PropertyChanged += propertyChanged;
+         _firstParameter = allParameters[0];
+         _firstParameter.PropertyChanged += propertyChanged;
       }
 
       private void propertyChanged(object sender, PropertyChangedEventArgs e)
@@ -66,9 +64,6 @@ namespace OSPSuite.Starter.Forms
 
       private bool canEditValueOrigin(ParameterDTO parameter)
       {
-//         if (!parameter.NameIsOneOf("Prameter_2", "Prameter_4"))
-//            return false;
-
          return true;
       }
 
@@ -76,8 +71,8 @@ namespace OSPSuite.Starter.Forms
       {
          parameterDTO.UpdateValueOriginFrom(newValueOrigin);
 
-         //Also update first parmaeter with same value origin to test update
-         _firstParmaeter.UpdateValueOriginFrom(newValueOrigin);
+         //Also update first parameter with same value origin to test update
+         _firstParameter.UpdateValueOriginFrom(newValueOrigin);
       }
 
       private IEnumerable<ParameterDTO> generateDummyContent()


### PR DESCRIPTION
part 1 of 3 (MoBi and PKSim will be affected).

My proposal is to remove this DisabledColor from OSPSuite.Core. Within Core itself, it's only used in a couple of places besides ```UxGridView```.

```
PKAnalysisPivotGridControl.cs
WeightedDataRepositoryDataView.cs
```

For those user controls, the usage is adjusting for some other cell states besides readonly/editable. There is some color adjustments going on if cells contents meet certain conditions like null or below LLOQ. For those cases, I actually want to use the skin disabled colors instead of a constant color.

I think the usage in UxGridView itself is not needed. We generally want the skin to take care of drawing the cells.