### PR TITLE
Fixes #2338 Clone module without some building blocks

### DIFF
--- a/src/OSPSuite.Core/Domain/Module.cs
+++ b/src/OSPSuite.Core/Domain/Module.cs
@@ -134,6 +134,9 @@ namespace OSPSuite.Core.Domain
 
       public void Remove(IBuildingBlock buildingBlock)
       {
+         // If a PKSim module is cloned and some building blocks removed
+         // it is no longer a PK-Sim module.
+         IsPKSimModule = false;
          buildingBlock.Module = null;
          _buildingBlocks.Remove(buildingBlock);
       }

--- a/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ObjectPathSpecs.cs
@@ -134,12 +134,6 @@ namespace OSPSuite.Core.Domain
             sut.AddAtFront(path);
          }
       }
-
-      [Observation]
-      public void should_return_the_desired_entity()
-      {
-         sut.Resolve<IParameter>(_organ).ShouldBeEqualTo(_parameter);
-      }
    }
 
    public class When_setting_the_path_element_with_index : concern_for_ObjectPath


### PR DESCRIPTION
Fixes #2338

# Description
Cloning a module without all building blocks should make a module 'Not PKSim'.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):