### PR TITLE
Fixes #2260 Formulas are not applied correctly

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -4,6 +4,7 @@ using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Mappers;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Core.Domain.Services
@@ -126,7 +127,7 @@ namespace OSPSuite.Core.Domain.Services
          }
 
          //If the value is defined, this will be used instead of the formula (even if set previously)
-         if (pathAndValueEntity.Value.HasValue && !double.IsNaN(pathAndValueEntity.Value.Value))
+         if (pathAndValueEntity.Value.IsValid())
          {
             var parameterValue = pathAndValueEntity.Value.Value;
             if (parameter.Formula is ConstantFormula constantFormula)

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -126,7 +126,7 @@ namespace OSPSuite.Core.Domain.Services
          }
 
          //If the value is defined, this will be used instead of the formula (even if set previously)
-         if (pathAndValueEntity.Value != null)
+         if (pathAndValueEntity.Value.HasValue && !double.IsNaN(pathAndValueEntity.Value.Value))
          {
             var parameterValue = pathAndValueEntity.Value.Value;
             if (parameter.Formula is ConstantFormula constantFormula)

--- a/src/OSPSuite.Core/Extensions/DoubleExtensions.cs
+++ b/src/OSPSuite.Core/Extensions/DoubleExtensions.cs
@@ -84,5 +84,9 @@ namespace OSPSuite.Core.Extensions
          return EqualsByTolerance(value, equalValue, 1e-10);
       }
 
+      public static bool IsValid(this double? value)
+      {
+         return value.HasValue && value.Value.IsValid();
+      }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
@@ -487,6 +487,29 @@ namespace OSPSuite.Core
       }
    }
 
+   internal class When_a_parameter_value_is_defined_with_formula_and_nan_value : concern_for_ModelConstructor
+   {
+      private ParameterValue _parameterValue;
+
+      protected override void Context()
+      {
+         base.Context();
+         var simulationBuilder = new SimulationBuilder(_simulationConfiguration);
+
+         _parameterValue = simulationBuilder.ParameterValues.First(x => x.Name.Equals("FormulaParameterOverwritten"));
+         _parameterValue.Value = double.NaN;
+         _parameterValue.Formula = new ExplicitFormula("1");
+      }
+
+      [Observation]
+      public void should_not_overwrite_the_formula_with_NaN_fixed_value()
+      {
+         var targetParameter = _parameterValue.Path.TryResolve<IParameter>(_result.Model.Root);
+         targetParameter.IsFixedValue.ShouldBeFalse();
+         targetParameter.Value.ShouldNotBeEqualTo(double.NaN);
+      }
+   }
+
    internal class When_a_initial_condition_is_defined_for_logical_container : concern_for_ModelConstructor
    {
       protected override void Context()


### PR DESCRIPTION
Fixes #2261 Cannot create simulation when a module overwrites a value of a parameter with a formula
Fixes #2260

# Description
Checking that a defined start value is not NaN before using it as fixed value in a simulation parameter

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):