### PR TITLE
Fixes #2336 "Add local molecule parameters" should respect container …

### DIFF
--- a/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Descriptors;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Helpers;
 
@@ -62,6 +63,7 @@ namespace OSPSuite.Core.Domain
          _molecules = new List<MoleculeBuilder>();
 
          var constantFormulaParameter = DomainHelperForSpecs.ConstantParameterWithValue(5).WithDimension(DomainHelperForSpecs.FractionDimensionForSpecs()).WithName("constantFormulaParameterName");
+         constantFormulaParameter.ContainerCriteria = new DescriptorCriteria { new MatchTagCondition("physicalContainer") };
          var normalDistributionParameter = DomainHelperForSpecs.NormalDistributedParameter().WithDimension(DomainHelperForSpecs.FractionDimensionForSpecs()).WithName("normalDistributionParameterName");
          var molecule = new MoleculeBuilder().WithName("Molecule1");
          molecule.AddParameter(constantFormulaParameter);
@@ -76,9 +78,9 @@ namespace OSPSuite.Core.Domain
       }
 
       [Observation]
-      public void parameter_values_should_only_be_created_for_each_constant_formula_parameter_in_each_physical_container()
+      public void parameter_values_should_only_be_created_for_each_constant_formula_parameter_in_each_physical_container_matching_tags()
       {
-         _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain("Top|physicalContainer|Molecule1|constantFormulaParameterName", "Top|Molecule1|constantFormulaParameterName");
+         _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain("Top|physicalContainer|Molecule1|constantFormulaParameterName");
       }
    }
 
@@ -95,8 +97,12 @@ namespace OSPSuite.Core.Domain
          base.Context();
          _protein = new MoleculeBuilder().WithName("protein");
          _protein.QuantityType = QuantityType.Transporter;
-         _protein.AddParameter(new Parameter().WithName(Constants.Parameters.REL_EXP));
-         _protein.AddParameter(new Parameter().WithName("some other parameter"));
+         var expressionParameter = new Parameter().WithName(Constants.Parameters.REL_EXP);
+         expressionParameter.ContainerCriteria = new DescriptorCriteria { new MatchTagCondition("compartment") };
+         _protein.AddParameter(expressionParameter);
+         var anotherParameter = new Parameter().WithName("some other parameter");
+
+         _protein.AddParameter(anotherParameter);
 
          _molecules = new[] { _protein };
          _organContainer = new Container().WithName("organ").WithMode(ContainerMode.Physical);
@@ -110,9 +116,9 @@ namespace OSPSuite.Core.Domain
       }
 
       [Observation]
-      public void the_parameter_values_should_include_expression_parameters_for_the_organ()
+      public void the_parameter_values_should_include_expression_parameters_for_the_compartment()
       {
-         _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain($"organ|protein|{Constants.Parameters.REL_EXP}", $"organ|compartment|protein|{Constants.Parameters.REL_EXP}");
+         _parameterValues.Select(x => x.Path.ToString()).ShouldOnlyContain($"organ|compartment|protein|{Constants.Parameters.REL_EXP}");
       }
    }
 }


### PR DESCRIPTION
Fixes #2336

# Description
Creating way too many start values before while not respecting container criteria.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):