### PR TITLE
#1301 Add Initialize property to ToolTipController Extensions

### DIFF
--- a/src/OSPSuite.UI/Controls/UxTreeView.cs
+++ b/src/OSPSuite.UI/Controls/UxTreeView.cs
@@ -13,6 +13,7 @@ using OSPSuite.Assets;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Nodes;
 using OSPSuite.Presentation.Views;
+using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Mappers;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Collections;
@@ -64,6 +65,7 @@ namespace OSPSuite.UI.Controls
          ToolTipForNode = node => node.ToolTip;
          ToolTipController = new ToolTipController();
          ToolTipController.GetActiveObjectInfo += (o, e) => ShowToolTip(e);
+         ToolTipController.Initialize();
          OptionsMenu.ShowExpandCollapseItems = false;
       }
 

--- a/src/OSPSuite.UI/Extensions/ToolTipControllerExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/ToolTipControllerExtensions.cs
@@ -12,12 +12,18 @@ namespace OSPSuite.UI.Extensions
          toolTipController.ShowBeak = false;
          toolTipController.AllowHtmlText = true;
          toolTipController.ImageList = imageListRetriever.AllImages16x16;
-         toolTipController.AutoPopDelay = 300000;
          toolTipController.InitialDelay = delayInMilliseconds;
+         toolTipController.Initialize();
          return toolTipController;
       }
 
-      public static ToolTipController For(this ToolTipController toolTipController, EditorContainer editorContainer)
+      public static ToolTipController Initialize(this ToolTipController toolTipController)
+      {
+          toolTipController.AutoPopDelay = 300000;
+          return toolTipController;
+      }
+
+        public static ToolTipController For(this ToolTipController toolTipController, EditorContainer editorContainer)
       {
          editorContainer.ToolTipController = toolTipController;
          return toolTipController;


### PR DESCRIPTION
Fixes #2254

# Description

Added Initialize property with default value for property AutoPopDelay = 300000

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):