### PR TITLE
Fixes #2161:

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -583,16 +583,16 @@ namespace OSPSuite.Assets
          public static readonly string ObjectPath = "Path";
          public static readonly string ExcludeMolecule = "Exclude Molecule";
          public static readonly string IncludeMolecule = "Include Molecule";
+         public static readonly string Count = "Number of item";
          public static readonly string Assignment = "Assignment";
          public static readonly string OneObjectIsNull = "One object used in the comparison is null";
          public static readonly string Connection = "Connection";
          public static readonly string SourceAmount = "Source Amount";
          public static readonly string TargetAmount = "Target Amount";
 
-         public static string PropertyDiffers(string propertyName, string value1, string value2)
-         {
-            return $"{propertyName.Pluralize()} are not equal ({value1} ≠ {value2})";
-         }
+         public static string PropertyDiffers(string propertyName, int value1, int value2) => PropertyDiffers(propertyName, $"{value1}", $"{value2}");
+
+         public static string PropertyDiffers(string propertyName, string value1, string value2) => $"{propertyName.Pluralize()} are not equal ({value1} ≠ {value2})";
 
          public static string DifferentTypes(string type1, string type2)
          {

--- a/src/OSPSuite.Core/Comparison/TableFormulaDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/TableFormulaDiffBuilder.cs
@@ -1,8 +1,5 @@
-﻿using OSPSuite.Assets;
-using OSPSuite.Core.Domain.Formulas;
-using OSPSuite.Core.Domain.Services;
+﻿using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Services;
-using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Core.Comparison
 {
@@ -11,14 +8,12 @@ namespace OSPSuite.Core.Comparison
       private readonly IObjectComparer _objectComparer;
       private readonly ObjectBaseDiffBuilder _objectBaseDiffBuilder;
       private readonly EnumerableComparer _enumerableComparer;
-      private readonly IDisplayNameProvider _displayNameProvider;
 
-      public TableFormulaDiffBuilder(IObjectComparer objectComparer, ObjectBaseDiffBuilder objectBaseDiffBuilder, EnumerableComparer enumerableComparer, IDisplayNameProvider displayNameProvider)
+      public TableFormulaDiffBuilder(IObjectComparer objectComparer, ObjectBaseDiffBuilder objectBaseDiffBuilder, EnumerableComparer enumerableComparer)
       {
          _objectComparer = objectComparer;
          _objectBaseDiffBuilder = objectBaseDiffBuilder;
          _enumerableComparer = enumerableComparer;
-         _displayNameProvider = displayNameProvider;
       }
 
       public override void Compare(IComparison<TableFormula> comparison)
@@ -28,14 +23,8 @@ namespace OSPSuite.Core.Comparison
          CompareStringValues(x => x.XName, x => x.XName, comparison);
          CompareStringValues(x => x.YName, x => x.YName, comparison);
          CompareValues(x => x.UseDerivedValues, x => x.UseDerivedValues, comparison);
-         _enumerableComparer.CompareEnumerables(comparison, x => x.AllPoints(), (pt1, pt2) => ValueComparer.AreValuesEqual(pt1.X, pt2.X, comparison.Settings.RelativeTolerance), x => displayValueFor(x, comparison));
-      }
-
-      private string displayValueFor(ValuePoint valuePoint, IComparison<TableFormula> comparison)
-      {
-         var formulaOwnerName = _displayNameProvider.DisplayNameFor(comparison.CommonAncestor);
-         var tableFormula = comparison.Object1.DowncastTo<TableFormula>();
-         return Captions.Comparisons.ValuePointAt(tableFormula.Name, formulaOwnerName, tableFormula.XDisplayValueFor(valuePoint.X));
+         //We do not use enumerable comparison here as we need to compare the values by index
+         _enumerableComparer.CompareEnumerablesByIndex(comparison, x => x.AllPoints);
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Formulas/TableFormula.cs
+++ b/src/OSPSuite.Core/Domain/Formulas/TableFormula.cs
@@ -52,7 +52,7 @@ namespace OSPSuite.Core.Domain.Formulas
    public class TableFormula : Formula
    {
       private readonly IInterpolation _interpolation;
-      private readonly IList<ValuePoint> _allPoints;
+      private readonly List<ValuePoint> _allPoints;
       private Unit _xDisplayUnit;
       private Unit _yDisplayUnit;
 
@@ -88,9 +88,9 @@ namespace OSPSuite.Core.Domain.Formulas
          UseDerivedValues = true;
       }
 
-      public virtual IEnumerable<ValuePoint> AllPoints() => _allPoints;
+      public virtual IReadOnlyList<ValuePoint> AllPoints => _allPoints;
 
-      public virtual ValuePoint[] AllPointsAsArray() => AllPoints().ToArray();
+      public virtual ValuePoint[] AllPointsAsArray() => AllPoints.ToArray();
 
       /// <summary>
       ///    Returns the yValue defined for the xValue in base unit given as parameter. If the table contains no point, 0 is
@@ -283,7 +283,7 @@ namespace OSPSuite.Core.Domain.Formulas
          _yDisplayUnit = tableFormula._yDisplayUnit;
 
          ClearPoints();
-         tableFormula.AllPoints().Each(p => AddPoint(p.Clone()));
+         tableFormula.AllPoints.Each(p => AddPoint(p.Clone()));
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Mappers/TableFormulaToDataRepositoryMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/TableFormulaToDataRepositoryMapper.cs
@@ -26,8 +26,8 @@ namespace OSPSuite.Core.Domain.Mappers
          var baseGrid = new BaseGrid(_idGenerator.NewId(), tableFormula.XDimension.Name, tableFormula.XDimension) {DataInfo = {DisplayUnitName = tableFormula.XDisplayUnit.Name}};
          var value = new DataColumn(_idGenerator.NewId(), tableFormula.Name, tableFormula.Dimension, baseGrid) {DataInfo = {DisplayUnitName = tableFormula.YDisplayUnit.Name}};
 
-         baseGrid.Values = tableFormula.AllPoints().Select(x => x.X).ToFloatArray();
-         value.Values = tableFormula.AllPoints().Select(x => x.Y).ToFloatArray();
+         baseGrid.Values = tableFormula.AllPoints.Select(x => x.X).ToFloatArray();
+         value.Values = tableFormula.AllPoints.Select(x => x.Y).ToFloatArray();
 
          dataRepository.Add(value);
          return dataRepository;

--- a/src/OSPSuite.Core/Domain/Services/ModelReportCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ModelReportCreator.cs
@@ -290,7 +290,7 @@ namespace OSPSuite.Core.Domain.Services
 
       private void reportFor(TableFormula tableFormula, int noOfTabs)
       {
-         foreach (var valuePoint in tableFormula.AllPoints())
+         foreach (var valuePoint in tableFormula.AllPoints)
          {
             _report.AppendFormat("{0}{1}; {2}   RestartSolver = {3}", tabs(noOfTabs), valuePoint.X, valuePoint.Y, valuePoint.RestartSolver);
             _report.AppendLine();

--- a/src/OSPSuite.Core/Serialization/SimModel/Services/TableFormulaToTableFormulaExportMapper.cs
+++ b/src/OSPSuite.Core/Serialization/SimModel/Services/TableFormulaToTableFormulaExportMapper.cs
@@ -14,7 +14,7 @@ namespace OSPSuite.Core.Serialization.SimModel.Services
       public TableFormulaExport MapFrom(TableFormula input)
       {
          var export = new TableFormulaExport();
-         input.AllPoints().Each(export.AddPoint);
+         input.AllPoints.Each(export.AddPoint);
 
          export.UseDerivedValues = input.UseDerivedValues;
 

--- a/src/OSPSuite.Core/Serialization/Xml/FormulaXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/FormulaXmlSerializer.cs
@@ -60,7 +60,7 @@ namespace OSPSuite.Core.Serialization.Xml
          Map(x => x.XDimension).WithMappingName(Constants.Serialization.Attribute.X_DIMENSION);
          Map(x => x.XName);
          Map(x => x.YName);
-         MapEnumerable(x => x.AllPoints(), addPoint);
+         MapEnumerable(x => x.AllPoints, addPoint);
          Map(x => x.UseDerivedValues);
       }
 

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TableFormulaDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TableFormulaDiffBuilderSpecs.cs
@@ -36,4 +36,34 @@ namespace OSPSuite.Core.DiffBuilders
          _report.Count.ShouldBeEqualTo(5);
       }
    }
+
+   public class When_comparing_two_table_formula_with_different_number_of_points : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var parameter1 = new Parameter().WithName("P");
+         var formula1 = new TableFormula();
+         formula1.AddPoint(10, 1);
+         formula1.AddPoint(20, 2); 
+         formula1.AddPoint(30, 3); 
+         parameter1.Formula = formula1;
+
+         var parameter2 = new Parameter().WithName("P");
+         var formula2 = new TableFormula();
+         formula2.AddPoint(10, 1); 
+         formula2.AddPoint(20, 2); 
+         parameter2.Formula = formula2;
+
+         _object1 = parameter1;
+         _object2 = parameter2;
+      }
+
+      [Observation]
+      public void should_report_the_path_entries_and_different_entries_as_difference()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+      }
+   }
+
 }

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TableFormulaDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TableFormulaDiffBuilderSpecs.cs
@@ -60,7 +60,7 @@ namespace OSPSuite.Core.DiffBuilders
       }
 
       [Observation]
