### PR TITLE
Fixes #2331 hiearchy of parmaeter value does not work with distribute…

### DIFF
--- a/src/OSPSuite.Core/Domain/Formulas/DiscreteDistributionFormula.cs
+++ b/src/OSPSuite.Core/Domain/Formulas/DiscreteDistributionFormula.cs
@@ -13,7 +13,8 @@ namespace OSPSuite.Core.Domain.Formulas
       protected override double CalculateFor(IReadOnlyList<IObjectReference> usedObjects, IUsingFormula dependentObject)
       {
          var distributedParameter = dependentObject.ConvertedTo<IDistributedParameter>();
-         return CalculateValueFromPercentile(distributedParameter.Percentile, distributedParameter);
+         //percentile not used in this formula
+         return CalculateValueFromPercentile(Constants.DEFAULT_PERCENTILE, distributedParameter);
       }
 
       public override double CalculatePercentileForValue(double value, IUsingFormula refObject)

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -112,7 +112,7 @@ namespace OSPSuite.Core.Domain.Services
 
          simulationBuilder.AddBuilderReference(parameter, parameterValue);
 
-         //now we remove the parameter by name form the parent container just in case it already exists but with a different type (distributed vs not distributed)
+         //now we remove the parameter by name from the parent container just in case it already exists but with a different type (distributed vs not distributed)
          var potentialParameter = parentContainer.Parameter(parameterValue.Name);
          parentContainer.RemoveChild(potentialParameter);
 

--- a/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
+++ b/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
@@ -109,4 +109,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Services\" />
+  </ItemGroup>
 </Project>

