### PR TITLE
Fixes #2310 Confusing behavior of comparison view when editing a distributed parameter in the individuals BB

### DIFF
--- a/src/OSPSuite.Core/Comparison/BuildingBlockDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/BuildingBlockDiffBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
@@ -6,9 +7,9 @@ namespace OSPSuite.Core.Comparison
 {
    public abstract class BuildingBlockDiffBuilder<TBuildingBlock, TBuilder> : DiffBuilder<TBuildingBlock> where TBuildingBlock : class, IBuildingBlock<TBuilder> where TBuilder : class, IBuilder
    {
-      private readonly ObjectBaseDiffBuilder _objectBaseDiffBuilder;
+      protected readonly ObjectBaseDiffBuilder _objectBaseDiffBuilder;
       protected readonly EnumerableComparer _enumerableComparer;
-      private readonly Func<TBuilder, object> _equalityProperty;
+      protected readonly Func<TBuilder, object> _equalityProperty;
       protected Func<TBuilder, string> _presentObjectDetailsFunc;
 
       protected BuildingBlockDiffBuilder(ObjectBaseDiffBuilder objectBaseDiffBuilder,
@@ -27,7 +28,12 @@ namespace OSPSuite.Core.Comparison
       public override void Compare(IComparison<TBuildingBlock> comparison)
       {
          _objectBaseDiffBuilder.Compare(comparison);
-         _enumerableComparer.CompareEnumerables(comparison, x => x, _equalityProperty, _presentObjectDetailsFunc);
+         _enumerableComparer.CompareEnumerables(comparison, GetBuilders, _equalityProperty, _presentObjectDetailsFunc);
+      }
+
+      protected virtual IEnumerable<TBuilder> GetBuilders(TBuildingBlock buildingBlock)
+      {
+         return buildingBlock;
       }
    }
 

--- a/src/OSPSuite.Core/Comparison/PathAndValueEntityBuildingBlockDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/PathAndValueEntityBuildingBlockDiffBuilder.cs
@@ -1,4 +1,8 @@
-﻿using OSPSuite.Core.Domain.Builder;
+﻿using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Extensions;
 
 namespace OSPSuite.Core.Comparison
 {
@@ -7,6 +11,17 @@ namespace OSPSuite.Core.Comparison
    {
       protected PathAndValueEntityBuildingBlockDiffBuilder(ObjectBaseDiffBuilder objectBaseDiffBuilder, EnumerableComparer enumerableComparer) : base(objectBaseDiffBuilder, enumerableComparer, x => x.Path)
       {
+
+      }
+
+      protected override IEnumerable<TBuilder> GetBuilders(TBuildingBlock buildingBlock)
+      {
+         return base.GetBuilders(buildingBlock).Where(x => !isSubParameter(x, buildingBlock.Where(parameter => parameter.IsDistributed()).Select(parameter => parameter.Path)));
+      }
+
+      private bool isSubParameter(TBuilder pathAndValueEntity, IEnumerable<ObjectPath> distributedPaths)
+      {
+         return distributedPaths.Any(x => pathAndValueEntity.ContainerPath.Equals(x));
       }
    }
 

--- a/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
@@ -26,9 +26,17 @@ namespace OSPSuite.Core.Comparison
 
          CompareValues(x => x.ContainerPath, x => x.ContainerPath, comparison);
 
-         // Always Compare Value and Formula, independent from settings as these are two different properties of a start value
-         CompareNullableDoubleValues(x => x.Value, x => x.Value, comparison, x => x.DisplayUnit);
-         _objectComparer.Compare(comparison.FormulaComparison());
+         // if the distribution types are different then we cannot compare values since the value
+         // of a distributed PathAndValueEntity is not fully calculated until  it is turned into
+         // a parameter
+         if(!comparison.Object1.DistributionType.Equals(comparison.Object2.DistributionType))
+            CompareValues(x => x.DistributionType, x => x.DistributionType, comparison);
+         else
+         {
+            // Always Compare Value and Formula, independent of settings as these are two different properties of a start value
+            CompareNullableDoubleValues(x => x.Value, x => x.Value, comparison, x => x.DisplayUnit);
+            _objectComparer.Compare(comparison.FormulaComparison());
+         }
       }
    }
 
@@ -38,7 +46,6 @@ namespace OSPSuite.Core.Comparison
 
       protected StartValueDiffBuilder(IObjectComparer objectComparer, EntityDiffBuilder entityDiffBuilder, WithValueOriginComparison<T> valueOriginComparison) :base(objectComparer, entityDiffBuilder)
       {
-
          _valueOriginComparison = valueOriginComparison;
       }
 

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/StartValueBuildingBlockDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/StartValueBuildingBlockDiffBuilderSpecs.cs
@@ -158,4 +158,78 @@ namespace OSPSuite.Core.DiffBuilders
          _report[1].DowncastTo<MissingDiffItem>().PresentObjectDetails.Contains("10").ShouldBeTrue();
       }
    }
