### PR TITLE
Fixes #2173 Tumor workflow does not create molecules in any added containers

### DIFF
--- a/src/OSPSuite.Core/Domain/ObjectPath.cs
+++ b/src/OSPSuite.Core/Domain/ObjectPath.cs
@@ -219,6 +219,14 @@ namespace OSPSuite.Core.Domain
          _pathEntries.Insert(0, pathEntry);
       }
 
+      /// <summary>
+      ///   Add a multipart <paramref name="pathToAdd"/> at the front
+      /// </summary>
+      public virtual void AddAtFront(ObjectPath pathToAdd)
+      {
+         pathToAdd.Reverse().Each(AddAtFront);
+      }
+
       private T resolvePath<T>(IEntity currentEntity, IEnumerable<string> path) where T : class
       {
          if (currentEntity == null)

--- a/tests/OSPSuite.Core.Tests/Domain/InitialConditionsCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/InitialConditionsCreatorSpecs.cs
@@ -92,6 +92,37 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   internal class When_creating_initial_conditions_in_a_container_with_parent_path_at_root : concern_for_InitialConditionsCreator
+   {
+      private MoleculeBuilder _molecule;
+      private Container _container;
+      private InitialCondition _initialCondition;
+
+      protected override void Context()
+      {
+         base.Context();
+         _molecule = new MoleculeBuilder().WithName("moleculeName").WithDimension(Constants.Dimension.NO_DIMENSION);
+         _container = new Container
+         {
+            ContainerType = ContainerType.Organ,
+            Mode = ContainerMode.Physical,
+            Name = "topContainer",
+            ParentPath = new ObjectPath("ItGoesSomewhere")
+         };
+      }
+
+      protected override void Because()
+      {
+         _initialCondition = sut.CreateInitialCondition(_container, _molecule);
+      }
+
+      [Observation]
+      public void the_initial_condition_should_have_root_container_parent_path()
+      {
+         _initialCondition.Path.PathAsString.ShouldBeEqualTo("ItGoesSomewhere|topContainer|moleculeName");
+      }
+   }
+
    internal class When_creating_initial_conditions_from_molecule_amount : concern_for_InitialConditionsCreator
    {
       private InitialCondition _initialCondition;

--- a/tests/OSPSuite.Core.Tests/Domain/InitialConditionsCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/InitialConditionsCreatorSpecs.cs
@@ -107,7 +107,7 @@ namespace OSPSuite.Core.Domain
             ContainerType = ContainerType.Organ,
             Mode = ContainerMode.Physical,
             Name = "topContainer",
-            ParentPath = new ObjectPath("ItGoesSomewhere")
+            ParentPath = new ObjectPath("ItGoesSomewhere", "Else")
          };
       }
 
@@ -119,7 +119,7 @@ namespace OSPSuite.Core.Domain
       [Observation]
       public void the_initial_condition_should_have_root_container_parent_path()
       {
-         _initialCondition.Path.PathAsString.ShouldBeEqualTo("ItGoesSomewhere|topContainer|moleculeName");
+         _initialCondition.Path.Equals(new ObjectPath("ItGoesSomewhere", "Else", "topContainer", "moleculeName")).ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
Fixes #2173 

# Description
When creating initial conditions for containers whose root has an additional ```ParentPath``` property, the parent path is not prepended to the path of the initial condition.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
Before:
![image](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/assets/261477/4f5c1d89-50bf-4437-bfe4-6b609488660e)

After:
![image](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/assets/261477/f33ab7d7-fe47-4b84-b649-68ee6e746f74)



# Questions (if appropriate):