### PR TITLE
Fixes #2227 Sensitivity Analysis window does not close on completion

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/SensitivityAnalyses/SensitivityAnalysisFeedbackPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/SensitivityAnalyses/SensitivityAnalysisFeedbackPresenter.cs
@@ -44,6 +44,7 @@ namespace OSPSuite.Presentation.Presenters.SensitivityAnalyses
       public void Handle(SensitivityAnalysisTerminatedEvent eventToHandle)
       {
          _view.ResetFeedback();
+         _view.Hide();
       }
 
       public void Handle(SensitivityAnalysisProgressEvent eventToHandle)


### PR DESCRIPTION
Fixes #2227

# Description

The SensitivityAnalysisFeedbackView can be opened by a buttonclick in the ribbon. When the SI stops this view reverts to the starting view (inital view indicating that there is no SI running), but does not close the window. 

The fix is to hide the view on termination of the SI. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [x] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):