+
+   public class When_comparing_parameter_values_building_blocks_with_distributed_parameters_that_have_sub_parameter_differences : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var initialConditionsBuildingBlock1 = new InitialConditionsBuildingBlock().WithName("Tada");
+         var initialConditionA = new InitialCondition().WithName("MSVa");
+         initialConditionA.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionA.DistributionType = DistributionType.Normal;
+         var initialConditionB = new InitialCondition().WithName("MSVb");
+         initialConditionB.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionsBuildingBlock1.Add(initialConditionA);
+         initialConditionsBuildingBlock1.Add(initialConditionB);
+         initialConditionsBuildingBlock1.Add(new InitialCondition
+         {
+            Path = new ObjectPath("Root", "Liver", "Plasma", "MSVa", "Median"),
+         });
+
+
+         var initialConditionsBuildingBlock2 = new InitialConditionsBuildingBlock().WithName("Tada");
+         initialConditionA = new InitialCondition().WithName("MSVa");
+         initialConditionA.DistributionType = DistributionType.Normal;
+         initialConditionA.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionB = new InitialCondition().WithName("MSVb");
+         initialConditionB.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+
+         initialConditionsBuildingBlock2.Add(initialConditionA);
+         initialConditionsBuildingBlock2.Add(initialConditionB);
+
+         _object1 = initialConditionsBuildingBlock1;
+         _object2 = initialConditionsBuildingBlock2;
+      }
+
+      [Observation]
+      public void should_not_report_any_differences()
+      {
+         _report.ShouldBeEmpty();
+      }
+   }
+
+   public class When_comparing_parameter_values_building_blocks_with_distributed_parameters_that_have_different_distribution_types : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var initialConditionsBuildingBlock1 = new InitialConditionsBuildingBlock().WithName("Tada");
+         var initialConditionA = new InitialCondition().WithName("MSVa");
+         initialConditionA.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionA.DistributionType = DistributionType.Normal;
+         var initialConditionB = new InitialCondition().WithName("MSVb");
+         initialConditionB.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionsBuildingBlock1.Add(initialConditionA);
+         initialConditionsBuildingBlock1.Add(initialConditionB);
+
+         var initialConditionsBuildingBlock2 = new InitialConditionsBuildingBlock().WithName("Tada");
+         initialConditionA = new InitialCondition().WithName("MSVa");
+         initialConditionA.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+         initialConditionB = new InitialCondition().WithName("MSVb");
+         initialConditionB.ContainerPath = new ObjectPath("Root", "Liver", "Plasma");
+
+         initialConditionsBuildingBlock2.Add(initialConditionA);
+         initialConditionsBuildingBlock2.Add(initialConditionB);
+
+         _object1 = initialConditionsBuildingBlock1;
+         _object2 = initialConditionsBuildingBlock2;
+      }
+
+      [Observation]
+      public void should_report_the_different_distribution_type()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+      }
+   }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/StartValueDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/StartValueDiffBuilderSpecs.cs
@@ -293,4 +293,33 @@ namespace OSPSuite.Core.DiffBuilders
          _report.Count.ShouldBeEqualTo(1);
       }
    }
+
+   public class When_comparing_two_initial_conditions_with_different_distribution_type : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+
+         var msv1 = new InitialCondition().WithName("Tada").WithFormula(new ConstantFormula(2));
+         msv1.Path = new ObjectPath("Root", "Liver", "Plasma");
+         msv1.IsPresent = true;
+         msv1.ScaleDivisor = 10;
+         
+         var msv2 = new InitialCondition().WithName("Tada").WithFormula(new ConstantFormula(2));
+         msv2.Path = new ObjectPath("Root", "Liver", "Plasma");
+         msv2.IsPresent = true;
+         msv2.ScaleDivisor = 10;
+
+         msv2.DistributionType = DistributionType.Normal;
+
+         _object1 = msv1;
+         _object2 = msv2;
+      }
+
+      [Observation]
+      public void should_not_report_any_differences()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2310

# Description
Changing the way differences in distribution types are shown during diff building.

I'm proposing that we do not compare the values if the distribution types are different. At the level of PathAndValueEntity we cannot calculate the ultimate parameter value since we need to recreate the parameter structure to get it. We do that in other places, but during comparison, I wonder if it's necessary.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/5f579fa5-fd10-4af3-aa95-8bbc5f982fa6)


# Questions (if appropriate):