### PR TITLE
#2043 misleading axes caption fix

### DIFF
--- a/src/OSPSuite.Core/Chart/CurveChart.cs
+++ b/src/OSPSuite.Core/Chart/CurveChart.cs
@@ -75,6 +75,8 @@ namespace OSPSuite.Core.Chart
 
       public Axis XAxis => AxisBy(AxisTypes.X);
 
+      public Axis YAxis => AxisBy(AxisTypes.Y);
+
       public Axis YAxisFor(Curve curve) => AxisBy(curve.yAxisType);
 
       public IReadOnlyCollection<Curve> Curves => _curves;

--- a/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
+++ b/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
@@ -95,12 +95,13 @@ namespace OSPSuite.Core.Services
 
       public void ConfigureAxesDimensionAndTitle(IReadOnlyList<DataColumn> observationColumns, PredictedVsObservedChart chart)
       {
-         var xAxis = chart.AxisBy(AxisTypes.X);
-         var yAxis = chart.AxisBy(AxisTypes.Y);
+         var xAxis = chart.XAxis;
+         var yAxis = chart.YAxis;
 
          var defaultDimension = mostFrequentDimension(observationColumns);
 
          setAxisDimension(defaultDimension, chart, xAxis);
+         //we should also check this for consistency
          xAxis.Caption = $"{ObservedChartAxis} {defaultDimension}";
          yAxis.Caption = $"{SimulatedChartAxis}  {defaultDimension}";
          chart.UpdateAxesVisibility();
@@ -226,8 +227,8 @@ namespace OSPSuite.Core.Services
          if (dimension != null)
             axis.Dimension = dimension;
 
-         axis.Scaling = chart.AxisBy(AxisTypes.Y).Scaling;
-         axis.UnitName = chart.AxisBy(AxisTypes.Y).UnitName;
+         axis.Scaling = chart.YAxis.Scaling;
+         axis.UnitName = chart.YAxis.UnitName;
       }
 
       private IDimension mostFrequentDimension(IReadOnlyList<DataColumn> columns)
@@ -291,7 +292,7 @@ namespace OSPSuite.Core.Services
 
       private void adjustAxes(DataColumn calculationColumn, PredictedVsObservedChart chart)
       {
-         chart.AxisBy(AxisTypes.Y).UnitName = _displayUnitRetriever.PreferredUnitFor(calculationColumn).Name;
+         chart.YAxis.UnitName = _displayUnitRetriever.PreferredUnitFor(calculationColumn).Name;
       }
 
       private static float getIdentityMinimum(IEnumerable<DataColumn> allObservationColumns, IDimension mergedDimension)

--- a/src/OSPSuite.Core/Services/ResidualsVsTimeChartService.cs
+++ b/src/OSPSuite.Core/Services/ResidualsVsTimeChartService.cs
@@ -110,8 +110,8 @@ namespace OSPSuite.Core.Services
 
       public void ConfigureChartAxis(AnalysisChartWithLocalRepositories chart)
       {
-         chart.AxisBy(AxisTypes.Y).Caption = Residuals;
-         chart.AxisBy(AxisTypes.Y).Scaling = Scalings.Linear;
+         chart.YAxis.Caption = Residuals;
+         chart.YAxis.Scaling = Scalings.Linear;
       }
 
       public DataRepository GetOrCreateScatterDataRepositoryInChart(AnalysisChartWithLocalRepositories chart, OutputResiduals outputResidual, int? runIndex = null)

--- a/src/OSPSuite.Presentation/DTO/Charts/CurveDTO.cs
+++ b/src/OSPSuite.Presentation/DTO/Charts/CurveDTO.cs
@@ -94,7 +94,7 @@ namespace OSPSuite.Presentation.DTO.Charts
 
       private bool dataDimensionMatchesXAxis(DataColumn dataColumn)
       {
-         return dimensionsHaveSharedUnits(_chart.AxisBy(AxisTypes.X), dataColumn.Dimension);
+         return dimensionsHaveSharedUnits(_chart.XAxis, dataColumn.Dimension);
       }
 
       private bool dataDimensionMatchesYAxis(DataColumn dataColumn)

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
@@ -326,8 +326,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
             }
          });
 
