### PR TITLE
Fixes #1991 curve binder refresh performance

### DIFF
--- a/src/OSPSuite.Core/Domain/Data/DataColumn.cs
+++ b/src/OSPSuite.Core/Domain/Data/DataColumn.cs
@@ -54,7 +54,7 @@ namespace OSPSuite.Core.Domain.Data
          BaseGrid = baseGrid;
          QuantityInfo = new QuantityInfo(new List<string>(), QuantityType.Undefined);
          var defaultUnitName = dimension != null ? dimension.DefaultUnitName : string.Empty;
-         DataInfo = new DataInfo(ColumnOrigins.Undefined) {DisplayUnitName = defaultUnitName};
+         DataInfo = new DataInfo(ColumnOrigins.Undefined) { DisplayUnitName = defaultUnitName };
          IsInternal = false;
       }
 
@@ -142,7 +142,7 @@ namespace OSPSuite.Core.Domain.Data
       /// </summary>
       public virtual double Value
       {
-         set => ValuesAsArray = new[] {value};
+         set => ValuesAsArray = new[] { value };
       }
 
       /// <summary>
@@ -209,6 +209,17 @@ namespace OSPSuite.Core.Domain.Data
       }
 
       public virtual IReadOnlyCollection<DataColumn> RelatedColumns => RelatedColumnsCache;
+
+      public virtual float GetValueAt(int baseIndex)
+      {
+         if (Values == null || !Values.Any())
+            return float.NaN;
+         
+         if (baseIndex >= 0 && baseIndex < Values.Count)
+            return Values[baseIndex];
+
+         return float.NaN;
+      }
 
       public virtual float GetValue(float baseValue)
       {

--- a/src/OSPSuite.Core/Domain/Data/DataColumn.cs
+++ b/src/OSPSuite.Core/Domain/Data/DataColumn.cs
@@ -54,7 +54,7 @@ namespace OSPSuite.Core.Domain.Data
          BaseGrid = baseGrid;
          QuantityInfo = new QuantityInfo(new List<string>(), QuantityType.Undefined);
          var defaultUnitName = dimension != null ? dimension.DefaultUnitName : string.Empty;
-         DataInfo = new DataInfo(ColumnOrigins.Undefined) { DisplayUnitName = defaultUnitName };
+         DataInfo = new DataInfo(ColumnOrigins.Undefined) {DisplayUnitName = defaultUnitName};
          IsInternal = false;
       }
 
@@ -142,7 +142,7 @@ namespace OSPSuite.Core.Domain.Data
       /// </summary>
       public virtual double Value
       {
-         set => ValuesAsArray = new[] { value };
+         set => ValuesAsArray = new[] {value};
       }
 
       /// <summary>
@@ -209,17 +209,6 @@ namespace OSPSuite.Core.Domain.Data
       }
 
       public virtual IReadOnlyCollection<DataColumn> RelatedColumns => RelatedColumnsCache;
-
-      public virtual float GetValueAt(int baseIndex)
-      {
-         if (Values == null || !Values.Any())
-            return float.NaN;
-         
-         if (baseIndex >= 0 && baseIndex < Values.Count)
-            return Values[baseIndex];
-
-         return float.NaN;
-      }
 
       public virtual float GetValue(float baseValue)
       {

--- a/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
@@ -14,9 +14,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex)
       {
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(Curve.yData, baseValue, baseIndex));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(Curve.yData, baseGrid, baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
@@ -14,9 +14,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
       {
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, Curve.yData.GetValue(baseValue));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(Curve.yData, baseValue, baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
@@ -14,9 +14,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
       {
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, Curve.yData.GetValueAt(baseIndex));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, Curve.yData.GetValue(baseValue));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticMeanAreaCurveBinder.cs
@@ -14,9 +14,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
       {
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, Curve.yData.GetValue(baseValue));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, Curve.yData.GetValueAt(baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.ArithmeticStdDev);
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, relatedColumn.GetValue(baseValue));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, relatedColumn.GetValueAt(baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.ArithmeticStdDev);
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, relatedColumn.GetValue(baseValue));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(relatedColumn, baseValue, baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.ArithmeticStdDev);
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, relatedColumn.GetValueAt(baseIndex));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, relatedColumn.GetValue(baseValue));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/ArithmeticSTDCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.ArithmeticStdDev);
-         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(relatedColumn, baseValue, baseIndex));
+         var stdDev = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(relatedColumn, baseGrid, baseIndex));
          if (!IsValidValue(stdDev))
             stdDev = 0;
 

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -321,6 +321,7 @@ namespace OSPSuite.UI.Binders
          _dataTable.BeginLoadData();
          
          for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
