### PR TITLE
2001 exporting observed data incl lloq

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
 using OSPSuite.Core.Commands.Core;
@@ -10,7 +8,11 @@ using OSPSuite.Core.Import;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Command = OSPSuite.Assets.Command;
+using DataColumn = OSPSuite.Core.Domain.Data.DataColumn;
 
 namespace OSPSuite.Core.Domain.Services
 {
@@ -148,7 +150,16 @@ namespace OSPSuite.Core.Domain.Services
             Constants.DirectoryKey.OBSERVED_DATA, observedData.Name);
          if (string.IsNullOrEmpty(file)) return;
 
-         _dataRepositoryExportTask.ExportToExcel(observedData, file, launchExcel: true);
+         var lloqColumns = getLloqColumns(observedData);
+            
+         _dataRepositoryExportTask.ExportToExcel(observedData.Columns.Concat(lloqColumns), file, launchExcel: true);
+      }
+
+      private IEnumerable<DataColumn> getLloqColumns(DataRepository observedData)
+      {
+         return observedData.Columns
+            .Where(c => c.DataInfo.LLOQ != null)
+            .Select(c => new DataColumn($"LLOQ_{c.Name}", c.Dimension, c.BaseGrid) { Value = Convert.ToDouble(c.DataInfo.LLOQ) });
       }
 
       private bool observedDataAlreadyExistsInProject(DataRepository observedData)

--- a/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
@@ -150,12 +150,12 @@ namespace OSPSuite.Core.Domain.Services
             Constants.DirectoryKey.OBSERVED_DATA, observedData.Name);
          if (string.IsNullOrEmpty(file)) return;
 
-         var lloqColumns = getLloqColumns(observedData);
+         var lloqColumns = createLloqColumns(observedData);
             
          _dataRepositoryExportTask.ExportToExcel(observedData.Columns.Concat(lloqColumns), file, launchExcel: true);
       }
 
-      private IEnumerable<DataColumn> getLloqColumns(DataRepository observedData)
+      private IEnumerable<DataColumn> createLloqColumns(DataRepository observedData)
       {
          return observedData.Columns
             .Where(c => c.DataInfo.LLOQ != null)


### PR DESCRIPTION
Fixes #2001

# Description

When exporting observed data to excel, there is no LLOQ-data exported. When this export is import to PKSim or another tool, the LLOQ-information is lost. 

This fixes it by adding columns for every column containing LLOQ-data with the LLOQ-level on each row. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/assets/27804639/4b423eaf-aed1-4457-b692-e322c4106ff7)


# Questions (if appropriate):