### PR TITLE
Fixes #1909 Gridview dark mode is hard to use

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2458,8 +2458,6 @@ namespace OSPSuite.Assets
       /// </summary>
       public static Color ChartDiagramBack = Color.White;
 
-      public static Color Disabled = Color.FromArgb(255, 247, 247, 249);
-
       public static Color BelowLLOQ => Color.LightSkyBlue;
       public static Color DefaultRowColor => Color.White;
 

--- a/src/OSPSuite.Presentation/Presenters/Commands/HistoryBrowserConfiguration.cs
+++ b/src/OSPSuite.Presentation/Presenters/Commands/HistoryBrowserConfiguration.cs
@@ -15,7 +15,6 @@ namespace OSPSuite.Presentation.Presenters.Commands
 
       IEnumerable<string> AllDynamicColumnNames { get; }
       Color LabelColor { get; set; }
-      Color NotReversibleColor { get; set; }
    }
 
    public class HistoryBrowserConfiguration : IHistoryBrowserConfiguration
@@ -23,13 +22,11 @@ namespace OSPSuite.Presentation.Presenters.Commands
       //cache: key is name of column, value is description
       private readonly ICache<string, string> _dynamicColumns;
       public Color LabelColor { get; set; }
-      public Color NotReversibleColor { get; set; }
 
       public HistoryBrowserConfiguration()
       {
          _dynamicColumns = new Cache<string, string>();
          LabelColor = Color.YellowGreen;
-         NotReversibleColor = Color.LightGray;
       }
 
       public void AddDynamicColumn(string dynamicColumnName, string dynamicColumnCaption)

--- a/src/OSPSuite.UI/Controls/PKAnalysisPivotGridControl.cs
+++ b/src/OSPSuite.UI/Controls/PKAnalysisPivotGridControl.cs
@@ -57,7 +57,7 @@ namespace OSPSuite.UI.Controls
       {
          if (e.DataField != ValueField) return;
          if (e.Value == null)
-            updateAppearanceBackColor(e.Appearance, Colors.Disabled);
+            updateAppearanceBackColor(e.Appearance, UIConstants.Colors.Disabled);
       }
 
       private void updateAppearanceBackColor(AppearanceObject appearance, Color color)

--- a/src/OSPSuite.UI/Controls/UxGridView.cs
+++ b/src/OSPSuite.UI/Controls/UxGridView.cs
@@ -39,12 +39,7 @@ namespace OSPSuite.UI.Controls
       private DataTable rectangularSelectionOnlyTable => _gridViewToDataTableMapper.MapFrom(this, GetSelectedRows(), GetSelectedCells);
 
       protected override string ViewName => "UxGridView";
-
-      /// <summary>
-      ///    Color used for cell that are locked/disabled (End of gradient)
-      /// </summary>
-      protected Color _colorDisabled = Colors.Disabled;
-
+      
       public UxGridView(GridControl gridControl) : base(gridControl)
       {
          DoInit();
@@ -142,7 +137,7 @@ namespace OSPSuite.UI.Controls
             e.CombineAppearance(Appearance.Row);
          else
          {
-            AdjustAppearance(e, _colorDisabled);
+            AdjustAppearance(e, UIConstants.Colors.Disabled, UIConstants.Colors.TextDisabled);
          }
       }
 
@@ -151,23 +146,29 @@ namespace OSPSuite.UI.Controls
          if (isEnabled)
             e.CombineAppearance(Appearance.Row);
          else
-            AdjustAppearance(e, _colorDisabled);
+            AdjustAppearance(e, UIConstants.Colors.Disabled, UIConstants.Colors.TextDisabled);
       }
 
-      public void AdjustAppearance(RowCellStyleEventArgs e, Color color)
+      public void AdjustAppearance(RowCellStyleEventArgs e, Color backgroundColor, Color foregroundColor)
       {
          if (rowHasFocus(e.RowHandle))
             e.CombineAppearance(Appearance.FocusedCell);
          else
-            UpdateAppearanceBackColor(e.Appearance, color);
+         {
+            UpdateAppearanceBackColor(e.Appearance, backgroundColor);
+            e.Appearance.ForeColor = foregroundColor;
+         }
       }
 
-      public void AdjustAppearance(RowStyleEventArgs e, Color color)
+      public void AdjustAppearance(RowStyleEventArgs e, Color backgroundColor, Color foregroundColor)
       {
          if (rowHasFocus(e.RowHandle))
             e.CombineAppearance(Appearance.FocusedRow);
          else
-            UpdateAppearanceBackColor(e.Appearance, color);
+         {
+            UpdateAppearanceBackColor(e.Appearance, backgroundColor);
+            e.Appearance.ForeColor = foregroundColor;
+         }
       }
 
       public void UpdateAppearanceBackColor(AppearanceObject appearance, Color color)