-         Chart.AxisBy(AxisTypes.X).SetRange(xMin, xMax);
-         Chart.AxisBy(AxisTypes.Y).SetRange(yMin, yMax);
+         Chart.XAxis.SetRange(xMin, xMax);
+         Chart.YAxis.SetRange(yMin, yMax);
 
          RefreshAxisBinders();
       }

--- a/src/OSPSuite.Presentation/Presenters/Charts/SimpleChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/SimpleChartPresenter.cs
@@ -211,7 +211,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       private void setAxesCaptions(DataRepository observedData)
       {
          Chart.XAxis.Caption = observedData.BaseGrid.Name;
-         Chart.YAxis.Caption = observedData.AllButBaseGridAsArray.FirstOrDefault()?.Name;
+         Chart.YAxis.Caption = observedData.ObservationColumns().FirstOrDefault()?.Name;
       }
 
       private void addCurvesToChart(DataRepository observedData)

--- a/src/OSPSuite.Presentation/Presenters/Charts/SimpleChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/SimpleChartPresenter.cs
@@ -200,12 +200,18 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       private Axis getXAxis(CurveChart chart)
       {
-         return chart.AxisBy(AxisTypes.X);
+         return chart.XAxis;
       }
 
       private Axis getYAxis(CurveChart chart)
       {
-         return chart.AxisBy(AxisTypes.Y);
+         return chart.YAxis;
+      }
+
+      private void setAxesCaptions(DataRepository observedData)
+      {
+         Chart.XAxis.Caption = observedData.BaseGrid.Name;
+         Chart.YAxis.Caption = observedData.AllButBaseGridAsArray.FirstOrDefault()?.Name;
       }
 
       private void addCurvesToChart(DataRepository observedData)
@@ -216,9 +222,10 @@ namespace OSPSuite.Presentation.Presenters.Charts
             var curve = Chart.CreateCurve(c.BaseGrid, c, observedData.Name, _dimensionFactory);
 
             Chart.UpdateCurveColorAndStyle(curve, c, allObservations);
-
             Chart.AddCurve(curve);
          });
+
+         setAxesCaptions(observedData);
       }
    }
 }

--- a/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryChartPresenter.cs
@@ -56,8 +56,8 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
       private void plotObservedData(DataRepository dataRepository)
       {
          _simpleChartPresenter.PlotObservedData(dataRepository);
-         _simpleChartPresenter.Chart.AxisBy(AxisTypes.X).GridLines = true;
-         _simpleChartPresenter.Chart.AxisBy(AxisTypes.Y).GridLines = true;
+         _simpleChartPresenter.Chart.XAxis.GridLines = true;
+         _simpleChartPresenter.Chart.YAxis.GridLines = true;
       }
 
       private bool shouldHandleEvent(ObservedDataEvent eventToHandle)

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationErrorHistoryFeedbackPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationErrorHistoryFeedbackPresenter.cs
@@ -53,9 +53,9 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
             curve.VisibleInLegend = false;
          });
 
-         Chart.AxisBy(AxisTypes.X).Caption = Captions.ParameterIdentification.NumberOfEvaluations;
-         Chart.AxisBy(AxisTypes.Y).Caption = Captions.ParameterIdentification.TotalError;
-         Chart.AxisBy(AxisTypes.Y).Scaling = Scalings.Linear;
+         Chart.XAxis.Caption = Captions.ParameterIdentification.NumberOfEvaluations;
+         Chart.YAxis.Caption = Captions.ParameterIdentification.TotalError;
+         Chart.YAxis.Scaling = Scalings.Linear;
       }
 
       protected void AddCurvesFor(DataRepository dataRepository, Action<DataColumn, Curve> action = null)

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationTimeProfileChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationTimeProfileChartPresenter.cs
@@ -80,7 +80,7 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
 
       private void adjustAxes(DataColumn calculatedColumn)
       {
-         Chart.AxisBy(AxisTypes.Y).UnitName = _displayUnitRetriever.PreferredUnitFor(calculatedColumn).Name;
+         Chart.YAxis.UnitName = _displayUnitRetriever.PreferredUnitFor(calculatedColumn).Name;
       }
    }
 }

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -42,7 +42,7 @@ namespace OSPSuite.UI.Binders
          _axisView = yAxisView;
          _dataMode = dataMode;
          Curve = curve;
