### PR TITLE
Fixes #2241 Allow output selections to be refreshed from a list of selections

### DIFF
--- a/src/OSPSuite.Presentation/DTO/QuantitySelectionDTO.cs
+++ b/src/OSPSuite.Presentation/DTO/QuantitySelectionDTO.cs
@@ -39,10 +39,10 @@ namespace OSPSuite.Presentation.DTO
 
       public bool Selected
       {
-         get { return _selected; }
+         get => _selected;
          set
          {
-            //this check is extremly important to avoid raising Selected event too many time 
+            //this check is extremely important to avoid raising Selected event too many times
             //which may result in total rebind of the UI
             if (_selected == value)
                return;

--- a/src/OSPSuite.Presentation/Presenters/QuantitySelectionPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/QuantitySelectionPresenter.cs
@@ -63,6 +63,12 @@ namespace OSPSuite.Presentation.Presenters
       ///    If sets to true, empty path columns will be hidden automatically. Default is false
       /// </summary>
       bool AutomaticallyHideEmptyColumns { get; set; }
+
+      /// <summary>
+      /// Clears the current selection and refreshes using any quantities from <paramref name="selections"/>
+      /// that are available in the simulation where the paths match
+      /// </summary>
+      void UpdateSelection(IReadOnlyList<QuantitySelection> selections);
    }
 
    public class QuantitySelectionPresenter : AbstractPresenter<IQuantitySelectionView, IQuantitySelectionPresenter>, IQuantitySelectionPresenter
@@ -114,6 +120,24 @@ namespace OSPSuite.Presentation.Presenters
          selectedDTO.Each(dto => dto.Selected = true);
       }
 
+      public void UpdateSelection(IReadOnlyList<QuantitySelection> selections)
+      {
+         DeselectAll();
+         selections.Each(select);
+         refreshView();
+      }
+
+      private void select(QuantitySelection outputSelection)
+      {
+         var dto = _allQuantityListPresenter.QuantityDTOByPath(outputSelection.Path);
+
+         if (dto == null) 
+            return;
+
+         _selectedQuantityListPresenter.Add(dto);
+         dto.Selected = true;
+      }
+
       private void updateSelection(object sender, QuantitySelectionChangedEventArgs e)
       {
          var selectedQuantities = e.QuantitySelections.ToList();
@@ -140,7 +164,7 @@ namespace OSPSuite.Presentation.Presenters
 
       public void DeselectAll()
       {
-         //cache locally as UpdateSelection will be triggerd
+         //cache locally as UpdateSelection will be triggered
          var allMolecules = _selectedQuantityListPresenter.AllQuantityDTOs.ToList();
          _selectedQuantityListPresenter.UpdateSelection(allMolecules, selected: false);
       }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/QuantitySelectionPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/QuantitySelectionPresenterSpecs.cs
@@ -10,7 +10,7 @@ using OSPSuite.Presentation.Views;
 
 namespace OSPSuite.Presentation.Presentation
 {
-   public abstract class concern_for_QuantitySelectionPresenter : ContextSpecification<IQuantitySelectionPresenter>
+   public abstract class concern_for_QuantitySelectionPresenter : ContextSpecification<QuantitySelectionPresenter>
    {
       protected IQuantitySelectionView _view;
       protected IContainer _simulation;
@@ -85,7 +85,7 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
-   public class When_the_simulation_quantity_selection_presenter_is_being_notifed_that_the_selection_has_changed : concern_for_QuantitySelectionPresenter
+   public class When_the_simulation_quantity_selection_presenter_is_being_notified_that_the_selection_has_changed : concern_for_QuantitySelectionPresenter
    {
       private QuantitySelectionDTO _quantityDTO1;
       private QuantitySelectionDTO _quantityDTO2;
@@ -157,6 +157,42 @@ namespace OSPSuite.Presentation.Presentation
       public void should_expand_the_groups_in_all_sub_presenters()
       {
          _allQuantityPresenter.ExpandAllGroups.ShouldBeTrue();
+      }
+   }
+
+   public class When_updating_selections_from_a_list : concern_for_QuantitySelectionPresenter
+   {
+      private IReadOnlyList<QuantitySelection> _quantityList;
+      private QuantitySelectionDTO _dto;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new QuantitySelectionDTO();
+         var toto = new QuantitySelection("toto", QuantityType.Drug);
+         _quantityList = new List<QuantitySelection>
+         {
+            toto
+         };
+
+         A.CallTo(() => _allQuantityPresenter.QuantityDTOByPath(toto.Path)).Returns(_dto);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateSelection(_quantityList);
+      }
+
+      [Observation]
+      public void the_quantity_must_be_selected()
+      {
+         A.CallTo(() => _selectedQuantityPresenter.Add(_dto)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_existing_selections_are_cleared()
+      {
+         A.CallTo(() => _selectedQuantityPresenter.UpdateSelection(A<IReadOnlyList<QuantitySelectionDTO>>._, false)).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #2241

# Description
The presenter needs a way to refresh the selected outputs from a list to accommodate https://github.com/Open-Systems-Pharmacology/MoBi/issues/1296

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):