### PR TITLE
Fixes #2266 Remove ability for ModuleConfiguration to override Defaul…

### DIFF
--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -48,10 +48,7 @@ namespace OSPSuite.Core.Domain
 
       public string PKSimVersion { get; set; }
 
-      /// <summary>
-      /// This is the Default Merge Behavior for the module that can be overwritten when using a module in a module configuration
-      /// </summary>
-      public MergeBehavior DefaultMergeBehavior { get; set; } = MergeBehavior.Overwrite;
+      public MergeBehavior MergeBehavior { get; set; } = MergeBehavior.Overwrite;
 
       public EventGroupBuildingBlock EventGroups => buildingBlockByType<EventGroupBuildingBlock>();
       public MoleculeBuildingBlock Molecules => buildingBlockByType<MoleculeBuildingBlock>();
@@ -109,7 +106,7 @@ namespace OSPSuite.Core.Domain
          sourceModule.BuildingBlocks.Select(cloneManager.Clone).Each(Add);
          PKSimVersion = sourceModule.PKSimVersion;
          ModuleImportVersion = sourceModule.ModuleImportVersion;
-         DefaultMergeBehavior = sourceModule.DefaultMergeBehavior;
+         MergeBehavior = sourceModule.MergeBehavior;
       }
 
       public void Add(IBuildingBlock buildingBlock)

--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -51,7 +51,6 @@ namespace OSPSuite.Core.Domain
       public string PKSimVersion { get; set; }
 
       public MergeBehavior MergeBehavior { get; set; } = MergeBehavior.Overwrite;
-      /// <summary>
 
       public EventGroupBuildingBlock EventGroups => buildingBlockByType<EventGroupBuildingBlock>();
       public MoleculeBuildingBlock Molecules => buildingBlockByType<MoleculeBuildingBlock>();

--- a/src/OSPSuite.Core/Domain/ModuleConfiguration.cs
+++ b/src/OSPSuite.Core/Domain/ModuleConfiguration.cs
@@ -22,9 +22,9 @@ namespace OSPSuite.Core.Domain
       public ParameterValuesBuildingBlock SelectedParameterValues { get; set; }
 
       /// <summary>
-      /// Merge behavior for merging spatial structures form different modules. Default value will be taken from the module
+      /// Merge behavior for merging spatial structures from different modules.
       /// </summary>
-      public MergeBehavior MergeBehavior { get; set; } 
+      public MergeBehavior MergeBehavior => Module.MergeBehavior;
 
       [Obsolete("For serialization")]
       public ModuleConfiguration()
@@ -49,7 +49,6 @@ namespace OSPSuite.Core.Domain
       public ModuleConfiguration(Module module, InitialConditionsBuildingBlock selectedInitialConditionBuilding, ParameterValuesBuildingBlock selectedParameterValues)
       {
          Module = module;
-         MergeBehavior = module.DefaultMergeBehavior;
          SelectedInitialConditions = selectedInitialConditionBuilding;
          SelectedParameterValues = selectedParameterValues;
       }
@@ -89,7 +88,6 @@ namespace OSPSuite.Core.Domain
          if (!(source is ModuleConfiguration sourceConfiguration))
             return;
 
-         MergeBehavior = sourceConfiguration.MergeBehavior;
          Module = cloneManager.Clone(sourceConfiguration.Module);
          SelectedInitialConditions = Module.InitialConditionsCollection.FindByName(sourceConfiguration.SelectedInitialConditions?.Name);
          SelectedParameterValues = Module.ParameterValuesCollection.FindByName(sourceConfiguration.SelectedParameterValues?.Name);

--- a/src/OSPSuite.Core/Serialization/Xml/ModuleConfigurationXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/ModuleConfigurationXmlSerializer.cs
@@ -8,7 +8,6 @@ namespace OSPSuite.Core.Serialization.Xml
       {
          //TODO is this right? Or is this a real instance of a module?
          Map(x => x.Module);
-         Map(x => x.MergeBehavior);
          MapReference(x => x.SelectedInitialConditions);
          MapReference(x => x.SelectedParameterValues);
       }