+         // foreach (var baseValue in baseGrid.Values)
          {
             var baseValue = baseGrid.Values[baseIndex];
             try

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -309,20 +309,35 @@ namespace OSPSuite.UI.Binders
          if (!dimensionsConsistentToAxisUnits())
             return;
 
+         var baseGrid = activeBaseGrid(Curve.xData, ActiveYData);
+
+         // works for different base grids
+         _dataTable.BeginLoadData();
+
+         if (baseGrid.Values != null && baseGrid.Values.Any())
+         {
+            refreshAllValues(baseGrid);
+         }
+
+         if (_xAxis.NumberMode == NumberModes.Relative)
+            setRelativeValues(X);
+
+         if (_yAxis.NumberMode == NumberModes.Relative)
+            setRelativeValues(Y);
+
+         _dataTable.EndLoadData();
+      }
+
+      private void refreshAllValues(BaseGrid baseGrid)
+      {
+         var xData = Curve.xData;
+         var yData = ActiveYData;
          var xDimension = Curve.xDimension;
          var yDimension = Curve.yDimension;
          var xUnit = xDimension.Unit(_xAxis.UnitName);
          var yUnit = yDimension.Unit(_yAxis.UnitName);
-         var xData = Curve.xData;
-         var yData = ActiveYData;
-         var baseGrid = activeBaseGrid(xData, yData);
-
-         // works for different base grids
-         _dataTable.BeginLoadData();
-         
-         for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
+         for (var baseIndex = 0; baseIndex < baseGrid.Values.Count; baseIndex++)
          {
-            var baseValue = baseGrid.Values[baseIndex];
             try
             {
                double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValueAt(baseIndex));
@@ -348,14 +363,6 @@ namespace OSPSuite.UI.Binders
                //can  happen when plotting X vs Y and using different base grid
             }
          }
-
-         if (_xAxis.NumberMode == NumberModes.Relative)
-            setRelativeValues(X);
-
-         if (_yAxis.NumberMode == NumberModes.Relative)
-            setRelativeValues(Y);
-
-         _dataTable.EndLoadData();
       }
 
       protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex);

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -309,35 +309,20 @@ namespace OSPSuite.UI.Binders
          if (!dimensionsConsistentToAxisUnits())
             return;
 
-         var baseGrid = activeBaseGrid(Curve.xData, ActiveYData);
-
-         // works for different base grids
-         _dataTable.BeginLoadData();
-
-         if (baseGrid.Values != null && baseGrid.Values.Any())
-         {
-            refreshAllValues(baseGrid);
-         }
-
-         if (_xAxis.NumberMode == NumberModes.Relative)
-            setRelativeValues(X);
-
-         if (_yAxis.NumberMode == NumberModes.Relative)
-            setRelativeValues(Y);
-
-         _dataTable.EndLoadData();
-      }
-
-      private void refreshAllValues(BaseGrid baseGrid)
-      {
-         var xData = Curve.xData;
-         var yData = ActiveYData;
          var xDimension = Curve.xDimension;
          var yDimension = Curve.yDimension;
          var xUnit = xDimension.Unit(_xAxis.UnitName);
          var yUnit = yDimension.Unit(_yAxis.UnitName);
-         for (var baseIndex = 0; baseIndex < baseGrid.Values.Count; baseIndex++)
+         var xData = Curve.xData;
+         var yData = ActiveYData;
+         var baseGrid = activeBaseGrid(xData, yData);
+
+         // works for different base grids
+         _dataTable.BeginLoadData();
+         
+         for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
          {
+            var baseValue = baseGrid.Values[baseIndex];
             try
             {
                double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValueAt(baseIndex));
@@ -363,6 +348,14 @@ namespace OSPSuite.UI.Binders
                //can  happen when plotting X vs Y and using different base grid
             }
          }
