### PR TITLE
Fixes #2193 Create expression profile parameters values in parameter values creator

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
@@ -86,11 +86,11 @@ namespace OSPSuite.Core.Domain.Services
       public IReadOnlyList<ParameterValue> CreateExpressionFrom(IContainer physicalContainer, IReadOnlyList<MoleculeBuilder> molecules) => 
          physicalContainer.GetAllContainersAndSelf<IContainer>(x => x.Mode.Is(ContainerMode.Physical)).SelectMany(container => createFrom(container, molecules, x => x.IsExpression())).ToList();
 
-      private IReadOnlyList<ParameterValue> createFrom(IContainer container, IReadOnlyList<MoleculeBuilder> molecules, Func<IParameter, bool> createFor) => 
-         molecules.SelectMany(x => createFrom(container, x, createFor)).ToList();
+      private IEnumerable<ParameterValue> createFrom(IContainer container, IReadOnlyList<MoleculeBuilder> molecules, Func<IParameter, bool> createFor) => 
+         molecules.SelectMany(x => createFrom(container, x, createFor));
 
-      private IReadOnlyList<ParameterValue> createFrom(IContainer container, MoleculeBuilder molecule, Func<IParameter, bool> createFor) => 
-         molecule.Parameters.Where(createFor).Select(x => CreateParameterValue(objectPathForParameterInContainer(container, x.Name, molecule.Name), x)).ToList();
+      private IEnumerable<ParameterValue> createFrom(IContainer container, MoleculeBuilder molecule, Func<IParameter, bool> createFor) => 
+         molecule.Parameters.Where(createFor).Select(x => CreateParameterValue(objectPathForParameterInContainer(container, x.Name, molecule.Name), x));
 
       private static bool isLocalWithConstantFormula(IParameter x) => x.BuildMode == ParameterBuildMode.Local && x.Formula.IsConstant();
 

--- a/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Utility.Extensions;
+using OSPSuite.Core.Extensions;
 
 namespace OSPSuite.Core.Domain.Services
 {
@@ -84,7 +84,7 @@ namespace OSPSuite.Core.Domain.Services
          spatialStructure.PhysicalContainers.SelectMany(container => createFrom(container, molecules, isLocalWithConstantFormula)).ToList();
 
       public IReadOnlyList<ParameterValue> CreateExpressionFrom(IContainer physicalContainer, IReadOnlyList<MoleculeBuilder> molecules) => 
-         physicalContainer.GetAllContainersAndSelf<IContainer>(x => x.Mode.Equals(ContainerMode.Physical)).SelectMany(container => createFrom(container, molecules, x => x.IsExpression())).ToList();
+         physicalContainer.GetAllContainersAndSelf<IContainer>(x => x.Mode.Is(ContainerMode.Physical)).SelectMany(container => createFrom(container, molecules, x => x.IsExpression())).ToList();
 
       private IReadOnlyList<ParameterValue> createFrom(IContainer container, IReadOnlyList<MoleculeBuilder> molecules, Func<IParameter, bool> createFor) => 
          molecules.SelectMany(x => createFrom(container, x, createFor)).ToList();

--- a/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
@@ -80,25 +80,17 @@ namespace OSPSuite.Core.Domain.Services
          return parameterValue;
       }
 
-      public IReadOnlyList<ParameterValue> CreateFrom(SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules)
-      {
-         return spatialStructure.PhysicalContainers.SelectMany(container => createFrom(container, molecules, isLocalWithConstantFormula)).ToList();
-      }
+      public IReadOnlyList<ParameterValue> CreateFrom(SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) => 
+         spatialStructure.PhysicalContainers.SelectMany(container => createFrom(container, molecules, isLocalWithConstantFormula)).ToList();
 
