### PR TITLE
Fixes #2182 Interaction process containers listed too many times in s…

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ReactionCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ReactionCreator.cs
@@ -47,9 +47,14 @@ namespace OSPSuite.Core.Domain.Services
          return true;
       }
 
-      private IContainer createReactionPropertiesContainer(ReactionBuilder reactionBuilder, ModelConfiguration modelConfiguration)
+      private void createReactionPropertiesContainer(ReactionBuilder reactionBuilder, ModelConfiguration modelConfiguration)
       {
          var (model, simulationBuilder, replacementContext) = modelConfiguration;
+
+         //Do we have non local parameters in this container? If not, no need to create a global container
+         if (reactionBuilder.Parameters.All(x => x.BuildMode == ParameterBuildMode.Local))
+            return;
+
          var globalReactionContainer = _containerTask.CreateOrRetrieveSubContainerByName(model.Root, reactionBuilder.Name)
             .WithContainerType(ContainerType.Reaction)
             .WithIcon(reactionBuilder.Icon)
@@ -61,7 +66,6 @@ namespace OSPSuite.Core.Domain.Services
          _parameterMapper.MapGlobalOrPropertyFrom(reactionBuilder, simulationBuilder).Each(globalReactionContainer.Add);
 
          _keywordReplacerTask.ReplaceIn(globalReactionContainer, reactionBuilder.Name, replacementContext);
-         return globalReactionContainer;
       }
 
       private Func<IContainer, Reaction> createLocalReactionDef(ReactionBuilder reactionBuilder, SimulationBuilder simulationBuilder) => container

--- a/tests/OSPSuite.Core.Tests/Domain/ReactionCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ReactionCreatorSpecs.cs
@@ -60,8 +60,6 @@ namespace OSPSuite.Core.Domain
          _reactionBuilder.AddProduct(_product1);
          _reactionBuilder.AddModifier("modifier");
 
-
-
          _rootContainer = new Container().WithMode(ContainerMode.Physical);
          _model.Root = _rootContainer;
          _globalContainer = new Container();


### PR DESCRIPTION
Fixes #2182

# Description
We always create global containers, even for reactions that contain only local parameters. We can skip creating those containers.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):