### PR TITLE
#2302 add serialization property IsPKSimModule

### DIFF
--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -40,7 +40,7 @@ namespace OSPSuite.Core.Domain
       private IReadOnlyList<T> buildingBlocksByType<T>() where T : IBuildingBlock => _buildingBlocks.OfType<T>().ToList();
 
       /// <summary>
-      ///    Module is a PKSim module if created in PKSim
+      ///    Module is a PKSim module if created in PKSim 
       /// </summary>
       public bool IsPKSimModule { get; set; }
 

--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -40,8 +40,7 @@ namespace OSPSuite.Core.Domain
       private IReadOnlyList<T> buildingBlocksByType<T>() where T : IBuildingBlock => _buildingBlocks.OfType<T>().ToList();
 
       /// <summary>
-      ///    Module is a PKSim module if created in PKSim and the module version
-      ///    matches the version when it was first imported
+      ///    Module is a PKSim module if created in PKSim
       /// </summary>
       public bool IsPKSimModule { get; set; }
 

--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -36,7 +36,6 @@ namespace OSPSuite.Core.Domain
    public class Module : ObjectBase, IEnumerable<IBuildingBlock>
    {
       private readonly List<IBuildingBlock> _buildingBlocks = new List<IBuildingBlock>();
-
       private T buildingBlockByType<T>() where T : IBuildingBlock => _buildingBlocks.OfType<T>().SingleOrDefault();
       private IReadOnlyList<T> buildingBlocksByType<T>() where T : IBuildingBlock => _buildingBlocks.OfType<T>().ToList();
 
@@ -44,7 +43,7 @@ namespace OSPSuite.Core.Domain
       ///    Module is a PKSim module if created in PKSim and the module version
       ///    matches the version when it was first imported
       /// </summary>
-      public bool IsPKSimModule => !string.IsNullOrEmpty(PKSimVersion) && Equals(Version, ModuleImportVersion);
+      public bool IsPKSimModule { get; set; }
 
       public string ModuleImportVersion { get; set; }
 
@@ -115,6 +114,7 @@ namespace OSPSuite.Core.Domain
          PKSimVersion = sourceModule.PKSimVersion;
          ModuleImportVersion = sourceModule.ModuleImportVersion;
          MergeBehavior = sourceModule.MergeBehavior;
+         IsPKSimModule = sourceModule.IsPKSimModule;
       }
 
       public void Add(IBuildingBlock buildingBlock)

--- a/src/OSPSuite.Core/Serialization/Xml/ModuleXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/ModuleXmlSerializer.cs
@@ -11,6 +11,7 @@ namespace OSPSuite.Core.Serialization.Xml
          Map(x => x.PKSimVersion);
          Map(x => x.ModuleImportVersion);
          Map(x => x.MergeBehavior);
+         Map(x => x.IsPKSimModule);
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
-using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
@@ -326,29 +325,29 @@ namespace OSPSuite.Core.Domain
 
    public class When_changing_the_merge_behavior : concern_for_Module
    {
-       private string _preChangeVersion;
+      private string _preChangeVersion;
 
-       protected override void Context()
-       {
-           sut = new Module
-           {
-               new ParameterValuesBuildingBlock(),
-               new EventGroupBuildingBlock()
-           };
+      protected override void Context()
+      {
+         sut = new Module
+         {
+            new ParameterValuesBuildingBlock(),
+            new EventGroupBuildingBlock()
+         };
 
-           _preChangeVersion = sut.Version;
-       }
+         _preChangeVersion = sut.Version;
+      }
 
-       protected override void Because()
-       {
-           sut.MergeBehavior = MergeBehavior.Extend;
-       }
+      protected override void Because()
+      {
+         sut.MergeBehavior = MergeBehavior.Extend;
+      }
 
-       [Observation]
-       public void the_version_should_not_match()
-       {
-           sut.Version.ShouldNotBeEqualTo(_preChangeVersion);
-       }
+      [Observation]
+      public void the_version_should_not_match()
+      {
+         sut.Version.ShouldNotBeEqualTo(_preChangeVersion);
+      }
    }
 
    public class When_testing_if_the_extension_module_is_not_a_pk_sim_module : concern_for_Module
@@ -375,7 +374,7 @@ namespace OSPSuite.Core.Domain
          sut.IsPKSimModule.ShouldBeFalse();
       }
    }
-  
+
    public class When_checking_for_can_add : concern_for_Module
    {
       protected override void Context()

--- a/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ModuleSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
+using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
@@ -374,23 +375,7 @@ namespace OSPSuite.Core.Domain
          sut.IsPKSimModule.ShouldBeFalse();
       }
    }
-
-   public class When_testing_if_the_pk_sim_module_is_a_pk_sim_module : concern_for_Module
-   {
-      protected override void Context()
-      {
-         base.Context();
-         sut.PKSimVersion = "1";
-         sut.ModuleImportVersion = sut.Version;
-      }
-
-      [Observation]
-      public void the_module_indicates_it_is_a_pk_sim_module()
-      {
-         sut.IsPKSimModule.ShouldBeTrue();
-      }
-   }
-
+  
    public class When_checking_for_can_add : concern_for_Module
    {
       protected override void Context()


### PR DESCRIPTION
Fixes #2302

# Description

Add serialization property IsPKSimModule so that it can set on PkSim export and used in Mobi Import and change.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):