-         _xAxis = chart.AxisBy(AxisTypes.X);
+         _xAxis = chart.XAxis;
          _yAxis = chart.AxisBy(curve.yAxisType);
          _yAxisType = curve.yAxisType;
          _dataTable = new DataTable(Curve.Id);

--- a/tests/OSPSuite.Core.Tests/Domain/CurveChartSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/CurveChartSpecs.cs
@@ -25,8 +25,8 @@ namespace OSPSuite.Core.Domain
          _dimensionFactory = A.Fake<IDimensionFactory>();
          sut = new CurveChart().WithAxes();
 
-         _xAxis = sut.AxisBy(AxisTypes.X);
-         _yAxis = sut.AxisBy(AxisTypes.Y);
+         _xAxis = sut.XAxis;
+         _yAxis = sut.YAxis;
 
          _obsData1 = DomainHelperForSpecs.ObservedData();
          _obsData2 = DomainHelperForSpecs.ObservedData();
@@ -196,7 +196,7 @@ namespace OSPSuite.Core.Domain
          base.Context();
          _dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
          _y2Axis = sut.AddNewAxisFor(AxisTypes.Y2);
-         _yAxis = sut.AxisBy(AxisTypes.Y);
+         _yAxis = sut.YAxis;
          _yAxis.Dimension = _dimension;
          _yAxis.UnitName = _dimension.DefaultUnitName;
          _yAxis.SetRange(10, 20);

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationPredictedVsObservedChartSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationPredictedVsObservedChartSpecs.cs
@@ -21,10 +21,10 @@ namespace OSPSuite.Core.Domain
       protected override void Context()
       {
          base.Context();
-         sut.AxisBy(AxisTypes.Y).Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
+         sut.YAxis.Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
          sut.AxisBy(AxisTypes.Y2).Dimension = DomainHelperForSpecs.FractionDimensionForSpecs();
          sut.AxisBy(AxisTypes.Y3).Dimension = DomainHelperForSpecs.LengthDimensionForSpecs();
-         sut.AxisBy(AxisTypes.X).Dimension = sut.AxisBy(AxisTypes.Y3).Dimension;
+         sut.XAxis.Dimension = sut.AxisBy(AxisTypes.Y3).Dimension;
       }
 
       protected override void Because()
@@ -35,7 +35,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void the_x_axis_should_be_visible()
       {
-         sut.AxisBy(AxisTypes.X).Visible.ShouldBeTrue();
+         sut.XAxis.Visible.ShouldBeTrue();
       }
 
       [Observation]