+
+         if (_xAxis.NumberMode == NumberModes.Relative)
+            setRelativeValues(X);
+
+         if (_yAxis.NumberMode == NumberModes.Relative)
+            setRelativeValues(Y);
+
+         _dataTable.EndLoadData();
       }
 
       protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex);

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -337,7 +337,7 @@ namespace OSPSuite.UI.Binders
                if (HasLLOQ)
                   row[LLOQ_SUFFIX] = LLOQ;
 
-               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseValue);
+               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseValue, baseIndex);
 
                _dataTable.Rows.Add(row);
             }
@@ -368,7 +368,7 @@ namespace OSPSuite.UI.Binders
          return dataColumn.GetValue(baseValue);
       }
 
-      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue);
+      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex);
 
       private BaseGrid activeBaseGrid(DataColumn xData, DataColumn yData)
       {

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -319,12 +319,15 @@ namespace OSPSuite.UI.Binders
 
          // works for different base grids
          _dataTable.BeginLoadData();
-         foreach (var baseValue in baseGrid.Values)
+         
+         for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
+         // foreach (var baseValue in baseGrid.Values)
          {
+            var baseValue = baseGrid.Values[baseIndex];
             try
             {
-               double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValue(baseValue));
-               double y = yDimension.BaseUnitValueToUnitValue(yUnit, yData.GetValue(baseValue));
+               double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValueAt(baseIndex));
+               double y = yDimension.BaseUnitValueToUnitValue(yUnit, yData.GetValueAt(baseIndex));
 
                if (!isValidXValue(x) || !IsValidYValue(y))
                   continue;
@@ -332,12 +335,12 @@ namespace OSPSuite.UI.Binders
                var row = _dataTable.NewRow();
                row[X] = x;
                row[Y] = y;
-               row[INDEX_OF_VALUE_IN_CURVE] = baseGrid.IndexOf(baseValue);
+               row[INDEX_OF_VALUE_IN_CURVE] = baseIndex;
 
                if (HasLLOQ)
                   row[LLOQ_SUFFIX] = LLOQ;
 
-               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseValue);
+               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseIndex);
 
                _dataTable.Rows.Add(row);
             }
@@ -356,7 +359,7 @@ namespace OSPSuite.UI.Binders
          _dataTable.EndLoadData();
       }
 
-      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue);
+      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex);
 
       private BaseGrid activeBaseGrid(DataColumn xData, DataColumn yData)
       {

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -319,15 +319,12 @@ namespace OSPSuite.UI.Binders
 
          // works for different base grids
          _dataTable.BeginLoadData();
-         
-         for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
-         // foreach (var baseValue in baseGrid.Values)
+         foreach (var baseValue in baseGrid.Values)
          {
-            var baseValue = baseGrid.Values[baseIndex];
             try
             {
-               double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValueAt(baseIndex));
-               double y = yDimension.BaseUnitValueToUnitValue(yUnit, yData.GetValueAt(baseIndex));
+               double x = xDimension.BaseUnitValueToUnitValue(xUnit, xData.GetValue(baseValue));
+               double y = yDimension.BaseUnitValueToUnitValue(yUnit, yData.GetValue(baseValue));
 
                if (!isValidXValue(x) || !IsValidYValue(y))
                   continue;
@@ -335,12 +332,12 @@ namespace OSPSuite.UI.Binders
                var row = _dataTable.NewRow();
                row[X] = x;
                row[Y] = y;
-               row[INDEX_OF_VALUE_IN_CURVE] = baseIndex;
+               row[INDEX_OF_VALUE_IN_CURVE] = baseGrid.IndexOf(baseValue);
 
                if (HasLLOQ)
                   row[LLOQ_SUFFIX] = LLOQ;
 
-               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseIndex);
+               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseValue);
 
                _dataTable.Rows.Add(row);
             }