-      public void should_report_the_path_entries_and_different_entries_as_difference()
+      public void should_report_a_difference()
       {
          _report.Count.ShouldBeEqualTo(1);
       }

--- a/tests/OSPSuite.Core.IntegrationTests/Helpers/AssertForSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Helpers/AssertForSpecs.cs
@@ -621,7 +621,7 @@ namespace OSPSuite.Core.Helpers
          AreEqualUnit(x1.YDisplayUnit, x2.YDisplayUnit);
          Assert.AreEqual(x1.XName, x2.XName);
          Assert.AreEqual(x1.YName, x2.YName);
-         AreEqualEnumerableWithSameOrder(x1.AllPoints(), x2.AllPoints());
+         AreEqualEnumerableWithSameOrder(x1.AllPoints, x2.AllPoints);
       }
 
       public static void AreEqualExplicitFormula(ExplicitFormula x1, ExplicitFormula x2)

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/DistributedTableFormulaSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/DistributedTableFormulaSerializerSpecs.cs
@@ -17,13 +17,13 @@ namespace OSPSuite.Core.Serializers
 
          var x2 = SerializeAndDeserialize(x1);
 
-         x2.AllPoints().Count().ShouldBeEqualTo(2);
+         x2.AllPoints.Count().ShouldBeEqualTo(2);
 
