### PR TITLE
Modified the CompareDoubleValues method to format in consistent units

### DIFF
--- a/src/OSPSuite.Core/Comparison/DiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/DiffBuilder.cs
@@ -102,17 +102,28 @@ namespace OSPSuite.Core.Comparison
          CompareDoubleValues(x => funcEvaluation(x).GetValueOrDefault(double.NaN), propertyName, comparison, displayUnitFunc);
       }
 
-    
       protected void CompareDoubleValues<TInput>(Func<TInput, double> funcEvaluation, string propertyName, IComparison<TInput> comparison, Func<TInput, Unit> displayUnitFunc = null) where TInput : class
       {
-         try
+         // Determine the display unit to use for both values (based on object1)
+         var standardDisplayUnit = comparison.Object1 is IWithDimension && displayUnitFunc != null ? displayUnitFunc(comparison.Object1) : null;
+
+         string ConsistentUnitFormatter(TInput input, double value)
          {
-            CompareValues(funcEvaluation, propertyName, comparison, (x, y) => ValueComparer.AreValuesEqual(x, y, comparison.Settings.RelativeTolerance), (input, output) => numericFormatter(input, output, displayUnitFunc));
+                if (!(input is IWithDimension withDimension) || standardDisplayUnit == null || withDimension.Dimension == null)
+                    return _numericFormatter.Format(value);
+
+                // Convert the value to object1's unit for consistent display
+                var valueInStandardUnit = withDimension.ConvertToUnit(value, standardDisplayUnit);
+            return _numericFormatter.Format(valueInStandardUnit, standardDisplayUnit);
          }
-         catch (OSPSuiteException)
-         {
-            //in that case formula could not be evaluated for the given objects (can happen in pksim with parameters within alternatives)
-         }
+
+         CompareValues(
+            funcEvaluation,
+            propertyName,
+            comparison,
+            (x, y) => ValueComparer.AreValuesEqual(x, y, comparison.Settings.RelativeTolerance),
+            ConsistentUnitFormatter
+         );
       }
 
       /// <summary>

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
@@ -162,7 +162,7 @@ namespace OSPSuite.Core.DiffBuilders
       }
    }
 
-   public class When_comparing_parameters_having_the_different_base_values_but_the_same_display_value : concern_for_ObjectComparer
+   public class When_comparing_parameters_with_different_unit_representations : concern_for_ObjectComparer
    {
       protected override void Context()
       {
@@ -186,7 +186,7 @@ namespace OSPSuite.Core.DiffBuilders
       }
 
       [Observation]
-      public void should_have_some_differences()
+      public void should_present_values_in_consistent_base_unit()
       {
          _report.Count.ShouldBeEqualTo(1);
          var propertyDiffItem = _report[0].DowncastTo<PropertyValueDiffItem>();

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
@@ -191,7 +191,7 @@ namespace OSPSuite.Core.DiffBuilders
          _report.Count.ShouldBeEqualTo(1);
          var propertyDiffItem = _report[0].DowncastTo<PropertyValueDiffItem>();
          propertyDiffItem.FormattedValue1.ShouldBeEqualTo("1.000 m");
-         propertyDiffItem.FormattedValue2.ShouldBeEqualTo("1.000 mm");
+         propertyDiffItem.FormattedValue2.ShouldBeEqualTo("1.000E-3 m");
       }
    }
 

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ParameterDiffBuilderSpecs.cs
@@ -162,31 +162,64 @@ namespace OSPSuite.Core.DiffBuilders
       }
    }
 
+   public class When_comparing_parameters_with_different_values_in_same_units : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var dimension = DomainHelperForSpecs.LengthDimensionForSpecs();
+         var c1 = new Container { Name = "O" };
+         var p11 = new Parameter { Name = "P1" }.WithParentContainer(c1);
+         p11.DisplayUnit = dimension.Units.First();
+         p11.Formula = new ConstantFormula(1);
+         NumericFormatterOptions.Instance.DecimalPlace = 3;
+
+         var c2 = new Container { Name = "O" };
+         var p21 = new Parameter { Name = "P1" }.WithParentContainer(c2);
+         p21.DisplayUnit = dimension.Units.First();
+         p21.Formula = new ConstantFormula(1.1);
+
+         _object1 = c1;
+         _object2 = c2;
+
+         _comparerSettings = new ComparerSettings { FormulaComparison = FormulaComparison.Value, OnlyComputingRelevant = true };
+      }
+
+      [Observation]
+      public void should_present_differences()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+         var propertyDiffItem = _report[0].DowncastTo<PropertyValueDiffItem>();
+         propertyDiffItem.FormattedValue1.ShouldBeEqualTo("1.000 m");
+         propertyDiffItem.FormattedValue2.ShouldBeEqualTo("1.100 m");
+      }
+   }
+
    public class When_comparing_parameters_with_different_unit_representations : concern_for_ObjectComparer
    {
       protected override void Context()
       {
          base.Context();
          var dimension = DomainHelperForSpecs.LengthDimensionForSpecs();
-         var c1 = new Container {Name = "O"};
-         var p11 = new Parameter {Name = "P1"}.WithParentContainer(c1);
+         var c1 = new Container { Name = "O" };
+         var p11 = new Parameter { Name = "P1" }.WithParentContainer(c1);
          p11.DisplayUnit = dimension.Units.First();
          p11.Formula = new ConstantFormula(1);
          NumericFormatterOptions.Instance.DecimalPlace = 3;
 
-         var c2 = new Container {Name = "O"};
-         var p21 = new Parameter {Name = "P1"}.WithParentContainer(c2);
+         var c2 = new Container { Name = "O" };
+         var p21 = new Parameter { Name = "P1" }.WithParentContainer(c2);
          p21.DisplayUnit = dimension.Units.Last();
          p21.Formula = new ConstantFormula(0.001);
 
          _object1 = c1;
          _object2 = c2;
 
-         _comparerSettings = new ComparerSettings {FormulaComparison = FormulaComparison.Value, OnlyComputingRelevant = true};
+         _comparerSettings = new ComparerSettings { FormulaComparison = FormulaComparison.Value, OnlyComputingRelevant = true };
       }
 
       [Observation]
-      public void should_present_values_in_consistent_base_unit()
+      public void should_present_differences_in_consistent_base_unit()
       {
          _report.Count.ShouldBeEqualTo(1);
          var propertyDiffItem = _report[0].DowncastTo<PropertyValueDiffItem>();
@@ -195,7 +228,7 @@ namespace OSPSuite.Core.DiffBuilders
       }
    }
 
-   public class When_comparing_parameters_having_the_same_formula_but_depending_on_parameters_having_different_values_and_we_are_validating_using_formula_check : concern_for_ObjectComparer
+    public class When_comparing_parameters_having_the_same_formula_but_depending_on_parameters_having_different_values_and_we_are_validating_using_formula_check : concern_for_ObjectComparer
    {
       protected override void Context()
       {


### PR DESCRIPTION

Fixes #2349 

# Description

When comparing numeric values with units, values are sometimes displayed in different units (e.g., one in dm and one in cm). This makes it difficult for users to properly interpret the differences.
Solution
Modified the CompareDoubleValues method to always use the unit of the first object for displaying both values. This ensures differences are consistently displayed in the same unit.
This change only affects the display of differences, not the underlying comparison logic or conversions.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):