### PR TITLE
Fixes #2318 A reaction is not shown as a top-level container

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ReactionCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ReactionCreator.cs
@@ -50,11 +50,7 @@ namespace OSPSuite.Core.Domain.Services
       private void createReactionPropertiesContainer(ReactionBuilder reactionBuilder, ModelConfiguration modelConfiguration)
       {
          var (model, simulationBuilder, replacementContext) = modelConfiguration;
-
-         //Do we have non local parameters in this container? If not, no need to create a global container
-         if (reactionBuilder.Parameters.All(x => x.BuildMode == ParameterBuildMode.Local))
-            return;
-
+         
          var globalReactionContainer = _containerTask.CreateOrRetrieveSubContainerByName(model.Root, reactionBuilder.Name)
             .WithContainerType(ContainerType.Reaction)
             .WithIcon(reactionBuilder.Icon)

--- a/tests/OSPSuite.Core.Tests/Domain/ReactionCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ReactionCreatorSpecs.cs
@@ -5,7 +5,6 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Descriptors;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Helpers;
 
 namespace OSPSuite.Core.Domain
 {
@@ -39,10 +38,12 @@ namespace OSPSuite.Core.Domain
          _model = A.Fake<IModel>();
          _simulationConfiguration = new SimulationConfiguration();
          _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
-         _reactionBuilder = new ReactionBuilder();
-         _reactionBuilder.ContainerCriteria = new DescriptorCriteria();
-         _reactionBuilder.Description = "A great description";
-         _reactionBuilder.Name = "Reaction";
+         _reactionBuilder = new ReactionBuilder
+         {
+            ContainerCriteria = new DescriptorCriteria(),
+            Description = "A great description",
+            Name = "Reaction"
+         };
          _educt1 = new ReactionPartnerBuilder
          {
             MoleculeName = "sp1"
@@ -80,9 +81,9 @@ namespace OSPSuite.Core.Domain
    internal class When_creating_the_reaction_based_on_a_given_builder_in_a_container_hierarchy_without_global_parameters_in_the_reaction : When_creating_the_reaction_based_on_a_given_builder_in_a_container_hierarchy
    {
       [Observation]
-      public void the_global_container_is_not_created()
+      public void the_global_container_is_created()
       {
-         A.CallTo(() => _containerTask.CreateOrRetrieveSubContainerByName(_rootContainer, _reactionBuilder.Name)).MustNotHaveHappened();
+         A.CallTo(() => _containerTask.CreateOrRetrieveSubContainerByName(_rootContainer, _reactionBuilder.Name)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #2318 

# Description
These root level reaction containers were always excluded from the model until this request was made to see the empty containers in the root.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):