### PR TITLE
Fixes #2176 Data importer: error when "Reload under the same settings"

### DIFF
--- a/src/OSPSuite.Presentation/Services/DataImporter.cs
+++ b/src/OSPSuite.Presentation/Services/DataImporter.cs
@@ -112,8 +112,13 @@ namespace OSPSuite.Presentation.Services
       public override bool AreFromSameMetaDataCombination(DataRepository sourceDataRepository, DataRepository targetDataRepository)
       {
          // do not compare the file name when checking for equivalent metadata
-         return targetDataRepository.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
-            hasEquivalentMetaData(sourceDataRepository.ExtendedProperties, keyValuePair)
+         return compareMetaData(sourceDataRepository, targetDataRepository) && compareMetaData(targetDataRepository, sourceDataRepository);
+      }
+
+      private static bool compareMetaData(DataRepository repositoryOne, DataRepository repository2)
+      {
+         return repository2.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
+            hasEquivalentMetaData(repositoryOne.ExtendedProperties, keyValuePair)
          );
       }
 

--- a/src/OSPSuite.Presentation/Services/DataImporter.cs
+++ b/src/OSPSuite.Presentation/Services/DataImporter.cs
@@ -114,11 +114,11 @@ namespace OSPSuite.Presentation.Services
          return compareMetaData(sourceDataRepository, targetDataRepository) && compareMetaData(targetDataRepository, sourceDataRepository);
       }
 
-      private static bool compareMetaData(DataRepository repositoryOne, DataRepository repository2)
+      private static bool compareMetaData(DataRepository firstRepository, DataRepository secondRepository)
       {
          // do not compare the file name when checking for equivalent metadata
-         return repository2.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
-            hasEquivalentMetaData(repositoryOne.ExtendedProperties, keyValuePair)
+         return secondRepository.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
+            hasEquivalentMetaData(firstRepository.ExtendedProperties, keyValuePair)
          );
       }
 

--- a/src/OSPSuite.Presentation/Services/DataImporter.cs
+++ b/src/OSPSuite.Presentation/Services/DataImporter.cs
@@ -111,12 +111,12 @@ namespace OSPSuite.Presentation.Services
 
       public override bool AreFromSameMetaDataCombination(DataRepository sourceDataRepository, DataRepository targetDataRepository)
       {
-         // do not compare the file name when checking for equivalent metadata
          return compareMetaData(sourceDataRepository, targetDataRepository) && compareMetaData(targetDataRepository, sourceDataRepository);
       }
 
       private static bool compareMetaData(DataRepository repositoryOne, DataRepository repository2)
       {
+         // do not compare the file name when checking for equivalent metadata
          return repository2.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
             hasEquivalentMetaData(repositoryOne.ExtendedProperties, keyValuePair)
          );

