### PR TITLE
2150 removing observed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ paket-files/
 /tests/OSPSuite.Core.Tests/include
 
 licenses.licx
+*.DotSettings

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -223,6 +223,7 @@ namespace OSPSuite.Assets
       public static readonly string ReallyRemoveObservedDataFromSimulation = $"Really remove {ObjectTypes.ObservedData} from the simulation?\nHint: {ObjectTypes.ObservedData} will not be deleted from the project";
       public static readonly string SimulationWasCanceled = "Simulation was canceled";
       public static readonly string SelectMappingToShowObservedData = "Select mapping to show observed data";
+      public static readonly string DoNotShowThisAgainUntilRestart = "Do not show this again until restart";
 
       public static string ShouldWatermarkBeUsedForChartExportToClipboard(string applicationName, string optionLocation)
       {

--- a/src/OSPSuite.Core/CoreRegister.cs
+++ b/src/OSPSuite.Core/CoreRegister.cs
@@ -55,6 +55,7 @@ namespace OSPSuite.Core
             scan.ExcludeType<PKParameterRepositoryLoader>();
             scan.ExcludeType<ParameterIdentificationRunner>();
             scan.ExcludeType<SensitivityAnalysisRunner>();
+            scan.ExcludeType<ConfirmationManager>();
 
             scan.ExcludeType(typeof(ExtendedProperty<>));
             scan.ExcludeType(typeof(HistoryManager<>));
@@ -89,6 +90,7 @@ namespace OSPSuite.Core
          container.Register<IPKParameterRepositoryLoader, PKParameterRepositoryLoader>(LifeStyle.Singleton);
          container.Register<IParameterIdentificationRunner, ParameterIdentificationRunner>(LifeStyle.Singleton);
          container.Register<ISensitivityAnalysisRunner, SensitivityAnalysisRunner>(LifeStyle.Singleton);
+         container.Register<IConfirmationManager, ConfirmationManager>(LifeStyle.Singleton);
 
          registerComparers(container);
 

--- a/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
@@ -207,8 +207,8 @@ namespace OSPSuite.Core.Domain.Services
          {
             var viewResult = _dialogCreator.MessageBoxConfirm(Captions.ReallyRemoveObservedDataFromSimulation,
                SuppressWarningOnRemovingObservedDataEntryFromSimulation);
-            if (viewResult == ViewResult.No)
-               return;
+            if (viewResult != ViewResult.Yes)
+               return; 
          }
 
          usedObservedDataList.GroupBy(x => x.Simulation).Each(x => removeUsedObservedDataFromSimulation(x, x.Key));

--- a/src/OSPSuite.Core/Services/ConfirmationManager.cs
+++ b/src/OSPSuite.Core/Services/ConfirmationManager.cs
@@ -1,14 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace OSPSuite.Core.Services
 {
-   [Flags]
    public enum ConfirmationFlags
    {
       None = 0,
-      ObservedDataEntryRemoved = 1 << 0,
-      AnotherConfirmation = 1 << 1,
-      YetAnotherConfirmation = 1 << 2,
+      ObservedDataEntryRemoved = 1
    }
 
    public interface IConfirmationManager
@@ -19,16 +17,16 @@ namespace OSPSuite.Core.Services
 
    public class ConfirmationManager : IConfirmationManager
    {
+      private readonly HashSet<ConfirmationFlags> _suppressedConfirmations = new HashSet<ConfirmationFlags>();
 
       public void SuppressConfirmation(ConfirmationFlags confirmation)
       {
-         suppressConfirmationFlags |= confirmation;
+         _suppressedConfirmations.Add(confirmation);
       }
 
       public bool IsConfirmationSuppressed(ConfirmationFlags confirmation)
       {
-         return (suppressConfirmationFlags & confirmation) == confirmation;
+         return _suppressedConfirmations.Contains(confirmation);
       }
-      private ConfirmationFlags suppressConfirmationFlags { get; set; }
    }
 }

--- a/src/OSPSuite.Core/Services/ConfirmationManager.cs
+++ b/src/OSPSuite.Core/Services/ConfirmationManager.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace OSPSuite.Core.Services
+{
+   [Flags]
+   public enum ConfirmationFlags
+   {
+      None = 0,
+      ObservedDataEntryRemoved = 1 << 0,
+      AnotherConfirmation = 1 << 1,
+      YetAnotherConfirmation = 1 << 2,
+   }
+
+   public interface IConfirmationManager
+   {
+      void SuppressConfirmation(ConfirmationFlags confirmation);
+      bool IsConfirmationSuppressed(ConfirmationFlags confirmation);
+   }
+
+   public class ConfirmationManager : IConfirmationManager
+   {
+
+      public void SuppressConfirmation(ConfirmationFlags confirmation)
+      {
+         suppressConfirmationFlags |= confirmation;
+      }
+
+      public bool IsConfirmationSuppressed(ConfirmationFlags confirmation)
+      {
+         return (suppressConfirmationFlags & confirmation) == confirmation;
+      }
+      private ConfirmationFlags suppressConfirmationFlags { get; set; }
+   }
+}

--- a/src/OSPSuite.Core/Services/ConfirmationManager.cs
+++ b/src/OSPSuite.Core/Services/ConfirmationManager.cs
@@ -5,8 +5,7 @@ namespace OSPSuite.Core.Services
 {
    public enum ConfirmationFlags
    {
-      None = 0,
-      ObservedDataEntryRemoved = 1
+      ObservedDataEntryRemoved = 0
    }
 
    public interface IConfirmationManager

--- a/src/OSPSuite.Core/Services/IDialogCreator.cs
+++ b/src/OSPSuite.Core/Services/IDialogCreator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace OSPSuite.Core.Services
@@ -25,6 +26,14 @@ namespace OSPSuite.Core.Services
       ViewResult MessageBoxYesNoCancel(string message, string yes, string no, string cancel, ViewResult defaultButton = ViewResult.Yes);
 
       ViewResult MessageBoxYesNo(string message, ViewResult defaultButton = ViewResult.Yes);
+
+      /// <summary>
+      /// Displays a dialog prompting the user for confirmation on an action with significant impact. The dialog includes 'Yes' and 'Cancel' buttons and an option for a 'Do Not Show Again' checkbox.
+      /// </summary>
+      /// <param name="message">The message to be displayed in the dialog.</param>
+      /// <param name="doNotShowAgain">The action to execute if the user opts for the 'Do Not Show Again' checkbox.</param>
+      /// <param name="defaultButton">The button set as the default selection. Defaults to 'Yes'.</param>
+      ViewResult MessageBoxConfirm(string message, Action doNotShowAgain, ViewResult defaultButton = ViewResult.Yes);
 
       /// <summary>
       ///    Customize a yes no cancel message box by allowing to change caption for yes, no

--- a/src/OSPSuite.R/MinimalImplementations/DialogCreator.cs
+++ b/src/OSPSuite.R/MinimalImplementations/DialogCreator.cs
@@ -13,6 +13,7 @@ namespace OSPSuite.R.MinimalImplementations
       public ViewResult MessageBoxYesNoCancel(string message, string yes, string no, string cancel, ViewResult defaultButton) => ViewResult.Yes;
 
       public ViewResult MessageBoxYesNo(string message, ViewResult defaultButton) => ViewResult.Yes;
+      public ViewResult MessageBoxConfirm(string message, Action doNotShowAgain, ViewResult defaultButton = ViewResult.Yes) => ViewResult.Yes;
 
       public ViewResult MessageBoxYesNo(string message, string yes, string no, ViewResult defaultButton) => ViewResult.Yes;
 

--- a/src/OSPSuite.UI/Services/DialogCreator.cs
+++ b/src/OSPSuite.UI/Services/DialogCreator.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
 using DevExpress.Utils;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
@@ -12,6 +8,11 @@ using OSPSuite.Presentation.Services;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Mappers;
 using OSPSuite.Utility;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace OSPSuite.UI.Services
 {
@@ -35,7 +36,7 @@ namespace OSPSuite.UI.Services
 
       public void MessageBoxInfo(string message)
       {
-         showMessageBox(message, new[] {DialogResult.OK}, getIcon(SystemIcons.Information));
+         showMessageBox(message, new[] { DialogResult.OK }, getIcon(SystemIcons.Information));
       }
 
       private void showMessageBox(string message, DialogResult[] buttons, Icon icon)
@@ -43,7 +44,7 @@ namespace OSPSuite.UI.Services
          XtraMessageBox.Show(createMessageBoxArgs(message, buttons, icon));
       }
 
-      private XtraMessageBoxArgs createMessageBoxArgs(string message, DialogResult[] buttons, Icon icon, int defaultButtonIndex = 0)
+      private XtraMessageBoxArgs createMessageBoxArgs(string message, DialogResult[] buttons, Icon icon, int defaultButtonIndex = 0, bool doNotShowAgainCheckBoxVisible = false)
       {
          var args = new XtraMessageBoxArgs
          {
@@ -52,16 +53,18 @@ namespace OSPSuite.UI.Services
             Buttons = buttons,
             Icon = icon,
             DefaultButtonIndex = defaultButtonIndex,
-            AllowHtmlText = DefaultBoolean.True
+            AllowHtmlText = DefaultBoolean.True,
+            DoNotShowAgainCheckBoxVisible = doNotShowAgainCheckBoxVisible,
+            DoNotShowAgainCheckBoxText = UIConstants.DO_NOT_SHOW_THIS_AGAIN_UNTIL_RESTART
          };
 
          if (containsHyperlink(message))
-            args.HyperlinkClick += (o,e) => { System.Diagnostics.Process.Start(e.Link); };
-         
+            args.HyperlinkClick += (o, e) => { System.Diagnostics.Process.Start(e.Link); };
+
          return args;
       }
 
-      public ViewResult MessageBoxYesNoCancel(string message, ViewResult defaultButton= ViewResult.Yes)
+      public ViewResult MessageBoxYesNoCancel(string message, ViewResult defaultButton = ViewResult.Yes)
       {
          return MessageBoxYesNoCancel(message, string.Empty, string.Empty, string.Empty, defaultButton);
       }
@@ -79,21 +82,43 @@ namespace OSPSuite.UI.Services
 
       public ViewResult MessageBoxYesNo(string message, string yes, string no, ViewResult defaultButton = ViewResult.Yes)
       {
-         return showQuestionMessageBox(message, new [] {
-            DialogResult.Yes, DialogResult.No}, yes, no, string.Empty, defaultButton);
+         return showQuestionMessageBox(message, new[]
+         {
+            DialogResult.Yes, DialogResult.No
+         }, yes, no, string.Empty, defaultButton);
       }
 
-      private ViewResult showQuestionMessageBox(string message, IReadOnlyList<DialogResult> buttons, string yes, string no, string cancel, ViewResult defaultButton)
+      public ViewResult MessageBoxConfirm(string message, Action doNotShowAgain, ViewResult defaultButton = ViewResult.Yes)
+      {
+         return showQuestionMessageBox(message, new[]
+         {
+            DialogResult.Yes, DialogResult.Cancel
+         }, string.Empty, string.Empty, string.Empty, defaultButton, doNotShowAgain);
+      }
+
+      private ViewResult showQuestionMessageBox(string message, IReadOnlyList<DialogResult> buttons, string yes, string no, string cancel, ViewResult defaultButton, Action doNotShowAgain = null)
       {
          var currentLocalizer = Localizer.Active;
          try
          {
             Localizer.Active = new XtraMessageBoxLocalizer(yes, no, cancel);
-            return _mapper.MapFrom(XtraMessageBox.Show(createMessageBoxArgs(message, buttons.ToArray(), getIcon(SystemIcons.Question), defaultButtonFrom(defaultButton))));
+            var args = createMessageBoxArgs(message, buttons.ToArray(), getIcon(SystemIcons.Question), defaultButtonFrom(defaultButton), doNotShowAgain != null);
+            args.Closed += (sender, e) => onMessageBoxClosed(e, doNotShowAgain);
+            DialogResult input = XtraMessageBox.Show(args);
+            return _mapper.MapFrom(input);
          }
          finally
          {
             Localizer.Active = currentLocalizer;
+         }
+      }
+
+      private void onMessageBoxClosed(XtraMessageBoxClosedArgs e, Action doNotShowAgain)
+      {
+         // e.Visible gets whether the user checked the 'Do not show this message again' checkbox. Checked makes e.Visible = false 
+         if (!e.Visible && e.DialogResult == DialogResult.Yes)
+         {
+            doNotShowAgain?.Invoke();
          }
       }
 
@@ -124,13 +149,13 @@ namespace OSPSuite.UI.Services
 
       public string AskForFileToOpen(string title, string filter, string directoryKey, string defaultFileName = null, string defaultDirectory = null)
       {
-         var frmDialog = new OpenFileDialog {Multiselect = false};
+         var frmDialog = new OpenFileDialog { Multiselect = false };
          return selectionFor(frmDialog, title, filter, directoryKey, defaultFileName, defaultDirectory);
       }
 
       public string AskForFileToSave(string title, string filter, string directoryKey, string defaultFileName = null, string defaultDirectory = null)
       {
-         var frmDialog = new SaveFileDialog {OverwritePrompt = true};
+         var frmDialog = new SaveFileDialog { OverwritePrompt = true };
          return selectionFor(frmDialog, title, filter, directoryKey, defaultFileName, defaultDirectory);
       }
 
@@ -165,7 +190,7 @@ namespace OSPSuite.UI.Services
 
       public string AskForFolder(string title, string directoryKey, string defaultDirectory = null)
       {
-         using (var folderDialog = new CommonOpenFileDialog {Title = title, InitialDirectory = getInitialDirectory(directoryKey, defaultDirectory)})
+         using (var folderDialog = new CommonOpenFileDialog { Title = title, InitialDirectory = getInitialDirectory(directoryKey, defaultDirectory) })
          {
             folderDialog.IsFolderPicker = true;
             if (folderDialog.ShowDialog() != CommonFileDialogResult.Ok)
@@ -206,6 +231,7 @@ namespace OSPSuite.UI.Services
                case StringId.XtraMessageBoxNoButtonText:
                   return _no;
             }
+
             return string.Empty;
          }
       }

--- a/src/OSPSuite.UI/Services/DialogCreator.cs
+++ b/src/OSPSuite.UI/Services/DialogCreator.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using OSPSuite.Assets;
 
 namespace OSPSuite.UI.Services
 {
@@ -55,7 +56,7 @@ namespace OSPSuite.UI.Services
             DefaultButtonIndex = defaultButtonIndex,
             AllowHtmlText = DefaultBoolean.True,
             DoNotShowAgainCheckBoxVisible = doNotShowAgainCheckBoxVisible,
-            DoNotShowAgainCheckBoxText = UIConstants.DO_NOT_SHOW_THIS_AGAIN_UNTIL_RESTART
+            DoNotShowAgainCheckBoxText = Captions.DoNotShowThisAgainUntilRestart
          };
 
          if (containsHyperlink(message))

--- a/src/OSPSuite.UI/UIConstants.cs
+++ b/src/OSPSuite.UI/UIConstants.cs
@@ -18,10 +18,11 @@ namespace OSPSuite.UI
             return CommonSkins.GetSkin(DevExpress.LookAndFeel.UserLookAndFeel.Default).Colors[state];
          }
       }