@@ -359,7 +356,7 @@ namespace OSPSuite.UI.Binders
          _dataTable.EndLoadData();
       }
 
-      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex);
+      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue);
 
       private BaseGrid activeBaseGrid(DataColumn xData, DataColumn yData)
       {

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -357,7 +357,7 @@ namespace OSPSuite.UI.Binders
 
       /// <summary>
       /// If the <paramref name="dataColumn"/> BaseGrid is the same as <paramref name="baseGrid"/> then return the value
-      /// of <paramref name="dataColumn"/> at <paramref name="baseGrid"/>. Otherwise interpolate from the <paramref name="baseGrid"/> at <paramref name="baseGridIndex"/>
+      /// of <paramref name="dataColumn"/> at <paramref name="baseGridIndex"/>. Otherwise interpolate from the <paramref name="baseGrid"/> at <paramref name="baseGridIndex"/>
       /// </summary>
       protected static float ValueInBaseUnit(DataColumn dataColumn, BaseGrid baseGrid, int baseGridIndex)
       {

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -321,7 +321,6 @@ namespace OSPSuite.UI.Binders
          _dataTable.BeginLoadData();
          
          for(int baseIndex =0; baseIndex < baseGrid.Values.Count; baseIndex++)
-         // foreach (var baseValue in baseGrid.Values)
          {
             var baseValue = baseGrid.Values[baseIndex];
             try

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -323,8 +323,8 @@ namespace OSPSuite.UI.Binders
          {
             try
             {
-               double x = xDimension.BaseUnitValueToUnitValue(xUnit, ValueInBaseUnit(xData, baseValue, baseIndex));
-               double y = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(yData, baseValue, baseIndex));
+               double x = xDimension.BaseUnitValueToUnitValue(xUnit, ValueInBaseUnit(xData, baseGrid, baseIndex));
+               double y = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(yData, baseGrid, baseIndex));
 
                if (!isValidXValue(x) || !IsValidYValue(y))
                   return;
@@ -337,7 +337,7 @@ namespace OSPSuite.UI.Binders
                if (HasLLOQ)
                   row[LLOQ_SUFFIX] = LLOQ;
 
-               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseValue, baseIndex);
+               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseGrid, baseIndex);
 
                _dataTable.Rows.Add(row);
             }
@@ -356,19 +356,18 @@ namespace OSPSuite.UI.Binders
       }
 
       /// <summary>
-      /// Compares the <paramref name="dataColumn"/> base grid value at the <paramref name="baseIndex"/>. If it
-      /// is the same as <paramref name="baseValue"/> then we can use indexing to retrieve the value, otherwise use interpolation
+      /// If the <paramref name="dataColumn"/> BaseGrid is the same as <paramref name="baseGrid"/> then return the value
+      /// of <paramref name="dataColumn"/> at <paramref name="baseGrid"/>. Otherwise interpolate from the <paramref name="baseGrid"/> at <paramref name="baseGridIndex"/>
       /// </summary>
-      /// <returns>The value of the data column in base units for the given <paramref name="baseValue"/></returns>
-      protected static float ValueInBaseUnit(DataColumn dataColumn, float baseValue, int baseIndex)
+      protected static float ValueInBaseUnit(DataColumn dataColumn, BaseGrid baseGrid, int baseGridIndex)
       {
-         if ((dataColumn.BaseGrid.Count > baseIndex) && (Math.Abs(dataColumn.BaseGrid[baseIndex] - baseValue) < float.Epsilon))
-            return dataColumn.Values[baseIndex];
+         if (baseGrid == dataColumn.BaseGrid)
+            return dataColumn.Values[baseGridIndex];
          
-         return dataColumn.GetValue(baseValue);
+         return dataColumn.GetValue(baseGrid[baseGridIndex]);
       }
 
