### PR TITLE
Fixes #2314 Initial conditions from modules are not applied

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -93,8 +93,10 @@ namespace OSPSuite.Core.Domain.Builder
          cacheMoleculeDependentBuilders(x => x.Observers, _observers);
          _molecules.AddRange(allBuilder(x => x.Molecules));
          _parameterValues.AddRange(allStartValueBuilder(x => x.SelectedParameterValues));
-         _initialConditions.AddRange(allStartValueBuilder(x => x.SelectedInitialConditions)
-            .Concat(_simulationConfiguration.ExpressionProfiles.SelectMany(x => x.InitialConditions)));
+
+         // Concat order is important so that the values from expression profiles are overwritten if duplicated
+         _initialConditions.AddRange(_simulationConfiguration.ExpressionProfiles.SelectMany(x => x.InitialConditions)
+            .Concat(allStartValueBuilder(x => x.SelectedInitialConditions)));
       }
 
       private void cacheMoleculeDependentBuilders<T>(Func<Module, IBuildingBlock<T>> propAccess, ObjectBaseCache<T> cache) where T : class, IMoleculeDependentBuilder

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
@@ -27,6 +27,8 @@ namespace OSPSuite.Core.Domain
       private ModuleConfiguration _moduleConfiguration1;
       private ModuleConfiguration _moduleConfiguration2;
       private ObserverBuilder _observerBuilder;
+      private ExpressionProfileBuildingBlock _expressionProfileBuildingBlock;
+      private InitialConditionsBuildingBlock _initialConditionsBuildingBlock;
 
       protected override void Context()
       {
@@ -40,8 +42,28 @@ namespace OSPSuite.Core.Domain
          _moduleConfiguration1.Module.Observers.AmountObserverBuilders.Each(x => x.MoleculeList.AddMoleculeName("molecule1"));
          _moduleConfiguration2.Module.Observers.AmountObserverBuilders.Each(x => x.MoleculeList.AddMoleculeName("molecule2"));
 
+
+         _expressionProfileBuildingBlock = new ExpressionProfileBuildingBlock
+         {
+            new InitialCondition { Value = 1.0 }.WithName("name")
+         };
+
+         _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock
+         {
+            new InitialCondition { Value = 2.0 }.WithName("name")
+         };
+         _simulationConfiguration.AddExpressionProfile(_expressionProfileBuildingBlock);
+         _moduleConfiguration2.Module.Add(_initialConditionsBuildingBlock);
+         _moduleConfiguration2.SelectedInitialConditions = _initialConditionsBuildingBlock;
+
          sut = new SimulationBuilder(_simulationConfiguration);
          _observerBuilder = _moduleConfiguration2.Module.Observers.AmountObserverBuilders.First();
+      }
+
+      [Observation]
+      public void the_initial_condition_should_take_priority_over_the_expression()
+      {
+         sut.InitialConditions.Single().Value.ShouldBeEqualTo(2.0);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2314 

# Description
Just adjusting the merge order for IC's that come from expressions vs, those that come from IC building blocks

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):