### PR TITLE
#2271 the 'version' property of modules doesn't include the mergebehavior setting

### DIFF
--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -80,8 +80,9 @@ namespace OSPSuite.Core.Domain
 
       private string versionCalculation(IEnumerable<IBuildingBlock> buildingBlocks)
       {
-         // Use OrderBy to ensure alphabetical ordering of the typed versions
-         return string.Join(string.Empty, buildingBlocks.Select(typedVersionFor).OrderBy(x => x).ToArray()).GetHashCode().ToString();
+          // Use OrderBy to ensure alphabetical ordering of the typed versions
+          var plainVersionString = string.Concat(buildingBlocks.Select(typedVersionFor).OrderBy(x => x).ToArray()) + (int)MergeBehavior;
+          return plainVersionString.GetHashCode().ToString();
       }
 
       private static string typedVersionFor(IBuildingBlock x)

--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -80,9 +80,14 @@ namespace OSPSuite.Core.Domain
 
       private string versionCalculation(IEnumerable<IBuildingBlock> buildingBlocks)
       {
+          return string.Concat(typedVersionConcat(buildingBlocks), (int)MergeBehavior)
+              .GetHashCode().ToString();
+      }
+      
+      private static string typedVersionConcat(IEnumerable<IBuildingBlock> buildingBlocks)
+      {
           // Use OrderBy to ensure alphabetical ordering of the typed versions
-          var plainVersionString = string.Concat(buildingBlocks.Select(typedVersionFor).OrderBy(x => x).ToArray()) + (int)MergeBehavior;
-          return plainVersionString.GetHashCode().ToString();
+          return string.Concat(buildingBlocks.Select(typedVersionFor).OrderBy(x => x).ToArray());
       }
 
       private static string typedVersionFor(IBuildingBlock x)

--- a/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
@@ -323,6 +323,33 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_changing_the_merge_behavior : concern_for_Module
+   {
+       private string _preChangeVersion;
+
+       protected override void Context()
+       {
+           sut = new Module
+           {
+               new ParameterValuesBuildingBlock(),
+               new EventGroupBuildingBlock()
+           };
+
+           _preChangeVersion = sut.Version;
+       }
+
+       protected override void Because()
+       {
+           sut.MergeBehavior = MergeBehavior.Extend;
+       }
+
+       [Observation]
+       public void the_version_should_not_match()
+       {
+           sut.Version.ShouldNotBeEqualTo(_preChangeVersion);
+       }
+   }
+
    public class When_testing_if_the_extension_module_is_not_a_pk_sim_module : concern_for_Module
    {
       [Observation]


### PR DESCRIPTION
Fixes #2271 

# Description

Added the MergeBehavior-value to take into account when calculate the version-hash

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):