### PR TITLE
Fixes #2258 Module merge behavior "Extend" does not work

### DIFF
--- a/src/OSPSuite.Core/Domain/ModuleConfiguration.cs
+++ b/src/OSPSuite.Core/Domain/ModuleConfiguration.cs
@@ -38,8 +38,6 @@ namespace OSPSuite.Core.Domain
       /// <param name="module">Module</param>
       public ModuleConfiguration(Module module) : this(module, module.InitialConditionsCollection.FirstOrDefault(), module.ParameterValuesCollection.FirstOrDefault())
       {
-         Module = module;
-         MergeBehavior = module.DefaultMergeBehavior;
       }
 
       /// <summary>
@@ -51,6 +49,7 @@ namespace OSPSuite.Core.Domain
       public ModuleConfiguration(Module module, InitialConditionsBuildingBlock selectedInitialConditionBuilding, ParameterValuesBuildingBlock selectedParameterValues)
       {
          Module = module;
+         MergeBehavior = module.DefaultMergeBehavior;
          SelectedInitialConditions = selectedInitialConditionBuilding;
          SelectedParameterValues = selectedParameterValues;
       }

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -80,6 +80,44 @@ namespace OSPSuite.Core
       }
    }
 
+   internal class When_running_the_case_study_for_module_integration_with_merge_behavior_override_to_extend : concern_for_ModuleIntegration
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _simulationConfiguration = IoC.Resolve<ModuleHelperForSpecs>().CreateSimulationConfigurationForExtendMergeBehaviorOverridingModuleBehavior();
+         _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
+      }
+
+      [Observation]
+      public void should_have_added_the_missing_parameters_to_lung()
+      {
+         var lung = _model.Root.EntityAt<Container>(Constants.ORGANISM, Lung);
+         lung.Parameter(P2).Value.ShouldBeEqualTo(10);
+      }
+
+      [Observation]
+      public void should_have_updating_existing_parameters()
+      {
+         var lung = _model.Root.EntityAt<Container>(Constants.ORGANISM, Lung);
+         lung.Parameter(Q).Value.ShouldBeEqualTo(5);
+      }
+
+      [Observation]
+      public void should_have_kept_parameters_defined_in_the_source_container()
+      {
+         var lung = _model.Root.EntityAt<Container>(Constants.ORGANISM, Lung);
+         lung.Parameter(P).Value.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_have_added_the_existing_container()
+      {
+         var lung = _model.Root.EntityAt<Container>(Constants.ORGANISM, Lung);
+         lung.Container(Interstitial).ShouldNotBeNull();
+      }
+   }
+
    internal class When_running_the_case_study_for_module_integration_with_merge_behavior_extend : concern_for_ModuleIntegration
    {
       public override void GlobalContext()

--- a/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
@@ -63,8 +63,26 @@ namespace OSPSuite.Helpers
          var module1 = createModule1();
          var module2 = createModule2();
 
+         module2.DefaultMergeBehavior = MergeBehavior.Extend;
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
-         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2) {MergeBehavior = MergeBehavior.Extend});
+         // Using this constructor to validate that the merge behavior is set correctly
+         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2, null, null));
+         return simulationConfiguration;
+      }
+
+      public SimulationConfiguration CreateSimulationConfigurationForExtendMergeBehaviorOverridingModuleBehavior()
+      {
+         var simulationConfiguration = new SimulationConfiguration
+         {
+            SimulationSettings = createSimulationConfiguration(),
+         };
+
+         var module1 = createModule1();
+         var module2 = createModule2();
+
+         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
+         // Using this constructor to validate that the merge behavior is set correctly
+         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2, null, null) { MergeBehavior = MergeBehavior.Extend });
          return simulationConfiguration;
       }
 
@@ -79,7 +97,9 @@ namespace OSPSuite.Helpers
          var module5 = createModule5();
 
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module4));
-         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module5) { MergeBehavior = MergeBehavior.Extend });
+         module5.DefaultMergeBehavior = MergeBehavior.Extend;
+         // Using this constructor to validate that the merge behavior is set correctly
+         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module5));
          return simulationConfiguration;
       }
 
@@ -343,7 +363,7 @@ namespace OSPSuite.Helpers
 
       private SimulationSettings createSimulationConfiguration()
       {
-         return new SimulationSettings {Solver = _solverSettingsFactory.CreateCVODE(), OutputSchema = _outputSchemaFactory.CreateDefault(), OutputSelections = new OutputSelections()};
+         return new SimulationSettings { Solver = _solverSettingsFactory.CreateCVODE(), OutputSchema = _outputSchemaFactory.CreateDefault(), OutputSelections = new OutputSelections() };
       }
 
       private Module createModule4()
@@ -387,7 +407,6 @@ namespace OSPSuite.Helpers
          organism.Add(art);
 
 
-         
          var lung = createContainerWithName(Lung);
          var lngPlasma = createContainerWithName(Plasma, ContainerMode.Physical);
          lngPlasma.Add(newConstantParameter(Volume, 2));
@@ -458,7 +477,7 @@ namespace OSPSuite.Helpers
          artInterstitial.Add(newConstantParameter(P, 12));
          art.AddChildren(artPlasma, artInterstitial);
          organism.Add(art);
-         
+
 
          var lng = createContainerWithName(Lung);
          var lngPlasma = createContainerWithName(Plasma, ContainerMode.Physical);


### PR DESCRIPTION
Fixes #2258 

# Description
I think the intention of the ModuleConfiguration.MergeBehavior property is to allow the configuration to override the module default. In this case, one of the constructors was not initializing the configuration MergeBehavior to be read from the Module.DefaultMergeBehavior

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):