### PR TITLE
Fixes exception thrown when objectBase is null

### DIFF
--- a/src/OSPSuite.Presentation/Diagram/BaseDiagramManager.cs
+++ b/src/OSPSuite.Presentation/Diagram/BaseDiagramManager.cs
@@ -260,6 +260,9 @@ namespace OSPSuite.Presentation.Diagram
          where TObject : class, IObjectBase
          where TNode : class, IBaseNode, new()
       {
+         if (objectBase == null) 
+            return null;
+
          var node = NodeFor<TNode>(objectBase);
          if (node == null)
          {
@@ -285,11 +288,13 @@ namespace OSPSuite.Presentation.Diagram
 
          var containerNode = AddAndCoupleNode<IContainer, TContainerNode>(parent, container, coupleAll);
 
-         if (recursive)
-            foreach (var child in container.Children)
-            {
-               AddObjectBase(containerNode, child, true, coupleAll);
-            }
+         if (!recursive) 
+            return containerNode;
+
+         foreach (var child in container.Children)
+         {
+            AddObjectBase(containerNode, child, true, coupleAll);
+         }
 
          return containerNode;
       }


### PR DESCRIPTION
Fixes #2205

# Description
I checked for similar code in V11 and added this simple thing back in.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):