### PR TITLE
Fixes #2234 multiselect context menu for sensitivity analysis

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
+++ b/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
@@ -97,7 +97,7 @@ namespace OSPSuite.Core.Domain.Services
             return;
 
          //In this case, we add or replace the top container
-         if (topContainer.ParentPath == null)
+         if (topContainer.ParentPath == null || string.IsNullOrEmpty(topContainer.ParentPath.PathAsString))
             addOrReplaceContainer(topContainer, root);
          else
             insertTopContainerIntoStructure(topContainer, root);

--- a/src/OSPSuite.Presentation/UICommands/RemoveMultipleParameterIdentificationsUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RemoveMultipleParameterIdentificationsUICommand.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public class RemoveMultipleParameterIdentificationsUICommand : ObjectUICommand<IReadOnlyList<ParameterIdentification>>
+   {
+      private readonly IParameterIdentificationTask _parameterIdentificationTask;
+
+      public RemoveMultipleParameterIdentificationsUICommand(IParameterIdentificationTask parameterIdentificationTask)
+      {
+         _parameterIdentificationTask = parameterIdentificationTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         _parameterIdentificationTask.Delete(Subject);
+      }
+   }
+}

--- a/src/OSPSuite.Presentation/UICommands/RemoveMultipleSensitivityAnalysisUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RemoveMultipleSensitivityAnalysisUICommand.cs
@@ -1,0 +1,21 @@
+using OSPSuite.Core.Domain.SensitivityAnalyses;
+using OSPSuite.Core.Domain.Services.SensitivityAnalyses;
+using System.Collections.Generic;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public class RemoveMultipleSensitivityAnalysisUICommand : ObjectUICommand<IReadOnlyList<SensitivityAnalysis>>
+   {
+      private readonly ISensitivityAnalysisTask _sensitivityAnalysisTask;
+
+      public RemoveMultipleSensitivityAnalysisUICommand(ISensitivityAnalysisTask sensitivityAnalysisTask)
+      {
+         _sensitivityAnalysisTask = sensitivityAnalysisTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         _sensitivityAnalysisTask.Delete(Subject);
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2234

# Description

There is a UICommand needed to support the deletion of a multiple sensitivity-analysis at once

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):