-      
+
       public const int TOOL_TIP_INITIAL_DELAY = 500;
       public const int TOOL_TIP_INITIAL_DELAY_LONG = 1500;
       public const string EMPTY_COLUMN = " ";
+      public const string DO_NOT_SHOW_THIS_AGAIN_UNTIL_RESTART = "Do not show this again until restart";
 
       public const double DEFAULT_HTML_FONT_SIZE = 8.25;
 

--- a/src/OSPSuite.UI/UIConstants.cs
+++ b/src/OSPSuite.UI/UIConstants.cs
@@ -22,7 +22,6 @@ namespace OSPSuite.UI
       public const int TOOL_TIP_INITIAL_DELAY = 500;
       public const int TOOL_TIP_INITIAL_DELAY_LONG = 1500;
       public const string EMPTY_COLUMN = " ";
-      public const string DO_NOT_SHOW_THIS_AGAIN_UNTIL_RESTART = "Do not show this again until restart";
 
       public const double DEFAULT_HTML_FONT_SIZE = 8.25;
 

--- a/tests/OSPSuite.Core.Tests/Services/ConfirmationManager.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ConfirmationManager.cs
@@ -1,0 +1,50 @@
+﻿using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+
+namespace OSPSuite.Core.Services
+{
+   public abstract class concern_for_ConfirmationManager : ContextSpecification<IConfirmationManager>
+   {
+      protected override void Context()
+      {
+         sut = new ConfirmationManager();
+      }
+   }
+
+   internal class When_add_a_suppression_flag : concern_for_ConfirmationManager
+   {
+      protected override void Because()
+      {
+         sut.SuppressConfirmation(ConfirmationFlags.ObservedDataEntryRemoved);
+      }
+
+      [Observation]
+      public void should_confirm_this_suppression()
+      {
+         sut.IsConfirmationSuppressed(ConfirmationFlags.ObservedDataEntryRemoved).ShouldBeTrue();
+      }
+   }
+   internal class When_there_is_no_suppression_flag : concern_for_ConfirmationManager
+   {
+      [Observation]
+      public void should_deny_suppressions()
+      {
+         sut.IsConfirmationSuppressed(ConfirmationFlags.ObservedDataEntryRemoved).ShouldBeFalse();
+      }
+   }
+
+    internal class When_add_a_flag_that_already_exists : concern_for_ConfirmationManager
+   {
+      protected override void Because()
+      {
+         sut.SuppressConfirmation(ConfirmationFlags.ObservedDataEntryRemoved);
+         sut.SuppressConfirmation(ConfirmationFlags.ObservedDataEntryRemoved);
+        }
+
+      [Observation]
+      public void should_still_confirm_this_suppression()
+      {
+         sut.IsConfirmationSuppressed(ConfirmationFlags.ObservedDataEntryRemoved);
+      }
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Services/ConfirmationManager.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ConfirmationManager.cs
@@ -33,7 +33,7 @@ namespace OSPSuite.Core.Services
       }
    }
 