-      public IReadOnlyList<ParameterValue> CreateExpressionFrom(IContainer physicalContainer, IReadOnlyList<MoleculeBuilder> molecules)
-      {
-         return physicalContainer.GetAllContainersAndSelf<IContainer>(x => x.Mode.Equals(ContainerMode.Physical)).SelectMany(container => createFrom(container, molecules, x => x.IsExpression())).ToList();
-      }
+      public IReadOnlyList<ParameterValue> CreateExpressionFrom(IContainer physicalContainer, IReadOnlyList<MoleculeBuilder> molecules) => 
+         physicalContainer.GetAllContainersAndSelf<IContainer>(x => x.Mode.Equals(ContainerMode.Physical)).SelectMany(container => createFrom(container, molecules, x => x.IsExpression())).ToList();
 
-      private IReadOnlyList<ParameterValue> createFrom(IContainer container, IReadOnlyList<MoleculeBuilder> molecules, Func<IParameter, bool> createFor)
-      {
-         return molecules.SelectMany(x => createFrom(container, x, createFor)).ToList();
-      }
+      private IReadOnlyList<ParameterValue> createFrom(IContainer container, IReadOnlyList<MoleculeBuilder> molecules, Func<IParameter, bool> createFor) => 
+         molecules.SelectMany(x => createFrom(container, x, createFor)).ToList();
 
-      private IReadOnlyList<ParameterValue> createFrom(IContainer container, MoleculeBuilder molecule, Func<IParameter, bool> createFor)
-      {
-         return molecule.Parameters.Where(createFor).Select(x => CreateParameterValue(objectPathForParameterInContainer(container, x.Name, molecule.Name), x)).ToList();
-      }
+      private IReadOnlyList<ParameterValue> createFrom(IContainer container, MoleculeBuilder molecule, Func<IParameter, bool> createFor) => 
+         molecule.Parameters.Where(createFor).Select(x => CreateParameterValue(objectPathForParameterInContainer(container, x.Name, molecule.Name), x)).ToList();
 
       private static bool isLocalWithConstantFormula(IParameter x) => x.BuildMode == ParameterBuildMode.Local && x.Formula.IsConstant();
 

--- a/src/OSPSuite.Core/Extensions/ContainerModeExtensions.cs
+++ b/src/OSPSuite.Core/Extensions/ContainerModeExtensions.cs
@@ -1,0 +1,9 @@
+﻿using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Extensions
+{
+   public static class ContainerModeExtensions
+   {
+      public static bool Is(this ContainerMode containerMode, ContainerMode otherContainerMode) => containerMode == otherContainerMode;
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
@@ -81,4 +81,38 @@ namespace OSPSuite.Core.Domain
          _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain("Top|physicalContainer|Molecule1|constantFormulaParameterName", "Top|Molecule1|constantFormulaParameterName");
       }
    }
+
+   public class When_creating_expression_parameters_from_proteins_and_organ : concern_for_ParameterValuesCreator
+   {
+      private IContainer _organContainer;
+      private IReadOnlyList<MoleculeBuilder> _molecules;
+      private MoleculeBuilder _protein;
+      private IReadOnlyList<ParameterValue> _parameterValues;
+      private Container _compartmentContainer;
+
+      protected override void Context()
+      {
+         base.Context();
+         _protein = new MoleculeBuilder().WithName("protein");
+         _protein.QuantityType = QuantityType.Transporter;
+         _protein.AddParameter(new Parameter().WithName(Constants.Parameters.REL_EXP));
+         _protein.AddParameter(new Parameter().WithName("some other parameter"));
+
+         _molecules = new[] { _protein };
+         _organContainer = new Container().WithName("organ").WithMode(ContainerMode.Physical);
+         _compartmentContainer = new Container().WithName("compartment").WithMode(ContainerMode.Physical);
+         _organContainer.Add(_compartmentContainer);
+      }
+
+      protected override void Because()
+      {
+         _parameterValues = sut.CreateExpressionFrom(_organContainer, _molecules);
+      }
+
+      [Observation]
+      public void the_parameter_values_should_include_expression_parameters_for_the_organ()
+      {
+         _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain($"organ|protein|{Constants.Parameters.REL_EXP}", $"organ|compartment|protein|{Constants.Parameters.REL_EXP}");
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2193

# Description
To make this feature implementation symmetrical with other PathAndValue extend features, we are using this core ParameterVAluesCreator to give us all the expression values for a container and selection of molecules. The expression parameters will include all the sub containers.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):