--- a/src/OSPSuite.Core/Serialization/Xml/ModuleXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/ModuleXmlSerializer.cs
@@ -10,7 +10,7 @@ namespace OSPSuite.Core.Serialization.Xml
          MapEnumerable(x => x.BuildingBlocks, x => x.Add);
          Map(x => x.PKSimVersion);
          Map(x => x.ModuleImportVersion);
-         Map(x => x.DefaultMergeBehavior);
+         Map(x => x.MergeBehavior);
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/ModuleConfigurationSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ModuleConfigurationSpecs.cs
@@ -32,7 +32,7 @@ namespace OSPSuite.Core.Domain
          _parameterValuesBuildingBlock = new ParameterValuesBuildingBlock();
          _module.Add(_parameterValuesBuildingBlock);
 
-         _module.DefaultMergeBehavior = MergeBehavior.Overwrite;
+         _module.MergeBehavior = MergeBehavior.Overwrite;
 
          sut = new ModuleConfiguration(_module);
       }
@@ -51,17 +51,6 @@ namespace OSPSuite.Core.Domain
       {
          sut.SelectedInitialConditions.ShouldBeEqualTo(_initialConditionsBuildingBlock1);
          sut.SelectedParameterValues.ShouldBeEqualTo(_parameterValuesBuildingBlock);
-      }
-   }
-
-   public class When_setting_the_merge_behavior_on_the_module_configuration : concern_for_ModuleConfiguration
-   {
-      [Observation]
-      public void should_not_change_the_default_merge_behavior_in_the_underlying_module()
-      {
-         sut.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
-         sut.MergeBehavior = MergeBehavior.Extend;
-         _module.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
       }
    }
 
@@ -95,9 +84,8 @@ namespace OSPSuite.Core.Domain
 
          sut.SelectedInitialConditions = _initialConditionsBuildingBlock2;
          sut.SelectedParameterValues = null;
-         sut.Module.DefaultMergeBehavior = MergeBehavior.Extend;
+         sut.Module.MergeBehavior = MergeBehavior.Extend;
          sut.Module.ModuleImportVersion = "1.2.3";
-         sut.MergeBehavior = MergeBehavior.Extend;
       }
 
       protected override void Because()
@@ -118,7 +106,7 @@ namespace OSPSuite.Core.Domain
       {
          _result.Module.ShouldNotBeEqualTo(sut.Module);
          _result.Module.Name.ShouldBeEqualTo(sut.Module.Name);
-         _result.Module.DefaultMergeBehavior.ShouldBeEqualTo(sut.Module.DefaultMergeBehavior);
+         _result.Module.MergeBehavior.ShouldBeEqualTo(sut.Module.MergeBehavior);
          _result.Module.ModuleImportVersion.ShouldBeEqualTo(sut.Module.ModuleImportVersion);
          _result.MergeBehavior.ShouldBeEqualTo(sut.MergeBehavior);
       }

--- a/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
@@ -63,7 +63,7 @@ namespace OSPSuite.Helpers
          var module1 = createModule1();
          var module2 = createModule2();
 
-         module2.DefaultMergeBehavior = MergeBehavior.Extend;
+         module2.MergeBehavior = MergeBehavior.Extend;
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
          // Using this constructor to validate that the merge behavior is set correctly
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2, null, null));
@@ -79,10 +79,10 @@ namespace OSPSuite.Helpers
 
          var module1 = createModule1();
          var module2 = createModule2();
+         module2.MergeBehavior = MergeBehavior.Extend;
 
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
-         // Using this constructor to validate that the merge behavior is set correctly
-         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2, null, null) { MergeBehavior = MergeBehavior.Extend });
+         simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2, null, null));
          return simulationConfiguration;
       }
 
@@ -97,7 +97,7 @@ namespace OSPSuite.Helpers
          var module5 = createModule5();
 
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module4));
-         module5.DefaultMergeBehavior = MergeBehavior.Extend;
+         module5.MergeBehavior = MergeBehavior.Extend;
          // Using this constructor to validate that the merge behavior is set correctly
          simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module5));
          return simulationConfiguration;


### PR DESCRIPTION
Fixes #2266 

# Description
There was a separate setter/getter on module configuration for merge behavior, but now this is just delegated to the module since it cannot be changed

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):