### PR TITLE
Fixes #2234 Adds Run-command to single and multiselect context menu for pi objects

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
+++ b/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
@@ -97,7 +97,7 @@ namespace OSPSuite.Core.Domain.Services
             return;
 
          //In this case, we add or replace the top container
-         if (topContainer.ParentPath == null)
+         if (topContainer.ParentPath == null || string.IsNullOrEmpty(topContainer.ParentPath.PathAsString))
             addOrReplaceContainer(topContainer, root);
          else
             insertTopContainerIntoStructure(topContainer, root);

--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
@@ -76,10 +76,19 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
             .WithIcon(ApplicationIcons.AddToJournal);
       }
 
+      public static IMenuBarItem RunParameterIdentification(ParameterIdentification parameterIdentification, IContainer container)
+      {
+         return CreateMenuButton.WithCaption(MenuNames.RunParameterIdentification)
+            .WithIcon(ApplicationIcons.Run)
+            .WithCommandFor<RunParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container);
+      }
+
       public static IEnumerable<IMenuBarItem> ContextMenuItemsFor(ParameterIdentification parameterIdentification, IContainer container)
       {
-         yield return EditParameterIdentification(parameterIdentification, container);
+         yield return RunParameterIdentification(parameterIdentification, container);
 
+         yield return EditParameterIdentification(parameterIdentification, container)
+            .AsGroupStarter();
          yield return RenameParameterIdentification(parameterIdentification, container);
 
          yield return CloneParameterIdentification(parameterIdentification, container)

--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
@@ -89,6 +89,7 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
 
          yield return EditParameterIdentification(parameterIdentification, container)
             .AsGroupStarter();
+
          yield return RenameParameterIdentification(parameterIdentification, container);
 
          yield return CloneParameterIdentification(parameterIdentification, container)

--- a/src/OSPSuite.Presentation/UICommands/RemoveMultipleParameterIdentificationsUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RemoveMultipleParameterIdentificationsUICommand.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public class RemoveMultipleParameterIdentificationsUICommand : ObjectUICommand<IReadOnlyList<ParameterIdentification>>
+   {
+      private readonly IParameterIdentificationTask _parameterIdentificationTask;
+
+      public RemoveMultipleParameterIdentificationsUICommand(IParameterIdentificationTask parameterIdentificationTask)
+      {
+         _parameterIdentificationTask = parameterIdentificationTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         _parameterIdentificationTask.Delete(Subject);
+      }
+   }
+}

--- a/src/OSPSuite.Presentation/UICommands/RunMultipleParameterIdentificationsUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RunMultipleParameterIdentificationsUICommand.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace OSPSuite.Presentation.UICommands
 {
-    public class RunMultipleParameterIdentificationsUICommand : ActiveObjectUICommand<IReadOnlyList<ParameterIdentification>>
+   public class RunMultipleParameterIdentificationsUICommand : ActiveObjectUICommand<IReadOnlyList<ParameterIdentification>>
    {
       private readonly IParameterIdentificationRunner _parameterIdentificationRunner;
 
@@ -17,7 +17,7 @@ namespace OSPSuite.Presentation.UICommands
          IActiveSubjectRetriever activeSubjectRetriever)
          : base(activeSubjectRetriever)
       {
-         this._parameterIdentificationRunner = parameterIdentificationRunner;
+         _parameterIdentificationRunner = parameterIdentificationRunner;
       }
 
       protected override async void PerformExecute()

--- a/src/OSPSuite.Presentation/UICommands/RunMultipleParameterIdentificationsUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RunMultipleParameterIdentificationsUICommand.cs
@@ -1,0 +1,30 @@
+﻿using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Core.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OSPSuite.Presentation.UICommands
+{
+    public class RunMultipleParameterIdentificationsUICommand : ActiveObjectUICommand<IReadOnlyList<ParameterIdentification>>
+   {
+      private readonly IParameterIdentificationRunner _parameterIdentificationRunner;
+
+      public RunMultipleParameterIdentificationsUICommand(
+         IParameterIdentificationRunner parameterIdentificationRunner,
+         IActiveSubjectRetriever activeSubjectRetriever)
+         : base(activeSubjectRetriever)
+      {
+         this._parameterIdentificationRunner = parameterIdentificationRunner;
+      }
+
+      protected override async void PerformExecute()
+      {
+         var tasks = Subject.Select(pi => _parameterIdentificationRunner.SecureAwait(x => x.Run(pi)));
+
+         await Task.WhenAll(tasks);
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/UICommands/RunMultipleParameterIdentificationsUICommandSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/UICommands/RunMultipleParameterIdentificationsUICommandSpecs.cs
@@ -1,0 +1,48 @@
+﻿using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
+using OSPSuite.Core.Services;
+using System.Collections.Generic;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public abstract class concern_for_RunMultipleParameterIdentificationsUICommand : ContextSpecification<RunMultipleParameterIdentificationsUICommand>
+   {
+      protected IObservedDataMetaDataTask _task = A.Fake<IObservedDataMetaDataTask>();
+      protected IReadOnlyList<ParameterIdentification> _repository;
+      protected IParameterIdentificationRunner _parameterIdentificationRunner;
+      protected IActiveSubjectRetriever _activeSubjectRetriever;
+      protected ParameterIdentification _parameterIdentification1;
+      protected ParameterIdentification _parameterIdentification2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterIdentification1 = A.Fake<ParameterIdentification>();
+         _parameterIdentification2 = A.Fake<ParameterIdentification>();
+         _repository = new List<ParameterIdentification> { _parameterIdentification1, _parameterIdentification2 };
+         _parameterIdentificationRunner = A.Fake<IParameterIdentificationRunner>();
+         _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
+         sut = new RunMultipleParameterIdentificationsUICommand(_parameterIdentificationRunner, _activeSubjectRetriever);
+
+         sut.For(_repository);
+      }
+   }
+
+   public class When_running_multiple_Parameter_Identifications : concern_for_RunMultipleParameterIdentificationsUICommand
+   {
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_run_each_parameter_identification_concurrently_in_runner()
+      {
+         A.CallTo(() => _parameterIdentificationRunner.Run(_parameterIdentification1)).MustHaveHappened();
+         A.CallTo(() => _parameterIdentificationRunner.Run(_parameterIdentification2)).MustHaveHappened();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2234

# Description

Adds run-commands to single- and multiselect contextmenu for PI objects. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):