### PR TITLE
Fixes #2187 Allow default QuantitySelection type of Undefined

### DIFF
--- a/src/OSPSuite.Core/Domain/QuantitySelection.cs
+++ b/src/OSPSuite.Core/Domain/QuantitySelection.cs
@@ -18,7 +18,7 @@ namespace OSPSuite.Core.Domain
       {
       }
 
-      public QuantitySelection(string path, QuantityType quantityType)
+      public QuantitySelection(string path, QuantityType quantityType = QuantityType.Undefined)
       {
          Path = path;
          QuantityType = quantityType;


### PR DESCRIPTION
Fixes #2187 

# Description
We no longer need to force the QuantitySelection constructor to specify a type. The type is not always important for quantity selection

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):