@@ -48,7 +48,7 @@ namespace OSPSuite.Core.Domain
       public void axes_with_other_dimensions_are_not_visible()
       {
          sut.AxisBy(AxisTypes.Y2).Visible.ShouldBeFalse();
-         sut.AxisBy(AxisTypes.Y).Visible.ShouldBeFalse();
+         sut.YAxis.Visible.ShouldBeFalse();
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Services/DisplayUnitUpdaterSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/DisplayUnitUpdaterSpecs.cs
@@ -163,9 +163,9 @@ namespace OSPSuite.Core.Services
          _curveChart = new CurveChart().WithAxes();
          _unit1 = new Unit("XX", 1, 0);
 
-         _axisX = _curveChart.AxisBy(AxisTypes.X);
+         _axisX = _curveChart.XAxis;
          _axisX.UnitName = "OldX";
-         _axisY = _curveChart.AxisBy(AxisTypes.Y);
+         _axisY = _curveChart.YAxis;
          _axisY.UnitName = "OldY";
 
          A.CallTo(() => _displayUnitRetriever.PreferredUnitFor(_axisX, _axisX.Unit)).Returns(_unit1);

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
@@ -74,11 +74,11 @@ namespace OSPSuite.Presentation.Presentation
          _curveChart.AddAxis(new Axis(AxisTypes.X) {Dimension = _curve.xDimension});
          _curveChart.AddAxis(new Axis(AxisTypes.Y) {Dimension = _curve.yDimension});
 
-         _xAxisBinder = createAxisBinderFor(_curveChart.AxisBy(AxisTypes.X));
-         _yAxisBinder = createAxisBinderFor(_curveChart.AxisBy(AxisTypes.Y));
+         _xAxisBinder = createAxisBinderFor(_curveChart.XAxis);
+         _yAxisBinder = createAxisBinderFor(_curveChart.YAxis);
 
-         A.CallTo(() => _axisBinderFactory.Create(_curveChart.AxisBy(AxisTypes.X), _chartDisplayView.ChartControl, _curveChart)).Returns(_xAxisBinder);
-         A.CallTo(() => _axisBinderFactory.Create(_curveChart.AxisBy(AxisTypes.Y), _chartDisplayView.ChartControl, _curveChart)).Returns(_yAxisBinder);
+         A.CallTo(() => _axisBinderFactory.Create(_curveChart.XAxis, _chartDisplayView.ChartControl, _curveChart)).Returns(_xAxisBinder);
+         A.CallTo(() => _axisBinderFactory.Create(_curveChart.YAxis, _chartDisplayView.ChartControl, _curveChart)).Returns(_yAxisBinder);
 
          SetupChart();
          sut.Edit(_curveChart);
@@ -148,8 +148,8 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void axis_returned_should_be_correct()
       {
-         _resultX.ShouldBeEqualTo(_curveChart.AxisBy(AxisTypes.X));
-         _resultY.ShouldBeEqualTo(_curveChart.AxisBy(AxisTypes.Y));
+         _resultX.ShouldBeEqualTo(_curveChart.XAxis);
+         _resultY.ShouldBeEqualTo(_curveChart.YAxis);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartFactorySpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartFactorySpecs.cs
@@ -53,7 +53,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          _userSettings.DefaultChartYScaling = scale;
          _result = sut.CreateChartFor(_repository, Scalings.Log);
-         _result.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(Scalings.Log);
+         _result.YAxis.Scaling.ShouldBeEqualTo(Scalings.Log);
       }
    }
 
@@ -65,7 +65,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          _userSettings.DefaultChartYScaling = scale;
          _result = sut.CreateChartFor(_repository);
-         _result.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(_userSettings.DefaultChartYScaling);
+         _result.YAxis.Scaling.ShouldBeEqualTo(_userSettings.DefaultChartYScaling);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/CurveDTOSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/CurveDTOSpecs.cs
@@ -65,8 +65,8 @@ namespace OSPSuite.Presentation.Presentation
       protected override void InitializeChart()
       {
          base.InitializeChart();
-         _chart.AxisBy(AxisTypes.X).Dimension = _xDataColumn.Dimension;
-         _chart.AxisBy(AxisTypes.Y).Dimension = _yDataColumn.Dimension;
+         _chart.XAxis.Dimension = _xDataColumn.Dimension;
+         _chart.YAxis.Dimension = _yDataColumn.Dimension;
       }
 
       protected override void Context()
@@ -87,8 +87,8 @@ namespace OSPSuite.Presentation.Presentation
       protected override void InitializeChart()
       {
          base.InitializeChart();
-         _chart.AxisBy(AxisTypes.X).Dimension = _xDataColumn.Dimension;
-         _chart.AxisBy(AxisTypes.Y).Dimension = DomainHelperForSpecs.FractionDimensionForSpecs();
+         _chart.XAxis.Dimension = _xDataColumn.Dimension;
+         _chart.YAxis.Dimension = DomainHelperForSpecs.FractionDimensionForSpecs();
       }
 
       protected override void Context()