-    internal class When_add_a_flag_that_already_exists : concern_for_ConfirmationManager
+    internal class When_adding_a_flag_that_already_exists : concern_for_ConfirmationManager
    {
       protected override void Because()
       {

--- a/tests/OSPSuite.Core.Tests/Services/ConfirmationManagerSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ConfirmationManagerSpecs.cs
@@ -11,7 +11,7 @@ namespace OSPSuite.Core.Services
       }
    }
 
-   internal class When_add_a_suppression_flag : concern_for_ConfirmationManager
+   internal class When_adding_a_suppression_flag : concern_for_ConfirmationManager
    {
       protected override void Because()
       {

--- a/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
@@ -17,6 +17,7 @@ namespace OSPSuite.Core.Services
       protected IDataRepositoryExportTask _dataRepositoryTask;
       protected IContainerTask _containerTask;
       protected IObjectTypeResolver _objectTypeResolver;
+      protected IConfirmationManager _confirmationManager;
       protected DataRepository _obsData1;
       protected DataRepository _obsData2;
       protected List<IUsesObservedData> _allUserOfObservedData = new List<IUsesObservedData>();
@@ -28,8 +29,9 @@ namespace OSPSuite.Core.Services
          _dataRepositoryTask = A.Fake<IDataRepositoryExportTask>();
          _containerTask = A.Fake<IContainerTask>();
          _objectTypeResolver = A.Fake<IObjectTypeResolver>();
+         _confirmationManager = A.Fake<IConfirmationManager>();
 
-         sut = new ObservedDataTaskForSpecs(_dialogCreator, _context, _dataRepositoryTask, _containerTask, _objectTypeResolver);
+         sut = new ObservedDataTaskForSpecs(_dialogCreator, _context, _dataRepositoryTask, _containerTask, _objectTypeResolver, _confirmationManager);
 
          _obsData1 = DomainHelperForSpecs.ObservedData("OBS1");
          _obsData2 = DomainHelperForSpecs.ObservedData("OBS2");
@@ -60,7 +62,7 @@ namespace OSPSuite.Core.Services
       [Observation]
       public void should_throw_an_exception_notifying_the_user_that_no_observed_data_can_be_deleted()
       {
-         The.Action(() => sut.Delete(new[] {_obsData1, _obsData2})).ShouldThrowAn<CannotDeleteObservedDataException>();
+         The.Action(() => sut.Delete(new[] { _obsData1, _obsData2 })).ShouldThrowAn<CannotDeleteObservedDataException>();
       }
    }
 
@@ -88,7 +90,7 @@ namespace OSPSuite.Core.Services
 
       protected override void Because()
       {
-         sut.Delete(new[] {_obsData1, _obsData2});
+         sut.Delete(new[] { _obsData1, _obsData2 });
       }
 
       [Observation]
@@ -131,7 +133,7 @@ namespace OSPSuite.Core.Services
 
       protected override void Because()
       {
-         sut.Delete(new[] {_obsData1, _obsData2}, silent: true);
+         sut.Delete(new[] { _obsData1, _obsData2 }, silent: true);
       }
 
       [Observation]
@@ -143,8 +145,8 @@ namespace OSPSuite.Core.Services
 
    internal class ObservedDataTaskForSpecs : ObservedDataTask
    {
-      public ObservedDataTaskForSpecs(IDialogCreator dialogCreator, IOSPSuiteExecutionContext executionContext, IDataRepositoryExportTask dataRepositoryTask, IContainerTask containerTask, IObjectTypeResolver objectTypeResolver) : base(dialogCreator, executionContext, dataRepositoryTask,
-         containerTask, objectTypeResolver)
+      public ObservedDataTaskForSpecs(IDialogCreator dialogCreator, IOSPSuiteExecutionContext executionContext, IDataRepositoryExportTask dataRepositoryTask, IContainerTask containerTask, IObjectTypeResolver objectTypeResolver, IConfirmationManager confirmationManager) : base(dialogCreator, executionContext, dataRepositoryTask,
+         containerTask, objectTypeResolver, confirmationManager)
       {
       }
 


### PR DESCRIPTION
Fixes #2150 

# Description
To prevent showing the same confirmationmessages over and over again, users can now suppress it when deleting observed data from a simulation until next restart.

For easily expanding this behaviour to more confirmation-messages there is confirmationMessage-type added, which has a checkbox to suppress further confirmations. This accepts a handler which executes when the checkbox is clicked and the action is confirmed. 

There is a service added, the ConfirmationManager, to hold and manage a collection of confirmations to suppress. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![2024-03-19 14_47_46-MoBi® 12 0 0+53e21410768fb2c5dbf152c5e74e0a82e42d1bfa](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/assets/27804639/fc045a97-3ebb-427f-9944-1fe036a0a9a6)

# Questions (if appropriate):