### PR TITLE
Fixes #2199 Move DistributionType updates for cloning to the proper class

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/IndividualParameter.cs
+++ b/src/OSPSuite.Core/Domain/Builder/IndividualParameter.cs
@@ -14,9 +14,9 @@ namespace OSPSuite.Core.Domain.Builder
       {
          base.UpdatePropertiesFrom(source, cloneManager);
          var sourceIndividualParameter = source as IndividualParameter;
-         if (sourceIndividualParameter == null) return;
+         if (sourceIndividualParameter == null) 
+            return;
 
-         DistributionType = sourceIndividualParameter.DistributionType;
          Info = sourceIndividualParameter.Info?.Clone();
          Origin = sourceIndividualParameter.Origin?.Clone();
          IsDefault = sourceIndividualParameter.IsDefault;

--- a/src/OSPSuite.Core/Domain/Builder/PathAndValueEntity.cs
+++ b/src/OSPSuite.Core/Domain/Builder/PathAndValueEntity.cs
@@ -85,9 +85,11 @@ namespace OSPSuite.Core.Domain.Builder
       public override void UpdatePropertiesFrom(IUpdatable source, ICloneManager cloneManager)
       {
          base.UpdatePropertiesFrom(source, cloneManager);
-         var sourcePathAndValueEntity = source as PathAndValueEntity;
-         if (sourcePathAndValueEntity == null) return;
 
+         if (!(source is PathAndValueEntity sourcePathAndValueEntity)) 
+            return;
+
+         DistributionType = sourcePathAndValueEntity.DistributionType;
          Value = sourcePathAndValueEntity.Value;
          ContainerPath = sourcePathAndValueEntity.ContainerPath.Clone<ObjectPath>();
          DisplayUnit = sourcePathAndValueEntity.DisplayUnit;


### PR DESCRIPTION
Fixes #2199

# Description
Working on a new feature in MoBi that uses ```ParameterValue``` that are distributed. Cloning caused this property to be lost.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):