### PR TITLE
Fixes #2165 Combining Observers and passive transports in Modules

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/MoleculeList.cs
+++ b/src/OSPSuite.Core/Domain/Builder/MoleculeList.cs
@@ -23,14 +23,14 @@ namespace OSPSuite.Core.Domain.Builder
       ///    <para />
       ///    Otherwise (<see cref="ForAll" />=true) not relevant
       /// </summary>
-      public virtual IEnumerable<string> MoleculeNames => _moleculeNamesToInclude;
+      public virtual IReadOnlyList<string> MoleculeNames => _moleculeNamesToInclude;
 
       /// <summary>
       ///    If <see cref="ForAll" /> is set to true, molecules from this list will be excluded from use.
       ///    <para />
       ///    Otherwise (<see cref="ForAll" />=false) not relevant
       /// </summary>
-      public virtual IEnumerable<string> MoleculeNamesToExclude => _moleculeNamesToExclude;
+      public virtual IReadOnlyList<string> MoleculeNamesToExclude => _moleculeNamesToExclude;
 
       /// <summary>
       ///    Add molecule name to use. If molecule name already exists in the list or in

--- a/src/OSPSuite.Core/Domain/Builder/MoleculeList.cs
+++ b/src/OSPSuite.Core/Domain/Builder/MoleculeList.cs
@@ -1,49 +1,36 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Assets;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Exceptions;
 using OSPSuite.Utility.Extensions;