--- a/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
@@ -1,0 +1,180 @@
+﻿using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Helpers;
+using OSPSuite.Utility.Container;
+using static OSPSuite.Core.Domain.Constants.Distribution;
+using IContainer = OSPSuite.Core.Domain.IContainer;
+
+namespace OSPSuite.Core.Services
+{
+   internal abstract class concern_for_QuantityValuesUpdaterIntegration : ContextForIntegration<IQuantityValuesUpdater>
+   {
+      protected ISpatialStructureFactory _spatialStructureFactory;
+      protected IObjectBaseFactory _objectBaseFactory;
+      protected ModelHelperForSpecs _modelHelper;
+      protected SpatialStructure _spatialStructure;
+      protected IModel _model;
+      protected IContainer _organism;
+      protected IContainer _liver;
+      protected IParameter _parameter;
+      protected SimulationConfiguration _simulationConfiguration;
+      protected SimulationBuilder _simulationBuilder;
+      protected Module _module;
+      protected ParameterValuesBuildingBlock _parameterValues;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _spatialStructureFactory = IoC.Resolve<ISpatialStructureFactory>();
+         _objectBaseFactory = IoC.Resolve<IObjectBaseFactory>();
+         _modelHelper = IoC.Resolve<ModelHelperForSpecs>();
+         _simulationConfiguration = new SimulationConfiguration();
+         _parameterValues = new ParameterValuesBuildingBlock();
+
+         _spatialStructure = _spatialStructureFactory.Create();
+         _organism = _objectBaseFactory.Create<IContainer>()
+            .WithName("Organism")
+            .WithMode(ContainerMode.Logical);
+
+         _liver = _objectBaseFactory.Create<IContainer>()
+            .WithName("Liver")
+            .WithMode(ContainerMode.Physical);
+
+         _parameter = _modelHelper.NewConstantParameter("Param", 10);
+         _liver.Add(_parameter);
+
+         _organism.Add(_liver);
+
+         _model = new Model();
+         _model.Root = _organism;
+
+         _simulationConfiguration = new SimulationConfiguration();
+
+
+         _module = new Module();
+
+         _spatialStructure.AddTopContainer(_organism);
+      }
+
+      protected override void Context()
+      {
+         sut = IoC.Resolve<QuantityValuesUpdater>();
+      }
+   }
+
+   internal class When_updating_the_value_of_a_parameter_value_defined_as_formula_using_a_discrete_distributed_parameter : concern_for_QuantityValuesUpdaterIntegration
+   {
+      private ModelConfiguration _modelConfiguration;
+      private ModuleConfiguration _moduleConfiguration;
+      private ParameterValue _meanParameterValue;
+      private ParameterValue _distributedParameterValue;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _distributedParameterValue = new ParameterValue
+         {
+            DistributionType = DistributionType.Discrete,
+            Name = "Param",
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name),
+         };
+
+         _meanParameterValue = new ParameterValue
+         {
+            Name = MEAN,
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name, _parameter.Name),
+            Value = 20
+         };
+
+         _parameterValues.Add(_distributedParameterValue);
+         _parameterValues.Add(_meanParameterValue);
+
+         _moduleConfiguration = new ModuleConfiguration(_module, null, _parameterValues);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration);
+         _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
+         _modelConfiguration = new ModelConfiguration(_model, _simulationConfiguration, _simulationBuilder);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateQuantitiesValues(_modelConfiguration);
+      }
+
+      [Observation]
+      public void should_overwrite_the_parameter_value_with_mean_value_of_the_parameter()
+      {
+         var parameter = _model.Root.EntityAt<IParameter>("Liver", "Param");
+         parameter.Value.ShouldBeEqualTo(20);
+      }
+   }
+
+   internal class When_updating_the_value_of_a_parameter_value_defined_as_formula_using_a_normal_distributed_parameter : concern_for_QuantityValuesUpdaterIntegration
+   {
+      private ModelConfiguration _modelConfiguration;
+      private ModuleConfiguration _moduleConfiguration;
+      private ParameterValue _meanParameterValue;
+      private ParameterValue _distributedParameterValue;
+      private ParameterValue _deviationParameterValue;
+      private ParameterValue _percentileParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _distributedParameterValue = new ParameterValue
+         {
+            DistributionType = DistributionType.Normal,
+            Name = "Param",
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name),
+         };
+
+         _meanParameterValue = new ParameterValue
+         {
+            Name = MEAN,
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name, _parameter.Name),
+            Value = 20
+         };
+
+         _deviationParameterValue = new ParameterValue
+         {
+            Name = DEVIATION,
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name, _parameter.Name),
+            Value = 5
+         };
+
+         _percentileParameter = new ParameterValue
+         {
+            Name = PERCENTILE,
+            ContainerPath = new ObjectPath(_organism.Name, _liver.Name, _parameter.Name),
+            Value = 0.8
+         };
+
+         _parameterValues.Add(_distributedParameterValue);
+         _parameterValues.Add(_meanParameterValue);
+         _parameterValues.Add(_deviationParameterValue);
+         _parameterValues.Add(_percentileParameter);
+
+         _moduleConfiguration = new ModuleConfiguration(_module, null, _parameterValues);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration);
+         _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
+         _modelConfiguration = new ModelConfiguration(_model, _simulationConfiguration, _simulationBuilder);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateQuantitiesValues(_modelConfiguration);
+      }
+
+      [Observation]
+      public void should_overwrite_the_parameter_value_with_the_value_of_the_parameter()
+      {
+         var parameter = _model.Root.EntityAt<IParameter>("Liver", "Param");
+         parameter.Value.ShouldBeEqualTo(24.28, 1e-2);
+      }
+   }
+}


### PR DESCRIPTION
…d parameters

Fixes #2331

# Description

Well this was a tricky one! As I expected, the issue is because we are updating a NON_DISTRIBUTED Parameter by a DISTRIBUTED_PARAMETER. it works if the parameter does not exist because it's created. But in the case outlined by @PavelBal , the parameter was created by the other Module and therefore the update routine did not work. This PR removes the existing parameters if they don't have the same structure and add them again

Spent most of the time trying to reproduce the bug.. as always :)

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):