### PR TITLE
trigger an appveyor build with setup failure

### DIFF
--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -21,12 +21,6 @@ namespace OSPSuite.Core
       protected string _modelName = "MyModel";
       protected SimulationBuilder _simulationBuilder;
 
-      protected override void Context()
-      {
-         base.Context();
-         throw new Exception();
-      }
-
       public override void GlobalContext()
       {
          base.GlobalContext();
@@ -44,6 +38,12 @@ namespace OSPSuite.Core
 
    internal class When_running_the_case_study_for_module_integration : concern_for_ModuleIntegration
    {
+      protected override void Because()
+      {
+         base.Because();
+         throw new Exception();
+      }
+
       [Observation]
       public void should_return_a_successful_validation()
       {

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -23,6 +24,7 @@ namespace OSPSuite.Core
       public override void GlobalContext()
       {
          base.GlobalContext();
+         throw new Exception();
          _simulationConfiguration = IoC.Resolve<ModuleHelperForSpecs>().CreateSimulationConfiguration();
          _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
       }

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -21,10 +21,15 @@ namespace OSPSuite.Core
       protected string _modelName = "MyModel";
       protected SimulationBuilder _simulationBuilder;
 
+      protected override void Context()
+      {
+         base.Context();
+         throw new Exception();
+      }
+
       public override void GlobalContext()
       {
          base.GlobalContext();
-         throw new Exception();
          _simulationConfiguration = IoC.Resolve<ModuleHelperForSpecs>().CreateSimulationConfiguration();
          _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
       }


### PR DESCRIPTION
We've seen appveyor not pick up tests that fail during setup, and thus report build success