### PR TITLE
Fixes #2140 add functions for concatenation of 2 object paths

### DIFF
--- a/src/OSPSuite.Core/Domain/ObjectPath.cs
+++ b/src/OSPSuite.Core/Domain/ObjectPath.cs
@@ -66,10 +66,13 @@ namespace OSPSuite.Core.Domain
       ///    Add one entry at the end of the path
       /// </summary>
       /// <param name="pathEntry">path entry to add</param>
-      public virtual void Add(string pathEntry)
-      {
-         _pathEntries.Add(pathEntry);
-      }
+      public virtual void Add(string pathEntry) => _pathEntries.Add(pathEntry);
+
+      /// <summary>
+      ///    Add entries at the end of the path
+      /// </summary>
+      /// <param name="pathEntriesToAdd">path entries to add</param>
+      public virtual void AddRange(IEnumerable<string> pathEntriesToAdd) => pathEntriesToAdd.Each(Add);
 
       /// <summary>
       ///    Replace the first matching path entry with the given replacement if the entry is used in the current path
@@ -190,6 +193,11 @@ namespace OSPSuite.Core.Domain
       {
          _pathEntries.Clear();
          _pathEntries.AddRange(pathEntries);
+      }
+
+      public virtual void ConcatWith(ObjectPath objectPath)
+      {
+         AddRange(objectPath._pathEntries);
       }
 
       public IEnumerator<string> GetEnumerator()

--- a/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
@@ -208,7 +208,7 @@ namespace OSPSuite.Core.Domain.Services
 
          //recreate the path for this neighborhood and add the rest of the path. Validation of this path will be done later
          var neighborhoodPath = _objectPathFactory.CreateAbsoluteObjectPath(neighborhoodsBetweenContainer1AndContainer2[0]);
-         restOfPath.Each(neighborhoodPath.Add);
+         neighborhoodPath.AddRange(restOfPath);
          formulaUsablePath.ReplaceWith(neighborhoodPath);
       }
 
@@ -290,7 +290,7 @@ namespace OSPSuite.Core.Domain.Services
 
          //we can now reconstruct the path to the next or previous lumen segment
          var targetSegmentPath = _objectPathFactory.CreateAbsoluteObjectPath(lumen).AndAdd(allLumenSegments[navigationIndex]);
-         restOfPath.Each(targetSegmentPath.Add);
+         targetSegmentPath.AddRange(restOfPath);
          formulaUsablePath.ReplaceWith(targetSegmentPath);
       }
 

--- a/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
@@ -130,4 +130,15 @@ namespace OSPSuite.Core.Domain
          sut.ShouldOnlyContain("A", "C");
       }
    }
+
+   public class When_concatenating_two_object_paths : concern_for_ObjectPath
+   {
+      [Observation]
+      public void should_modify_the_first_object_path_and_add_the_entries_of_the_second_object_path()
+      {
+         sut = new ObjectPath("A", "B", "C");
+         sut.ConcatWith(new ObjectPath("D", "E"));
+         sut.ShouldOnlyContainInOrder("A", "B", "C", "D", "E");
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2140

# Description

Adds a method to concatenate two paths. The first path is modified in place

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well-tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):