### PR TITLE
Fixes #2195

### DIFF
--- a/src/OSPSuite.UI/Extensions/ToolTipControllerExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/ToolTipControllerExtensions.cs
@@ -12,7 +12,7 @@ namespace OSPSuite.UI.Extensions
          toolTipController.ShowBeak = false;
          toolTipController.AllowHtmlText = true;
          toolTipController.ImageList = imageListRetriever.AllImages16x16;
-         toolTipController.AutoPopDelay = 10000;
+         toolTipController.AutoPopDelay = 20000;
          toolTipController.InitialDelay = delayInMilliseconds;
          return toolTipController;
       }


### PR DESCRIPTION
Fixes #2195

# Description
The current length of time for tooltips was too short. Updated the value to be 20 seconds instead of 10. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):