--- a/src/OSPSuite.UI/UIConstants.cs
+++ b/src/OSPSuite.UI/UIConstants.cs
@@ -1,12 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using DevExpress.Skins;
 using OSPSuite.Assets;
 
 namespace OSPSuite.UI
 {
    public static class UIConstants
    {
+      public static class Colors
+      {
+         public static Color Disabled => skinColorFor("ReadOnly");
+         public static Color TextDisabled => skinColorFor("DisabledText");
+
+         private static Color skinColorFor(string state)
+         {
+            return CommonSkins.GetSkin(DevExpress.LookAndFeel.UserLookAndFeel.Default).Colors[state];
+         }
+      }
+      
       public const int TOOL_TIP_INITIAL_DELAY = 500;
       public const int TOOL_TIP_INITIAL_DELAY_LONG = 1500;
       public const string EMPTY_COLUMN = " ";

--- a/src/OSPSuite.UI/UIConstants.cs
+++ b/src/OSPSuite.UI/UIConstants.cs
@@ -10,6 +10,7 @@ namespace OSPSuite.UI
    {
       public static class Colors
       {
+         // These colors change with the skin, so we use a method to read the latest up-to-date value from the skin
          public static Color Disabled => skinColorFor("ReadOnly");
          public static Color TextDisabled => skinColorFor("DisabledText");
 

--- a/src/OSPSuite.UI/Views/Commands/HistoryBrowserView.cs
+++ b/src/OSPSuite.UI/Views/Commands/HistoryBrowserView.cs
@@ -213,7 +213,10 @@ namespace OSPSuite.UI.Views.Commands
          if (_presenter.IsLabel(historyItemId))
             e.Appearance.BackColor = _historyBrowserConfiguration.LabelColor;
          else if (!_presenter.CanRollBackTo(historyItemId))
-            e.Appearance.BackColor = _historyBrowserConfiguration.NotReversibleColor;
+         {
+            e.Appearance.BackColor = UIConstants.Colors.Disabled;
+            e.Appearance.ForeColor = UIConstants.Colors.TextDisabled;
+         }
       }
    }
 }

--- a/src/OSPSuite.UI/Views/Comparisons/ComparisonView.cs
+++ b/src/OSPSuite.UI/Views/Comparisons/ComparisonView.cs
@@ -61,7 +61,7 @@ namespace OSPSuite.UI.Views.Comparisons
          if (dto == null) return;
 
          if (dto.ItemIsMissing)
-            gridView.AdjustAppearance(e, Colors.ADDED_OR_MISSING);
+            gridView.AdjustAppearance(e, Colors.ADDED_OR_MISSING, e.Appearance.ForeColor);
 
       }
 

--- a/src/OSPSuite.UI/Views/ObservedData/BaseDataRepositoryDataView.cs
+++ b/src/OSPSuite.UI/Views/ObservedData/BaseDataRepositoryDataView.cs
@@ -92,7 +92,7 @@ namespace OSPSuite.UI.Views.ObservedData
          if (table == null) return;
 
          var color = _presenter.BackgroundColorForRow(sourceRow);
-         gridView.AdjustAppearance(e, color);
+         gridView.AdjustAppearance(e, color, e.Appearance.ForeColor);
       }
 
       public override ApplicationIcon ApplicationIcon => ApplicationIcons.Parameters;

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/WeightedDataRepositoryDataView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/WeightedDataRepositoryDataView.cs
@@ -79,7 +79,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          if (gridViewColumn == null)
             return;
          gridViewColumn.OptionsColumn.AllowEdit = false;
-         gridViewColumn.AppearanceCell.BackColor = Colors.Disabled;
+         gridViewColumn.AppearanceCell.BackColor = UIConstants.Colors.Disabled;
       }
 
       private GridColumn gridViewColumnFromDataColumn(DataColumn column)


### PR DESCRIPTION
Moving Colors.Disabled from OSPSuite.Core.UIConstants to OSPSUite.UI.UIConstants so that we can get disabled colors from the DevExpress skin definition.

Updating uxGridView to use this value as well as the similar TextDisabled to set forecolor.

Now disabled cells in the grid look like disabled textedits. Some skins do not differentiate between disabled and enabled, but the default skin does differentiate.