-using OSPSuite.Core.Domain.Services;
 
 namespace OSPSuite.Core.Domain.Builder
 {
    public class MoleculeList : IUpdatable
    {
-      private readonly List<string> _moleculeNamesToInclude;
-      private readonly List<string> _moleculeNamesToExclude;
+      private readonly List<string> _moleculeNamesToInclude = new List<string>();
+      private readonly List<string> _moleculeNamesToExclude = new List<string>();
 
       /// <summary>
       ///    If true, all molecules (with exception of those in <see cref="MoleculeNamesToExclude" />) will be used
       ///    If false, only the molecules in <see cref="MoleculeNames" /> will be used
       /// </summary>
-      public bool ForAll { get; set; }
-
-      public MoleculeList()
-      {
-         ForAll = true;
-         _moleculeNamesToInclude = new List<string>();
-         _moleculeNamesToExclude = new List<string>();
-      }
+      public bool ForAll { get; set; } = true;
 
       /// <summary>
       ///    If <see cref="ForAll" /> is set to false, only molecules from this list will be used.
       ///    <para />
       ///    Otherwise (<see cref="ForAll" />=true) not relevant
       /// </summary>
-      public virtual IEnumerable<string> MoleculeNames
-      {
-         get { return _moleculeNamesToInclude; }
-      }
+      public virtual IEnumerable<string> MoleculeNames => _moleculeNamesToInclude;
 
       /// <summary>
-      ///    If <see cref="ForAll" /> is set to true, molecules from this liost will be excluded from use.
+      ///    If <see cref="ForAll" /> is set to true, molecules from this list will be excluded from use.
       ///    <para />
       ///    Otherwise (<see cref="ForAll" />=false) not relevant
       /// </summary>
-      public virtual IEnumerable<string> MoleculeNamesToExclude
-      {
-         get { return _moleculeNamesToExclude; }
-      }
+      public virtual IEnumerable<string> MoleculeNamesToExclude => _moleculeNamesToExclude;
 
       /// <summary>
       ///    Add molecule name to use. If molecule name already exists in the list or in
@@ -123,10 +110,7 @@ namespace OSPSuite.Core.Domain.Builder
          sourceMoleculeDependentBuilder.MoleculeNamesToExclude.Each(AddMoleculeNameToExclude);
       }
 
-      public virtual void Update(MoleculeList moleculeList)
-      {
-         UpdatePropertiesFrom(moleculeList, null);
-      }
+      public virtual void Update(MoleculeList moleculeList) => UpdatePropertiesFrom(moleculeList, null);
 
       public virtual MoleculeList Clone()
       {
@@ -153,16 +137,13 @@ namespace OSPSuite.Core.Domain.Builder
       }
 
       /// <summary>
-      ///    Replaces any occurence of <paramref name="templateName" /> with <paramref name="moleculeName" /> in both lists to
+      ///    Replaces any occurrence of <paramref name="templateName" /> with <paramref name="moleculeName" /> in both lists to
       ///    include and exclude
       /// </summary>
-      public virtual void ReplaceMoleculeName(string templateName, string moleculeName)
-      {
-         ReplaceMoleculeName(templateName, new[] {moleculeName});
-      }
+      public virtual void ReplaceMoleculeName(string templateName, string moleculeName) => ReplaceMoleculeName(templateName, new[] { moleculeName });
 
       /// <summary>
-      ///    Replaces each occurence of <paramref name="templateName" /> with one entry for each name in
+      ///    Replaces each occurrence of <paramref name="templateName" /> with one entry for each name in
       ///    <paramref name="moleculeNames" /> in both lists to include and exclude
       /// </summary>
       public virtual void ReplaceMoleculeName(string templateName, IReadOnlyList<string> moleculeNames)

--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -88,12 +88,9 @@ namespace OSPSuite.Core.Domain.Builder
       private void performMerge()
       {
          cacheMoleculeDependentBuilders(x => x.PassiveTransports, _passiveTransports);
-
          _reactions.AddRange(allBuilder(x => x.Reactions));
          _eventGroups.AddRange(allBuilder(x => x.EventGroups));
-
          cacheMoleculeDependentBuilders(x => x.Observers, _observers);
-
          _molecules.AddRange(allBuilder(x => x.Molecules));
          _parameterValues.AddRange(allStartValueBuilder(x => x.SelectedParameterValues));
          _initialConditions.AddRange(allStartValueBuilder(x => x.SelectedInitialConditions)
@@ -109,13 +106,13 @@ namespace OSPSuite.Core.Domain.Builder
 
       private void cacheMoleculeLists<T>(IReadOnlyList<T> allBuilders, ObjectBaseCache<T> builderCache) where T : class, IMoleculeDependentBuilder
       {
-         builderCache.Each(builder => { combineMoleculeLists(allBuilders.Where(x => string.Equals(x.Name, builder.Name)).ToList(), builder); });
+         builderCache.Each(builderUsedInSimulation => combineMoleculeLists(allBuilders.Where(x => x.IsNamed(builderUsedInSimulation.Name)), builderUsedInSimulation));
       }
 
-      private void combineMoleculeLists(IReadOnlyList<IMoleculeDependentBuilder> builders, IMoleculeDependentBuilder lastBuilder)
+      private void combineMoleculeLists(IEnumerable<IMoleculeDependentBuilder> builders, IMoleculeDependentBuilder builderUsedInSimulation)
       {
-         _moleculeListCache[lastBuilder] = lastBuilder.MoleculeList.Clone();
-         builders.Each(x => addMolecules(x, _moleculeListCache[lastBuilder]));
+         _moleculeListCache[builderUsedInSimulation] = builderUsedInSimulation.MoleculeList.Clone();
+         builders.Each(x => addMolecules(x, _moleculeListCache[builderUsedInSimulation]));
       }
 
       private void addMolecules(IMoleculeDependentBuilder builder, MoleculeList moleculeList)

--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Core.Domain.Builder
 {
@@ -16,6 +17,7 @@ namespace OSPSuite.Core.Domain.Builder
       private readonly ObjectBaseCache<MoleculeBuilder> _molecules = new ObjectBaseCache<MoleculeBuilder>();
       private readonly StartValueCache<ParameterValue> _parameterValues = new StartValueCache<ParameterValue>();
       private readonly StartValueCache<InitialCondition> _initialConditions = new StartValueCache<InitialCondition>();
+      private readonly Cache<IMoleculeDependentBuilder, MoleculeList> _moleculeListCache = new Cache<IMoleculeDependentBuilder, MoleculeList>();
 
       private readonly Cache<IObjectBase, IObjectBase> _builderCache = new Cache<IObjectBase, IObjectBase>(onMissingKey: x => null);
 
@@ -47,7 +49,6 @@ namespace OSPSuite.Core.Domain.Builder
             .Where(initialCondition => initialCondition.IsPresent)
             .Select(initialCondition => initialCondition.MoleculeName)
             .Distinct();
-
 
          return moleculeNames.Select(x => _molecules[x]).Where(m => m != null);
       }
@@ -86,14 +87,41 @@ namespace OSPSuite.Core.Domain.Builder
 
       private void performMerge()
       {
-         _passiveTransports.AddRange(allBuilder(x => x.PassiveTransports));
+         cacheMoleculeDependentBuilders(x => x.PassiveTransports, _passiveTransports);
+
          _reactions.AddRange(allBuilder(x => x.Reactions));
          _eventGroups.AddRange(allBuilder(x => x.EventGroups));
-         _observers.AddRange(allBuilder(x => x.Observers));
+
+         cacheMoleculeDependentBuilders(x => x.Observers, _observers);
+
          _molecules.AddRange(allBuilder(x => x.Molecules));
          _parameterValues.AddRange(allStartValueBuilder(x => x.SelectedParameterValues));
          _initialConditions.AddRange(allStartValueBuilder(x => x.SelectedInitialConditions)
             .Concat(_simulationConfiguration.ExpressionProfiles.SelectMany(x => x.InitialConditions)));
+      }
+
+      private void cacheMoleculeDependentBuilders<T>(Func<Module, IBuildingBlock<T>> propAccess, ObjectBaseCache<T> cache) where T : class, IMoleculeDependentBuilder
+      {
+         var builders = allBuilder(propAccess).ToList();
+         cache.AddRange(builders);
+         cacheMoleculeLists(builders, cache);
+      }
+
+      private void cacheMoleculeLists<T>(IReadOnlyList<T> allBuilders, ObjectBaseCache<T> builderCache) where T : class, IMoleculeDependentBuilder
+      {
+         builderCache.Each(builder => { combineMoleculeLists(allBuilders.Where(x => string.Equals(x.Name, builder.Name)).ToList(), builder); });
+      }
+
+      private void combineMoleculeLists(IReadOnlyList<IMoleculeDependentBuilder> builders, IMoleculeDependentBuilder lastBuilder)
+      {
+         _moleculeListCache[lastBuilder] = lastBuilder.MoleculeList.Clone();
+         builders.Each(x => addMolecules(x, _moleculeListCache[lastBuilder]));
+      }
+
+      private void addMolecules(IMoleculeDependentBuilder builder, MoleculeList moleculeList)
+      {
+         builder.MoleculeList.MoleculeNames.Each(moleculeList.AddMoleculeName);
+         builder.MoleculeList.MoleculeNamesToExclude.Each(moleculeList.AddMoleculeNameToExclude);
       }
 
       internal IReadOnlyList<SpatialStructure> SpatialStructures => all(x => x.SpatialStructure);
@@ -104,6 +132,7 @@ namespace OSPSuite.Core.Domain.Builder
       internal IReadOnlyCollection<MoleculeBuilder> Molecules => _molecules;
       internal IReadOnlyCollection<ParameterValue> ParameterValues => _parameterValues;
       internal IReadOnlyCollection<InitialCondition> InitialConditions => _initialConditions;
+      internal MoleculeList MoleculeListFor(IMoleculeDependentBuilder builder) => _moleculeListCache[builder];
 
       internal MoleculeBuilder MoleculeByName(string name) => _molecules[name];
    }

--- a/src/OSPSuite.Core/Domain/Services/ObserverBuilderTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObserverBuilderTask.cs
@@ -48,11 +48,11 @@ namespace OSPSuite.Core.Domain.Services
          try
          {
             foreach (var observerBuilder in observers.OfType<AmountObserverBuilder>())
-               createAmountObserver(observerBuilder, presentMolecules, replacementContext);
+               createAmountObserver(observerBuilder, presentMolecules, replacementContext, simulationBuilder);
 
 
             foreach (var observerBuilder in observers.OfType<ContainerObserverBuilder>())
-               createContainerObserver(observerBuilder, presentMolecules, replacementContext);
+               createContainerObserver(observerBuilder, presentMolecules, replacementContext, simulationBuilder);
          }
          finally
          {
@@ -77,9 +77,9 @@ namespace OSPSuite.Core.Domain.Services
       ///    in the spatial structure of the model.
       ///    Typical example: "Concentration"-Observer (M/V)
       /// </summary>
-      private void createAmountObserver(AmountObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext)
+      private void createAmountObserver(AmountObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
       {
-         var moleculeNamesForObserver = moleculeBuildersValidFor(observerBuilder.MoleculeList, presentMolecules)
+         var moleculeNamesForObserver = moleculeBuildersValidFor(simulationBuilder.MoleculeListFor(observerBuilder), presentMolecules)
             .Select(x => x.Name).ToList();
 
          foreach (var container in _allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
@@ -100,9 +100,9 @@ namespace OSPSuite.Core.Domain.Services
       ///    of the model.
       ///    Typical example is average drug concentration in an organ
       /// </summary>
-      private void createContainerObserver(ContainerObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext)
+      private void createContainerObserver(ContainerObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
       {
-         var moleculeBuildersForObserver = moleculeBuildersValidFor(observerBuilder.MoleculeList, presentMolecules).ToList();
+         var moleculeBuildersForObserver = moleculeBuildersValidFor(simulationBuilder.MoleculeListFor(observerBuilder), presentMolecules).ToList();
          //retrieve a list here to avoid endless loop if observers criteria is not well defined
          foreach (var container in _allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
          {

--- a/src/OSPSuite.Core/Domain/Services/TransportCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/TransportCreator.cs
@@ -65,7 +65,7 @@ namespace OSPSuite.Core.Domain.Services
       {
          var (_, simulationBuilder, replacementContext) = modelConfiguration;
          // first check if the molecule should be transported
-         if (!passiveTransportBuilder.TransportsMolecule(molecule.Name))
+         if (!simulationBuilder.MoleculeListFor(passiveTransportBuilder).Uses(molecule.Name))
             return;
 
          var neighborhoods = getNeighborhoodsForPassiveTransport(passiveTransportBuilder, allNeighborhoods, molecule.Name);

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Utility.Extensions;
+
+namespace OSPSuite.Core.Domain
+{
+   internal class concern_for_SimulationBuilder : ContextSpecification<SimulationBuilder>
+   {
+   }
+
+   internal class When_mapping_an_observer_from_an_observer_builder_and_there_are_multiple_observer_builders_for_the_name : concern_for_SimulationBuilder
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private ModuleConfiguration _moduleConfiguration1;
+      private ModuleConfiguration _moduleConfiguration2;
+      private ObserverBuilder _observerBuilder;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moduleConfiguration1 = createModuleConfiguration();
+         _moduleConfiguration2 = createModuleConfiguration();
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration1);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration2);
+
+         _moduleConfiguration1.Module.Observers.AmountObserverBuilders.Each(x => x.MoleculeList.AddMoleculeName("molecule1"));
+         _moduleConfiguration2.Module.Observers.AmountObserverBuilders.Each(x => x.MoleculeList.AddMoleculeName("molecule2"));
+
+         sut = new SimulationBuilder(_simulationConfiguration);
+         _observerBuilder = _moduleConfiguration2.Module.Observers.AmountObserverBuilders.First();
+      }
+
+      private static ModuleConfiguration createModuleConfiguration()
+      {
+         var module = new Module();
+         var moduleConfiguration = new ModuleConfiguration(module);
+         var observerBuildingBlock = new ObserverBuildingBlock();
+         module.Add(observerBuildingBlock);
+         observerBuildingBlock.Add(new AmountObserverBuilder().WithName("toto").WithDimension(A.Fake<IDimension>()));
+         return moduleConfiguration;
+      }
+
+      [Observation]
+      public void the_observer_should_be_created_for_both_()
+      {
+         sut.MoleculeListFor(_observerBuilder).MoleculeNames.ShouldContain("molecule1");
+         sut.MoleculeListFor(_observerBuilder).MoleculeNames.ShouldContain("molecule2");
+      }
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
@@ -10,6 +10,15 @@ namespace OSPSuite.Core.Domain
 {
    internal class concern_for_SimulationBuilder : ContextSpecification<SimulationBuilder>
    {
+      protected static ModuleConfiguration CreateModuleConfiguration()
+      {
+         var module = new Module();
+         var moduleConfiguration = new ModuleConfiguration(module);
+         var observerBuildingBlock = new ObserverBuildingBlock();
+         module.Add(observerBuildingBlock);
+         observerBuildingBlock.Add(new AmountObserverBuilder().WithName("toto").WithDimension(A.Fake<IDimension>()));
+         return moduleConfiguration;
+      }
    }
 
    internal class When_mapping_an_observer_from_an_observer_builder_and_there_are_multiple_observer_builders_for_the_name : concern_for_SimulationBuilder
@@ -22,8 +31,8 @@ namespace OSPSuite.Core.Domain
       protected override void Context()
       {
          base.Context();
-         _moduleConfiguration1 = createModuleConfiguration();
-         _moduleConfiguration2 = createModuleConfiguration();
+         _moduleConfiguration1 = CreateModuleConfiguration();
+         _moduleConfiguration2 = CreateModuleConfiguration();
          _simulationConfiguration = new SimulationConfiguration();
          _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration1);
          _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration2);
@@ -33,16 +42,6 @@ namespace OSPSuite.Core.Domain
 
          sut = new SimulationBuilder(_simulationConfiguration);
          _observerBuilder = _moduleConfiguration2.Module.Observers.AmountObserverBuilders.First();
-      }
-
-      private static ModuleConfiguration createModuleConfiguration()
-      {
-         var module = new Module();
-         var moduleConfiguration = new ModuleConfiguration(module);
-         var observerBuildingBlock = new ObserverBuildingBlock();
-         module.Add(observerBuildingBlock);
-         observerBuildingBlock.Add(new AmountObserverBuilder().WithName("toto").WithDimension(A.Fake<IDimension>()));
-         return moduleConfiguration;
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2165 

# Description
When merging passive transports and observers, we should combine the include/exclude molecule lists

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):