-         x2.AllPoints().ElementAt(0).X.ShouldBeEqualTo(0);
-         x2.AllPoints().ElementAt(0).Y.ShouldBeEqualTo(1);
+         x2.AllPoints.ElementAt(0).X.ShouldBeEqualTo(0);
+         x2.AllPoints.ElementAt(0).Y.ShouldBeEqualTo(1);
 
-         x2.AllPoints().ElementAt(1).X.ShouldBeEqualTo(2);
-         x2.AllPoints().ElementAt(1).Y.ShouldBeEqualTo(3);
+         x2.AllPoints.ElementAt(1).X.ShouldBeEqualTo(2);
+         x2.AllPoints.ElementAt(1).Y.ShouldBeEqualTo(3);
 
          x2.AllDistributionMetaData().Count().ShouldBeEqualTo(2);
          var distributionMetaData = x2.AllDistributionMetaData().ElementAt(0);

--- a/tests/OSPSuite.Core.Tests/Domain/TableFormulaSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/TableFormulaSpecs.cs
@@ -96,7 +96,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_return_them_sorted_by_time()
       {
-         sut.AllPoints().ShouldOnlyContainInOrder(_p1, _p2, _p3);
+         sut.AllPoints.ShouldOnlyContainInOrder(_p1, _p2, _p3);
       }
    }
 
@@ -119,7 +119,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_not_add_the_same_point_twice()
       {
-         sut.AllPoints().ShouldOnlyContainInOrder(_p1, _p2);
+         sut.AllPoints.ShouldOnlyContainInOrder(_p1, _p2);
       }
    }
 
@@ -163,7 +163,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void the_table_formula_should_not_contain_any_points()
       {
-         sut.AllPoints().Count().ShouldBeEqualTo(0);
+         sut.AllPoints.Count().ShouldBeEqualTo(0);
       }
    }
 
@@ -213,7 +213,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_have_removed_that_point()
       {
-         sut.AllPoints().ShouldOnlyContain(_p2);
+         sut.AllPoints.ShouldOnlyContain(_p2);
       }
    }
 
@@ -240,7 +240,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_have_removed_that_point()
       {
-         sut.AllPoints().ShouldOnlyContain(_p2);
+         sut.AllPoints.ShouldOnlyContain(_p2);
       }
    }
 
@@ -267,7 +267,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void should_not_remove_the_existing_points()
       {
-         sut.AllPoints().ShouldOnlyContain(_p1, _p2);
+         sut.AllPoints.ShouldOnlyContain(_p1, _p2);
       }
    }
 


### PR DESCRIPTION
Fixes #2161

# Description
Comparision of tables should be done by trying to find matching points by axis. Instead, two tables are equal when all points in their order are the same. So we needed to introduce  a comparison by index

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):