-      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex);
+      protected abstract bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex);
 
       private BaseGrid activeBaseGrid(DataColumn xData, DataColumn yData)
       {

--- a/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
@@ -15,9 +15,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
       {
-         var stdDev = Curve.yData.GetValue(baseValue);
+         var stdDev = Curve.yData.GetValueAt(baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
@@ -15,9 +15,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
       {
-         var stdDev = Curve.yData.GetValue(baseValue);
+         var stdDev = ValueInBaseUnit(Curve.yData, baseValue, baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
@@ -15,9 +15,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex)
       {
-         var stdDev = ValueInBaseUnit(Curve.yData, baseValue, baseIndex);
+         var stdDev = ValueInBaseUnit(Curve.yData, baseGrid, baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricMeanAreaCurveBinder.cs
@@ -15,9 +15,9 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
       {
-         var stdDev = Curve.yData.GetValueAt(baseIndex);
+         var stdDev = Curve.yData.GetValue(baseValue);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.GeometricStdDev);
-         var stdDev = relatedColumn.GetValue(baseValue);
+         var stdDev = ValueInBaseUnit(relatedColumn, baseValue, baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.GeometricStdDev);
-         var stdDev = relatedColumn.GetValue(baseValue);
+         var stdDev = relatedColumn.GetValueAt(baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.GeometricStdDev);
-         var stdDev = relatedColumn.GetValueAt(baseIndex);
+         var stdDev = relatedColumn.GetValue(baseValue);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/GeometricStdCurveBinder.cs
@@ -14,10 +14,10 @@ namespace OSPSuite.UI.Binders
       {
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex)
       {
          var relatedColumn = yData.GetRelatedColumn(AuxiliaryType.GeometricStdDev);
-         var stdDev = ValueInBaseUnit(relatedColumn, baseValue, baseIndex);
+         var stdDev = ValueInBaseUnit(relatedColumn, baseGrid, baseIndex);
          if (!IsValidValue(stdDev) || stdDev == 0)
             stdDev = 1;
 

--- a/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
@@ -22,7 +22,7 @@ namespace OSPSuite.UI.Binders
          UpdateLineSeries(_lineSeries);
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
       {
          //no related values here
          return true;

--- a/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
@@ -22,7 +22,7 @@ namespace OSPSuite.UI.Binders
          UpdateLineSeries(_lineSeries);
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
       {
          //no related values here
          return true;

--- a/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
@@ -3,6 +3,7 @@ using System.Data;
 using DevExpress.XtraCharts;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Chart.Mappers;
+using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.UnitSystem;
 using DataColumn = OSPSuite.Core.Domain.Data.DataColumn;
 
@@ -22,7 +23,7 @@ namespace OSPSuite.UI.Binders
          UpdateLineSeries(_lineSeries);
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue, int baseIndex)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, BaseGrid baseGrid, int baseIndex)
       {
          //no related values here
          return true;

--- a/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/SingleValueCurveBinder.cs
@@ -22,7 +22,7 @@ namespace OSPSuite.UI.Binders
          UpdateLineSeries(_lineSeries);
       }
 
-      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, float baseValue)
+      protected override bool AddRelatedValuesToRow(DataRow row, DataColumn yData, IDimension yDimension, Unit yUnit, double y, int baseIndex)
       {
          //no related values here
          return true;


### PR DESCRIPTION
We are frequently looking up the index of basegrid values so that we can use the index to get y value.
In the refresh, we can avoid searching the list over and over by using the index in the first place.

I had a project that was a bit sluggish. Profiling showed that we spent a lot of time finding the index of values in the basegrid

![image](https://user-images.githubusercontent.com/261477/234645830-00bbb982-2275-4ef5-b7ab-740ccbf7d702.png)
