### PR TITLE
Fixes #2180 Simulation Settings building block from a simulation is not registered in the project

### DIFF
--- a/src/OSPSuite.Core/Domain/ModelCoreSimulation.cs
+++ b/src/OSPSuite.Core/Domain/ModelCoreSimulation.cs
@@ -94,6 +94,8 @@ namespace OSPSuite.Core.Domain
       {
          base.AcceptVisitor(visitor);
 
+         Settings?.AcceptVisitor(visitor);
+
          Model?.AcceptVisitor(visitor);
 
          Configuration?.AcceptVisitor(visitor);

--- a/src/OSPSuite.Core/Events/OutputSchemaChangedEvent.cs
+++ b/src/OSPSuite.Core/Events/OutputSchemaChangedEvent.cs
@@ -1,0 +1,14 @@
+﻿using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Events
+{
+   public class OutputSchemaChangedEvent
+   {
+      public OutputSchema OutputSchema { get; }
+
+      public OutputSchemaChangedEvent(OutputSchema outputSchema)
+      {
+         OutputSchema = outputSchema;
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2180

# Description
Formerly the ```SimulationSettings``` were handled like all the other building blocks and registered along with them, that's been reconfigured and while the ```SimulationConfiguration``` is used to register building blocks, it does not handle the ```SimulationSettings``` as they are not included in ```SimulationConfiguraiton```

There's more to this fix in MoBi once the Core PR is merged

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):