@@ -115,8 +115,8 @@ namespace OSPSuite.Presentation.Presentation
       protected override void InitializeChart()
       {
          base.InitializeChart();
-         _chart.AxisBy(AxisTypes.X).Dimension = DomainHelperForSpecs.FractionDimensionForSpecs();
-         _chart.AxisBy(AxisTypes.Y).Dimension = _yDataColumn.Dimension;
+         _chart.XAxis.Dimension = DomainHelperForSpecs.FractionDimensionForSpecs();
+         _chart.YAxis.Dimension = _yDataColumn.Dimension;
       }
 
       protected override void Context()

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationErrorHistoryFeedbackPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationErrorHistoryFeedbackPresenterSpecs.cs
@@ -79,14 +79,14 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_have_set_the_chart_axis_captions_as_expected()
       {
-         sut.Chart.AxisBy(AxisTypes.X).Caption.ShouldBeEqualTo(Captions.ParameterIdentification.NumberOfEvaluations);
-         sut.Chart.AxisBy(AxisTypes.Y).Caption.ShouldBeEqualTo(Captions.ParameterIdentification.TotalError);
+         sut.Chart.XAxis.Caption.ShouldBeEqualTo(Captions.ParameterIdentification.NumberOfEvaluations);
+         sut.Chart.YAxis.Caption.ShouldBeEqualTo(Captions.ParameterIdentification.TotalError);
       }
 
       [Observation]
       public void should_have_set_the_y_axis_as_linear_scale()
       {
-         sut.Chart.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(Scalings.Linear);
+         sut.Chart.YAxis.Scaling.ShouldBeEqualTo(Scalings.Linear);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileFeedbackPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileFeedbackPresenterSpecs.cs
@@ -176,7 +176,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          var bestCurve = sut.Chart.Curves.Find(x => x.xData.Repository.IsNamed(Captions.ParameterIdentification.Best));
          var currentCurve = sut.Chart.Curves.Find(x => x.xData.Repository.IsNamed(Captions.ParameterIdentification.Current));
-         sut.Chart.AxisBy(AxisTypes.Y).Dimension.ShouldBeEqualTo(_outputMapping3.Dimension);
+         sut.Chart.YAxis.Dimension.ShouldBeEqualTo(_outputMapping3.Dimension);
          bestCurve.yDimension.ShouldBeEqualTo(_outputMapping3.Dimension);
          currentCurve.yDimension.ShouldBeEqualTo(_outputMapping3.Dimension);
       }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
@@ -58,8 +58,8 @@ namespace OSPSuite.Presentation.Presentation
       {
          base.Context();
          _concentrationObservationColumn.Values = Enumerable.Repeat(0f, _concentrationObservationColumn.Values.Count).ToArray();
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
-         _predictedVsObservedChart.AxisBy(AxisTypes.Y).Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
+         _predictedVsObservedChart.XAxis.Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
+         _predictedVsObservedChart.YAxis.Dimension = DomainHelperForSpecs.ConcentrationDimensionForSpecs();
       }
 
       [Observation]
@@ -89,7 +89,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_dimension_selected_to_plot_identity_curve_should_be_fraction()
       {
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension.ShouldBeEqualTo(DomainHelperForSpecs.NoDimension());
+         _predictedVsObservedChart.XAxis.Dimension.ShouldBeEqualTo(DomainHelperForSpecs.NoDimension());
       }
    }
 
@@ -164,7 +164,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_chart_x_axis_should_be_set_to_the_correct_dimension()
       {
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension.DisplayName.ShouldBeEqualTo(_fractionDimensionForSpecs.DisplayName);
+         _predictedVsObservedChart.XAxis.Dimension.DisplayName.ShouldBeEqualTo(_fractionDimensionForSpecs.DisplayName);
       }
 
       [Observation]
