### PR TITLE
#2286 double click does not open PI

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
@@ -85,10 +85,11 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
 
       public static IEnumerable<IMenuBarItem> ContextMenuItemsFor(ParameterIdentification parameterIdentification, IContainer container)
       {
-         yield return RunParameterIdentification(parameterIdentification, container);
+         yield return EditParameterIdentification(parameterIdentification, container);
+            
 
-         yield return EditParameterIdentification(parameterIdentification, container)
-            .AsGroupStarter();
+         yield return RunParameterIdentification(parameterIdentification, container)
+            .AsGroupStarter(); 
 
          yield return RenameParameterIdentification(parameterIdentification, container);
 


### PR DESCRIPTION
Fixes #2286

# Description

Double click is triggering first menu which is "Run", changed it to "Edit"

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/54d15763-2cd8-437f-be1e-ff68c4a62e70)



# Questions (if appropriate):