### PR TITLE
Fixes #2163 Add ability to check if one ObjectPath starts with another

### DIFF
--- a/src/OSPSuite.Core/Domain/ObjectPath.cs
+++ b/src/OSPSuite.Core/Domain/ObjectPath.cs
@@ -296,5 +296,13 @@ namespace OSPSuite.Core.Domain
          //todo Optimize this
          return _pathEntries.Contains(entry);
       }
+
+      public bool StartsWith(ObjectPath otherPath)
+      {
+         if (Count < otherPath.Count)
+            return false;
+
+         return !otherPath.Where((x, i) => _pathEntries[i] != x).Any();
+      }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
@@ -141,4 +141,35 @@ namespace OSPSuite.Core.Domain
          sut.ShouldOnlyContainInOrder("A", "B", "C", "D", "E");
       }
    }
+
+   public class When_testing_if_one_path_starts_with_another : concern_for_ObjectPath
+   {
+      [Observation]
+      public void if_the_first_path_is_not_long_enough_then_false()
+      {
+         sut = new ObjectPath("A", "B", "C");
+         sut.StartsWith(new ObjectPath("A", "B", "C", "D")).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void if_the_paths_are_the_same_then_true()
+      {
+         sut = new ObjectPath("A", "B", "C");
+         sut.StartsWith(new ObjectPath("A", "B", "C")).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void if_the_paths_is_contained_then_true()
+      {
+         sut = new ObjectPath("A", "B", "C");
+         sut.StartsWith(new ObjectPath("A", "B")).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void if_the_paths_is_not_contained_then_false()
+      {
+         sut = new ObjectPath("A", "B", "C");
+         sut.StartsWith(new ObjectPath("A", "C")).ShouldBeFalse();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2163 

# Description
Adding a method to ObjectPath that tests if one object path starts with another.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):