@@ -252,9 +252,9 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_x_axis_of_the_chart_should_be_updated()
       {
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).Dimension);
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Scaling.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).Scaling);
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).UnitName.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).UnitName);
+         _predictedVsObservedChart.XAxis.Dimension.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).Dimension);
+         _predictedVsObservedChart.XAxis.Scaling.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).Scaling);
+         _predictedVsObservedChart.XAxis.UnitName.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y2).UnitName);
       }
    }
 
@@ -275,9 +275,9 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_x_axis_of_the_chart_should_be_updated()
       {
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y).Dimension);
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Scaling.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y).Scaling);
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).UnitName.ShouldBeEqualTo(_predictedVsObservedChart.AxisBy(AxisTypes.Y).UnitName);
+         _predictedVsObservedChart.XAxis.Dimension.ShouldBeEqualTo(_predictedVsObservedChart.YAxis.Dimension);
+         _predictedVsObservedChart.XAxis.Scaling.ShouldBeEqualTo(_predictedVsObservedChart.YAxis.Scaling);
+         _predictedVsObservedChart.XAxis.UnitName.ShouldBeEqualTo(_predictedVsObservedChart.YAxis.UnitName);
       }
    }
 
@@ -314,7 +314,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_curve_x_axis_should_have_the_merged_dimension()
       {
-         _predictedVsObservedChart.AxisBy(AxisTypes.X).Dimension.ShouldBeEqualTo(_concentrationObservationColumn.Dimension);
+         _predictedVsObservedChart.XAxis.Dimension.ShouldBeEqualTo(_concentrationObservationColumn.Dimension);
       }
 
       [Observation]

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimpleChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimpleChartPresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using System.Linq;
+using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
@@ -70,7 +71,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void chart_scale_should_be_using_the_default_chart_y_scaling()
       {
-         sut.Chart.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(_presentationUserSettings.DefaultChartYScaling);
+         sut.Chart.YAxis.Scaling.ShouldBeEqualTo(_presentationUserSettings.DefaultChartYScaling);
       }
    }
 
@@ -118,13 +119,36 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void chart_axis_set_to_log()
       {
-         sut.Chart.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(Scalings.Log);
+         sut.Chart.YAxis.Scaling.ShouldBeEqualTo(Scalings.Log);
       }
 
       [Observation]
       public void should_refresh_the_chart_display()
       {
          A.CallTo(() => _chartDisplayPresenter.Refresh()).MustHaveHappened();
+      }
+   }
+
+   public class When_plotting_observed_data : concern_for_SimpleChartPresenter
+   {
+      private DataRepository _dataRepository;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dataRepository = DomainHelperForSpecs.ObservedData();
+      }
+
+      protected override void Because()
+      {
+         sut.PlotObservedData(_dataRepository);
+      }
+
+      [Observation]
+      public void the_chart_should_have_axis_scaling_set_to_log()
+      {
+         sut.Chart.XAxis.Caption.ShouldBeEqualTo(_dataRepository.BaseGrid.Name);
+         sut.Chart.YAxis.Caption.ShouldBeEqualTo(_dataRepository.AllButBaseGridAsArray.First().Name);
       }
    }
 
@@ -146,7 +170,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_chart_should_have_axis_scaling_set_to_log()
       {
-         sut.Chart.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(Scalings.Log);
+         sut.Chart.YAxis.Scaling.ShouldBeEqualTo(Scalings.Log);
       }
    }
 
@@ -169,7 +193,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void the_chart_should_have_axis_scaling_set_to_linear()
       {
-         sut.Chart.AxisBy(AxisTypes.Y).Scaling.ShouldBeEqualTo(Scalings.Linear);
+         sut.Chart.YAxis.Scaling.ShouldBeEqualTo(Scalings.Linear);
       }
    }
 


### PR DESCRIPTION
closes #2043 

note: also contains a small refactoring for the codebase to use XAxis instead of AxisBy(AxisTypes.X) since it is available and the extension of the same logic for the yAxis