### PR TITLE
2327 comparison of simulation with bb when a parameter is distributed in the bb bot not in the simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,4 @@ paket-files/
 
 licenses.licx
 *.DotSettings
+/OSPSuite.Core.v3.ncrunchsolution

--- a/OSPSuite.Core.v3.ncrunchsolution
+++ b/OSPSuite.Core.v3.ncrunchsolution
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <SolutionConfigured>True</SolutionConfigured>
-  </Settings>
-</SolutionConfiguration>

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -226,6 +226,7 @@ namespace OSPSuite.Assets
       public static readonly string DoNotShowThisAgainUntilRestart = "Do not show this again until restart";
       public static readonly string AddPoint = "Add Point";
       public static readonly string UseDerivedValues = "Use derivative values";
+      public static readonly string NotDistributed = "Not Distributed";
 
       public static string EditTableParameter(string parameter, bool editable) => $"{(editable ? "Edit" : "Show")} table parameter '{parameter}'";
 

--- a/src/OSPSuite.Core/Comparison/DiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/DiffBuilder.cs
@@ -72,9 +72,9 @@ namespace OSPSuite.Core.Comparison
       }
 
       protected void CompareValues<TInput, TOutput>(Func<TInput, TOutput> funcEvaluation, Expression<Func<TInput, TOutput>> propertyNameExpression, IComparison<TInput> comparison,
-         Func<TOutput, TOutput, bool> areEquals, Func<TInput, TOutput, string> formatter) where TInput : class
+         Func<TOutput, TOutput, bool> areEqual, Func<TInput, TOutput, string> formatter) where TInput : class
       {
-         CompareValues(funcEvaluation, nameFrom(propertyNameExpression), comparison, areEquals, formatter);
+         CompareValues(funcEvaluation, nameFrom(propertyNameExpression), comparison, areEqual, formatter);
       }
 
       private string nameFrom<TInput, TOutput>(Expression<Func<TInput, TOutput>> propertyNameExpression)

--- a/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.Core.Domain;
+﻿using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace OSPSuite.Core.Comparison
@@ -30,7 +31,9 @@ namespace OSPSuite.Core.Comparison
          // of a distributed PathAndValueEntity is not fully calculated until  it is turned into
          // a parameter
          if(!comparison.Object1.DistributionType.Equals(comparison.Object2.DistributionType))
-            CompareValues(x => x.DistributionType, x => x.DistributionType, comparison);
+            CompareValues(x => x.DistributionType, x => x.DistributionType, comparison, 
+               areEquals: (type1, type2) => Equals(type2, type1), 
+               formatter: (entity, type) => type == null ? Captions.NotDistributed : type.ToString());
          else
          {
             // Always Compare Value and Formula, independent of settings as these are two different properties of a start value

--- a/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/StartValueDiffBuilder.cs
@@ -32,7 +32,7 @@ namespace OSPSuite.Core.Comparison
          // a parameter
          if(!comparison.Object1.DistributionType.Equals(comparison.Object2.DistributionType))
             CompareValues(x => x.DistributionType, x => x.DistributionType, comparison, 
-               areEquals: (type1, type2) => Equals(type2, type1), 
+               areEqual: (type1, type2) => Equals(type2, type1), 
                formatter: (entity, type) => type == null ? Captions.NotDistributed : type.ToString());
          else
          {


### PR DESCRIPTION
Fixes #2327

# Description
Adding a "Not Distributed" for comparison view when comparing a distributed vs. non distributed PathAndValueEntity

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/1bffb668-4619-4879-9e0f-6fb27b31f5d7)


# Questions (if appropriate):