### PR TITLE
Fixes #2312 Error when a molecule is applied in an Application and the molecule is not in the MoleucleBuilding block

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1905,9 +1905,9 @@ namespace OSPSuite.Assets
          return $"Multiple {notificationType}s were found for '{builderName}'";
       }
 
-      public static string ApplicatedMoleculeNotPresent(string moleculeName, string applicationBuilderName, string moleculeBuildingBlock)
+      public static string ApplicatedMoleculeNotPresent(string moleculeName, string applicationBuilderName)
       {
-         return $"Molecule: '{moleculeName}' applicated by Application builder {applicationBuilderName} is not definde in Molecules Building Block {moleculeBuildingBlock}";
+         return $"Molecule: '{moleculeName}' applicated by Application builder {applicationBuilderName} is not present in simulation";
       }
 
       public static string ValueGreaterThanMinSizeInPixelAndLessThanMaxSizeIsRequiredOrEmpty(int minSizeInPixel, int maxSizeInPixel)

--- a/src/OSPSuite.Core/Domain/Services/EventBuilderTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/EventBuilderTask.cs
@@ -93,7 +93,7 @@ namespace OSPSuite.Core.Domain.Services
          var eventGroup = _eventGroupMapper.MapFrom(eventGroupBuilder, simulationBuilder);
          sourceContainer.Add(eventGroup);
 
-         //needs to add the requires transport into model only for the added event group
+         //needs to add the required transport into model only for the added event group
          foreach (var childEventGroup in eventGroup.GetAllContainersAndSelf<EventGroup>())
          {
             var childEventGroupBuilder = simulationBuilder.BuilderFor(childEventGroup).DowncastTo<EventGroupBuilder>();

--- a/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
@@ -34,9 +34,19 @@ namespace OSPSuite.Core.Services
          _moleculeBuildingBlock = new MoleculeBuildingBlock().WithName("Molecules");
          _moleculeBuildingBlock.Add(new MoleculeBuilder().WithName("A"));
 
-         var module = new Module
+         var moleculeModule = new Module
          {
             _moleculeBuildingBlock,
+            new ObserverBuildingBlock(),
+            new PassiveTransportBuildingBlock(),
+            new ReactionBuildingBlock(),
+            new SpatialStructure(),
+            new InitialConditionsBuildingBlock(),
+            new ParameterValuesBuildingBlock()
+         };
+
+         var eventModule = new Module
+         {
             new ObserverBuildingBlock(),
             new PassiveTransportBuildingBlock(),
             new ReactionBuildingBlock(),
@@ -47,7 +57,8 @@ namespace OSPSuite.Core.Services
          };
 
          _simulationConfiguration = new SimulationConfiguration();
-         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module));
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(moleculeModule));
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(eventModule));
 
       }
 
@@ -70,7 +81,7 @@ namespace OSPSuite.Core.Services
             m.NotificationType.Equals(NotificationType.Error) &&
             m.BuildingBlock.Equals(_eventBuildingBlock) &&
             m.Object.Equals(_applicationBuilder) &&
-            m.Text.Equals(Validation.ApplicatedMoleculeNotPresent(_applicationBuilder.MoleculeName, _applicationBuilder.Name, _moleculeBuildingBlock.Name))).ShouldBeTrue();
+            m.Text.Equals(Validation.ApplicatedMoleculeNotPresent(_applicationBuilder.MoleculeName, _applicationBuilder.Name))).ShouldBeTrue();
       }
    }
 }


### PR DESCRIPTION
Fixes #2312

# Description
This particular validation requires that we look in all the modules to validate whether or not an application applies a not-present molecule. Formerly, with only one BB of each type, this was never needed

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):