--- a/src/OSPSuite.Presentation/Services/DataImporter.cs
+++ b/src/OSPSuite.Presentation/Services/DataImporter.cs
@@ -111,10 +111,15 @@ namespace OSPSuite.Presentation.Services
 
       public override bool AreFromSameMetaDataCombination(DataRepository sourceDataRepository, DataRepository targetDataRepository)
       {
-         return targetDataRepository.ExtendedProperties.KeyValues.All(keyValuePair =>
-            keyValuePair.Key == Constants.FILE || //Ignore source file
-            Equals(sourceDataRepository.ExtendedProperties[keyValuePair.Key].ValueAsObject, keyValuePair.Value.ValueAsObject)
+         // do not compare the file name when checking for equivalent metadata
+         return targetDataRepository.ExtendedProperties.KeyValues.Where(x => !Equals(x.Key, Constants.FILE)).All(keyValuePair =>
+            hasEquivalentMetaData(sourceDataRepository.ExtendedProperties, keyValuePair)
          );
+      }
+
+      private static bool hasEquivalentMetaData(ExtendedProperties sourceExtendedProperties, KeyValuePair<string, IExtendedProperty> keyValuePair)
+      {
+         return sourceExtendedProperties.Contains(keyValuePair.Key) && Equals(sourceExtendedProperties[keyValuePair.Key].ValueAsObject, keyValuePair.Value.ValueAsObject);
       }
 
       private bool repositoryExistsInList(IEnumerable<DataRepository> dataRepositoryList, DataRepository targetDataRepository)

--- a/tests/OSPSuite.UI.Tests/Services/DataImporterSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Services/DataImporterSpecs.cs
@@ -25,8 +25,6 @@ namespace OSPSuite.UI.Services
       protected IReadOnlyList<DataRepository> _existingDataSets;
       protected IReadOnlyList<DataRepository> _dataSetsToImport;
 
-
-
       public override void GlobalContext()
       {
          base.GlobalContext();
@@ -38,21 +36,46 @@ namespace OSPSuite.UI.Services
 
          A.CallTo(() => _applicationController.Start<IImporterReloadPresenter>()).Returns(_reloadPresenter);
          A.CallTo(() => _reloadPresenter.Canceled()).Returns(false);
-
       }
 
       protected override void Context()
       {
-         _existingDataSets = new List<DataRepository>()
+         _existingDataSets = new List<DataRepository>
          {
-            new DataRepository()
+            new DataRepository
             {
                Name = "repo1",
                ExtendedProperties =
                {
-                  new ExtendedProperty<string>() {Name = "Sheet", Value = "Sheet1"},
-                  new ExtendedProperty<string>() {Name = "Organ", Value = "Organ1"},
-                  new ExtendedProperty<string>() {Name = "Patient", Value = "Patient1"},
+                  new ExtendedProperty<string> { Name = "Sheet", Value = "Sheet1" },
+                  new ExtendedProperty<string> { Name = "Organ", Value = "Organ1" },
+                  new ExtendedProperty<string> { Name = "Patient", Value = "Patient1" },
+                  new ExtendedProperty<string> { Name = Constants.FILE, Value = "File1" }
+               }
+            },
+            new DataRepository
+            {
+               Name = "repo2",
+               ExtendedProperties =
+               {
+                  new ExtendedProperty<string> { Name = "Sheet", Value = "Sheet2" },
+                  new ExtendedProperty<string> { Name = "Organ", Value = "Organ2" },
+                  new ExtendedProperty<string> { Name = "Patient", Value = "Patient2" },
+                  new ExtendedProperty<string> { Name = Constants.FILE, Value = "File2" }
+               }
+            }
+         };
+         _dataSetsToImport = new List<DataRepository>
+         {
+            new DataRepository
+            {
+               Name = "repo1",
+               ExtendedProperties =
+               {
+                  new ExtendedProperty<string> { Name = "Sheet", Value = "Sheet1" },
+                  new ExtendedProperty<string> { Name = "Organ", Value = "Organ1" },
+                  new ExtendedProperty<string> { Name = "Patient", Value = "Patient1" },
+                  new ExtendedProperty<string> { Name = Constants.FILE, Value = "File1" }
                }
             },
             new DataRepository()
@@ -60,40 +83,17 @@ namespace OSPSuite.UI.Services
                Name = "repo2",
                ExtendedProperties =
                {
-                  new ExtendedProperty<string>() {Name = "Sheet", Value = "Sheet2"},
-                  new ExtendedProperty<string>() {Name = "Organ", Value = "Organ2"},
-                  new ExtendedProperty<string>() {Name = "Patient", Value = "Patient2"},
+                  new ExtendedProperty<string> { Name = "Sheet", Value = "Sheet2" },
+                  new ExtendedProperty<string> { Name = "Organ", Value = "Organ2" },
+                  new ExtendedProperty<string> { Name = "Patient", Value = "Patient2" },
+                  new ExtendedProperty<string> { Name = Constants.FILE, Value = "File2" }
                }
             }
          };
-         _dataSetsToImport = new List<DataRepository>()
-         {
-            new DataRepository()
-            {
-               Name = "repo1",
-               ExtendedProperties =
-               {
-                  new ExtendedProperty<string>() {Name = "Sheet", Value = "Sheet1"},
-                  new ExtendedProperty<string>() {Name = "Organ", Value = "Organ1"},
-                  new ExtendedProperty<string>() {Name = "Patient", Value = "Patient1"},
-               }
-            },
-            new DataRepository()
-            {
-               Name = "repo2",
-               ExtendedProperties =
-               {
-                  new ExtendedProperty<string>() {Name = "Sheet", Value = "Sheet2"},
-                  new ExtendedProperty<string>() {Name = "Organ", Value = "Organ2"},
-                  new ExtendedProperty<string>() {Name = "Patient", Value = "Patient2"},
-               }
-            }
-         };
-         sut = new DataImporter(_dialogCreator, _importer , _applicationController, _dimensionFactory);
+         sut = new DataImporter(_dialogCreator, _importer, _applicationController, _dimensionFactory);
       }
    }
 
