### PR TITLE
#2334 Comparing populaitons not showing ok

### DIFF
--- a/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
@@ -108,6 +108,7 @@ namespace OSPSuite.Presentation.Mappers
             displayIf<ObjectPath>(diffItem, x => ancestorDisplayName(diffItem)) ??
             displayIf<ValuePoint>(diffItem, x => ancestorDisplayName(diffItem)) ??
             displayIf<PathAndValueEntity>(diffItem, x => x.Name) ??
+            displayIf<ExtendedProperty<string>>(diffItem, x => x.DisplayName) ??
             _displayNameProvider.DisplayNameFor(diffItem.Object1);
       }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DiffItemToDiffItemDTOMapperSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DiffItemToDiffItemDTOMapperSpecs.cs
@@ -64,7 +64,30 @@ namespace OSPSuite.Presentation.Presentation
       {
          A.CallTo(() => _pathAndValueEntityToPathElementsMapper.MapFrom(_diffItem.Object1 as InitialCondition)).MustHaveHappened();
       }
+   }
 
+   public class When_mapping_an_extended_property : concern_for_DiffItemToDiffItemDTOMapper
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _diffItem = new PropertyValueDiffItem
+         {
+            Object1 = new ExtendedProperty<string> { Name = "Name1", Value = "vale1" },
+            Object2 = new ExtendedProperty<string> { Name = "Name1", Value = "vale2" },
+            FormattedValue1 = "xx",
+            FormattedValue2 = "yy",
+            CommonAncestor = _container,
+            PropertyName = "ABC"
+         };
+      }
+
+      [Observation]
+      public void the_extended_property_shows_the_displayName()
+      {
+         _dto.PathElements.ShouldBeEqualTo(_pathElements);
+         _dto.ObjectName.ShouldBeEqualTo("Name1");
+      }
    }
 
    public class When_mapping_a_property_diff_item_for_an_entity_to_a_diff_item_dto : concern_for_DiffItemToDiffItemDTOMapper


### PR DESCRIPTION
Fixes #2334 

# Description

Comparing individuals from different populations not showing the values as they should.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/786c0c91-8d0b-469d-930e-3f72afb5ff7a)


# Questions (if appropriate):