### PR TITLE
Fixes #2347 V12: value origins of some individual parameters are lost…

### DIFF
--- a/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
@@ -30,6 +30,8 @@ namespace OSPSuite.Core.Domain.Mappers
             ? _parameterFactory.CreateParameter(name, dimension: dimension, displayUnit: displayUnit)
             : _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit);
 
+         parameter.ValueOrigin.UpdateAllFrom(parameterValue.ValueOrigin);
+
          return parameter.WithUpdatedMetaFrom(parameterValue);
       }
    }

--- a/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using FakeItEasy;
 using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
@@ -22,6 +23,7 @@ namespace OSPSuite.Core.Mappers
    public class When_mapping_a_distributed_parameter_value_to_parameter_value : concern_for_ParameterValueToParameterMapper
    {
       private IndividualParameter _individualParameter;
+      private IParameter _parameter;
 
       protected override void Context()
       {
@@ -29,13 +31,20 @@ namespace OSPSuite.Core.Mappers
          _individualParameter = new IndividualParameter
          {
             Name = "name",
-            DistributionType = DistributionType.Discrete,
+            DistributionType = DistributionType.Discrete
          };
+         _individualParameter.UpdateValueOriginFrom(ValueOrigin.Unknown);
       }
 
       protected override void Because()
       {
-         sut.MapFrom(_individualParameter);
+         _parameter = sut.MapFrom(_individualParameter);
+      }
+
+      [Observation]
+      public void the_value_origin_should_be_updated()
+      {
+         _parameter.ValueOrigin.ShouldBeEqualTo(ValueOrigin.Unknown);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2347

# Description
ValueOrigin was not updated during creation of a simulation parameter from any of the PathAndValue Types

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):