### PR TITLE
Fixes #2015 Small expression display caption changes

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -34,9 +34,9 @@ namespace OSPSuite.Assets
    {
       public static readonly string Transporter = "Transporter";
       public static readonly string Protein = "Protein";
-      public static readonly string Enzyme = "Enzyme";
+      public static readonly string MetabolizingEnzyme = "Metabolizing Enzyme";
       public static readonly string Species = "Species";
-      public static readonly string Category = "Category";
+      public static readonly string Phenotype = "Phenotype";
       public static readonly string ConfirmationDialog = "Confirmation";
       public static readonly string Excel = "Excel®";
       public static readonly string EmptyColumn = " ";

--- a/src/OSPSuite.Core/Domain/Builder/ExpressionTypes.cs
+++ b/src/OSPSuite.Core/Domain/Builder/ExpressionTypes.cs
@@ -13,7 +13,7 @@ namespace OSPSuite.Core.Domain.Builder
    public static class ExpressionTypes
    {
       public static ExpressionType TransportProtein = new ExpressionType(ExpressionTypesId.Transport, IconNames.Transporter, Captions.Transporter);
-      public static ExpressionType MetabolizingEnzyme = new ExpressionType(ExpressionTypesId.Enzyme, IconNames.Enzyme, Captions.Enzyme);
+      public static ExpressionType MetabolizingEnzyme = new ExpressionType(ExpressionTypesId.Enzyme, IconNames.Enzyme, Captions.MetabolizingEnzyme);
       public static ExpressionType ProteinBindingPartner = new ExpressionType(ExpressionTypesId.BindingPartner, IconNames.Protein, Captions.Protein);
 
       private static readonly ICache<ExpressionTypesId, ExpressionType> _typesCache = new Cache<ExpressionTypesId, ExpressionType>(x => x.Id)


### PR DESCRIPTION
![image](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/assets/261477/94dde556-3e68-428d-afd3-18576abad42e)

Formerly

- 'Metabolizing Enzyme' was just 'Enzyme'
- 'Phenotype' was 'Category'

I checked a little in PK-Sim code and there appears to be similarly named domain properties 'Category' displayed as 'Phenotype'. I don't think it's necessary to rename the domain properties for that reason.