-   
    public class When_reloading_only_existing_data_sets : concern_for_DataImporter
    {
       private ReloadDataSets _result;
@@ -124,6 +124,51 @@ namespace OSPSuite.UI.Services
       }
    }
 
+   public class When_reloading_a_data_set_with_only_file_name_changed : concern_for_DataImporter
+   {
+      private ReloadDataSets _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _existingDataSets.FirstOrDefault(x => x.Name == "repo2").ExtendedProperties[Constants.FILE].ValueAsObject = "Another file";
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CalculateReloadDataSetsFromConfiguration(_dataSetsToImport, _existingDataSets);
+      }
+
+      [Test]
+      public void should_return_no_new_data_sets()
+      {
+         _result.NewDataSets.Count().ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_reloading_a_data_set_with_new_meta_data : concern_for_DataImporter
+   {
+      private ReloadDataSets _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _existingDataSets.FirstOrDefault(x => x.Name == "repo2").ExtendedProperties.Remove("Organ");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CalculateReloadDataSetsFromConfiguration(_dataSetsToImport, _existingDataSets);
+      }
+
+      [Test]
+      public void should_return_one_new_data_set()
+      {
+         _result.NewDataSets.Count().ShouldBeEqualTo(1);
+         _result.NewDataSets.Any(x => x.Name == "repo2").ShouldBeTrue();
+      }
+   }
+
    public class When_reloading_one_new_data_set_one_data_set_to_be_deleted : concern_for_DataImporter
    {
       private ReloadDataSets _result;
@@ -133,7 +178,6 @@ namespace OSPSuite.UI.Services
          base.Context();
          _dataSetsToImport.FirstOrDefault(x => x.Name == "repo2").ExtendedProperties["Organ"].ValueAsObject = "Organ3";
          _dataSetsToImport.FirstOrDefault(x => x.Name == "repo2").Name = "repo3";
-
       }
 
       protected override void Because()

--- a/tests/OSPSuite.UI.Tests/Services/DataImporterSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Services/DataImporterSpecs.cs
@@ -169,6 +169,29 @@ namespace OSPSuite.UI.Services
       }
    }
 
+   public class When_reloading_a_data_set_with_removed_meta_data : concern_for_DataImporter
+   {
+      private ReloadDataSets _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dataSetsToImport.FirstOrDefault(x => x.Name == "repo2").ExtendedProperties.Remove("Organ");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CalculateReloadDataSetsFromConfiguration(_dataSetsToImport, _existingDataSets);
+      }
+
+      [Test]
+      public void should_return_one_new_data_set()
+      {
+         _result.NewDataSets.Count().ShouldBeEqualTo(1);
+         _result.NewDataSets.Any(x => x.Name == "repo2").ShouldBeTrue();
+      }
+   }
+
    public class When_reloading_one_new_data_set_one_data_set_to_be_deleted : concern_for_DataImporter
    {
       private ReloadDataSets _result;


### PR DESCRIPTION
Fixes #2176

# Description
A calculation is made to determine if data sets are equivalent or not, one of the checks is to make sure that all the metadata is the same. In the case from the issue the metadata are different in that there is additional metadata in the new import rather than just different values. That was not taken into account

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):