### PR TITLE
Fixes #2351 Simulations that error while running under sensitivity analysis do not show any error message

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1257,7 +1257,7 @@ namespace OSPSuite.Assets
             return $"Number of selected parameters: {numberOfParameters}";
          }
 
-         public static string SensitivityAnalsysisErrorMessage(IReadOnlyList<string> errorMessages)
+         public static string SensitivityAnalysisErrorMessage(IReadOnlyList<string> errorMessages)
          {
             var stringBuilder = new StringBuilder();
             errorMessages.Each(message =>

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -302,7 +302,7 @@ namespace OSPSuite.Assets
          return $"Do you want to delete the directory '{newDirectoryName}' and continue?";
       }
 
-      public static void AppendListItem(StringBuilder sb, bool html, string listItem, int index)
+      public static void AppendOrderedListItem(StringBuilder sb, bool html, string listItem, int index)
       {
          if (html)
             sb.Append($"<li>{listItem}</li>");
@@ -326,7 +326,7 @@ namespace OSPSuite.Assets
          list.Each((item, i) =>
          {
             //index in list item should start at 1
-            AppendListItem(sb, html, item, i + 1);
+            AppendOrderedListItem(sb, html, item, i + 1);
          });
 
          if (html)
@@ -1196,6 +1196,7 @@ namespace OSPSuite.Assets
          public static readonly string ParameterSelection = "Parameters";
          public static readonly string Results = "Results";
          public static readonly string NoResultsAvailable = "No result available. Please start sensitivity analysis";
+         public static readonly string ErrorsDuringPreviousRun = "<b>The last run resulted in one or more errors:</b>";
 
          public static string SensitivityAnalysisFinished(string duration)
          {
@@ -1254,6 +1255,19 @@ namespace OSPSuite.Assets
          public static string NumberOfSelectedParameters(int numberOfParameters)
          {
             return $"Number of selected parameters: {numberOfParameters}";
+         }
+
+         public static string SensitivityAnalsysisErrorMessage(IReadOnlyList<string> errorMessages)
+         {
+            var stringBuilder = new StringBuilder();
+            errorMessages.Each(message =>
+            {
+               stringBuilder.AppendLine($"{message}");
+               stringBuilder.AppendLine();
+               stringBuilder.AppendLine();
+            });
+            
+            return stringBuilder.ToString();
          }
       }
 

--- a/src/OSPSuite.Core/Domain/SensitivityAnalyses/SensitivityAnalysisRunResult.cs
+++ b/src/OSPSuite.Core/Domain/SensitivityAnalyses/SensitivityAnalysisRunResult.cs
@@ -118,5 +118,7 @@ namespace OSPSuite.Core.Domain.SensitivityAnalyses
       public string[] AllParameterPaths => _allPKParameterSensitivities.Select(x => x.ParameterPath).Distinct().ToArray();
 
       public virtual int Count => _allPKParameterSensitivities.Count;
+
+      public IReadOnlyList<IndividualRunInfo> Errors { get; set; } = new List<IndividualRunInfo>();
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/SensitivityAnalyses/SensitivityAnalysisEngine.cs
+++ b/src/OSPSuite.Core/Domain/Services/SensitivityAnalyses/SensitivityAnalysisEngine.cs
@@ -77,7 +77,7 @@ namespace OSPSuite.Core.Domain.Services.SensitivityAnalyses
 
       private Task<SensitivityAnalysisRunResult> calculateSensitivityBasedOn(SensitivityAnalysis sensitivityAnalysis, VariationData variationData, PopulationRunResults runResults, SensitivityAnalysisRunOptions sensitivityAnalysisRunOptions)
       {
-         return Task.Run(() => _runResultCalculator.CreateFor(sensitivityAnalysis, variationData, runResults.Results, sensitivityAnalysisRunOptions.ReturnOutputValues));
+         return Task.Run(() => _runResultCalculator.CreateFor(sensitivityAnalysis, variationData, runResults.Results, runResults.Errors, sensitivityAnalysisRunOptions.ReturnOutputValues));
       }
 
       private void simulationProgress(object sender, MultipleSimulationsProgressEventArgs eventArgs)

--- a/src/OSPSuite.Core/Domain/Services/SensitivityAnalyses/SensitivityAnalysisRunResultCalculator.cs
+++ b/src/OSPSuite.Core/Domain/Services/SensitivityAnalyses/SensitivityAnalysisRunResultCalculator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.SensitivityAnalyses;
@@ -8,7 +9,7 @@ namespace OSPSuite.Core.Domain.Services.SensitivityAnalyses
 {
    public interface ISensitivityAnalysisRunResultCalculator
    {
-      SensitivityAnalysisRunResult CreateFor(SensitivityAnalysis sensitivityAnalysis, VariationData variationData, SimulationResults simulationResults, bool addOutputParameterSensitivitiesToResult);
+      SensitivityAnalysisRunResult CreateFor(SensitivityAnalysis sensitivityAnalysis, VariationData variationData, SimulationResults simulationResults, IReadOnlyList<IndividualRunInfo> runErrors, bool addOutputParameterSensitivitiesToResult);
    }
 
    public class SensitivityAnalysisRunResultCalculator : ISensitivityAnalysisRunResultCalculator
@@ -20,9 +21,12 @@ namespace OSPSuite.Core.Domain.Services.SensitivityAnalyses
          _pkAnalysesTask = pkAnalysesTask;
       }
 
-      public SensitivityAnalysisRunResult CreateFor(SensitivityAnalysis sensitivityAnalysis, VariationData variationData, SimulationResults simulationResults, bool addOutputParameterSensitivitiesToResult)
+      public SensitivityAnalysisRunResult CreateFor(SensitivityAnalysis sensitivityAnalysis, VariationData variationData, SimulationResults simulationResults, IReadOnlyList<IndividualRunInfo> runErrors, bool addOutputParameterSensitivitiesToResult)
       {
-         var sensitivityRunResult = new SensitivityAnalysisRunResult();
+         var sensitivityRunResult = new SensitivityAnalysisRunResult
+         {
+            Errors = runErrors
+         };
 
          addPKAnalysisSensitivities(variationData, simulationResults, sensitivityRunResult, sensitivityAnalysis);
 

--- a/src/OSPSuite.Presentation/Presenters/SensitivityAnalyses/SensitivityAnalysisResultsPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/SensitivityAnalyses/SensitivityAnalysisResultsPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Utility.Events;
 using OSPSuite.Core.Domain;
@@ -55,7 +56,10 @@ namespace OSPSuite.Presentation.Presenters.SensitivityAnalyses
 
       private void showNoResultsAvailable()
       {
-         _view.HideResultsView();
+         if (_sensitivityAnalysis.Results.Errors.Any())
+            _view.ShowErrors(_sensitivityAnalysis.Results.Errors.Select(x => x.ErrorMessage).ToList());
+         else
+            _view.HideResultsView();
       }
 
       public void Handle(SensitivityAnalysisResultsUpdatedEvent eventToHandle)

--- a/src/OSPSuite.Presentation/Views/SensitivityAnalyses/ISensitivityAnalysisResultsView.cs
+++ b/src/OSPSuite.Presentation/Views/SensitivityAnalyses/ISensitivityAnalysisResultsView.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using OSPSuite.Presentation.Presenters.SensitivityAnalyses;
 
 namespace OSPSuite.Presentation.Views.SensitivityAnalyses
@@ -8,5 +9,6 @@ namespace OSPSuite.Presentation.Views.SensitivityAnalyses
       void HideResultsView();
       void BindTo(DataTable dataTable);
       DataTable GetSummaryData();
+      void ShowErrors(IReadOnlyList<string> errorMessages);
    }
 }

--- a/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.Designer.cs
+++ b/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.Designer.cs
@@ -32,12 +32,17 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
       private void InitializeComponent()
       {
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
-         this.pivotGrid = new PKAnalysisPivotGridControl();
+         this.btnExportToExcel = new DevExpress.XtraEditors.SimpleButton();
+         this.pivotGrid = new OSPSuite.UI.Controls.PKAnalysisPivotGridControl();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemParameters = new DevExpress.XtraLayout.LayoutControlItem();
-         this.btnExportToExcel = new DevExpress.XtraEditors.SimpleButton();
          this.layoutItemExportToExcel = new DevExpress.XtraLayout.LayoutControlItem();
          this.emptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.errorLayoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.lblError = new DevExpress.XtraEditors.LabelControl();
+         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.errorLayoutItem = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
@@ -46,10 +51,16 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameters)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemExportToExcel)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorLayoutControl)).BeginInit();
+         this.errorLayoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorLayoutItem)).BeginInit();
          this.SuspendLayout();
          // 
          // layoutControl
          // 
+         this.layoutControl.AllowCustomization = false;
          this.layoutControl.Controls.Add(this.btnExportToExcel);
          this.layoutControl.Controls.Add(this.pivotGrid);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -60,12 +71,21 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl1";
          // 
+         // btnExportToExcel
+         // 
+         this.btnExportToExcel.Location = new System.Drawing.Point(12, 2);
+         this.btnExportToExcel.Name = "btnExportToExcel";
+         this.btnExportToExcel.Size = new System.Drawing.Size(375, 22);
+         this.btnExportToExcel.StyleController = this.layoutControl;
+         this.btnExportToExcel.TabIndex = 5;
+         this.btnExportToExcel.Text = "btnExportToExcel";
+         // 
          // pivotGrid
          // 
          this.pivotGrid.ExceptionManager = null;
-         this.pivotGrid.Location = new System.Drawing.Point(112, 28);
+         this.pivotGrid.Location = new System.Drawing.Point(121, 28);
          this.pivotGrid.Name = "pivotGrid";
-         this.pivotGrid.Size = new System.Drawing.Size(275, 438);
+         this.pivotGrid.Size = new System.Drawing.Size(266, 438);
          this.pivotGrid.TabIndex = 4;
          // 
          // layoutControlGroup
@@ -76,7 +96,6 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
             this.layoutItemParameters,
             this.layoutItemExportToExcel,
             this.emptySpaceItem});
-         this.layoutControlGroup.Location = new System.Drawing.Point(0, 0);
          this.layoutControlGroup.Name = "layoutControlGroup";
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
          this.layoutControlGroup.Size = new System.Drawing.Size(389, 468);
@@ -90,16 +109,7 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          this.layoutItemParameters.Size = new System.Drawing.Size(389, 442);
          this.layoutItemParameters.TextSize = new System.Drawing.Size(107, 13);
          // 
-         // btnExportToExcel
-         // 
-         this.btnExportToExcel.Location = new System.Drawing.Point(12, 2);
-         this.btnExportToExcel.Name = "btnExportToExcel";
-         this.btnExportToExcel.Size = new System.Drawing.Size(375, 22);
-         this.btnExportToExcel.StyleController = this.layoutControl;
-         this.btnExportToExcel.TabIndex = 5;
-         this.btnExportToExcel.Text = "btnExportToExcel";
-         // 
-         // layoutControlItem1
+         // layoutItemExportToExcel
          // 
          this.layoutItemExportToExcel.Control = this.btnExportToExcel;
          this.layoutItemExportToExcel.Location = new System.Drawing.Point(10, 0);
@@ -116,10 +126,60 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          this.emptySpaceItem.Size = new System.Drawing.Size(10, 26);
          this.emptySpaceItem.TextSize = new System.Drawing.Size(0, 0);
          // 
+         // errorLayoutControl
+         // 
+         this.errorLayoutControl.AllowCustomization = false;
+         this.errorLayoutControl.Controls.Add(this.lblError);
+         this.errorLayoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.errorLayoutControl.Location = new System.Drawing.Point(0, 0);
+         this.errorLayoutControl.Name = "errorLayoutControl";
+         this.errorLayoutControl.Root = this.Root;
+         this.errorLayoutControl.Size = new System.Drawing.Size(389, 468);
+         this.errorLayoutControl.TabIndex = 6;
+         this.errorLayoutControl.Text = "uxLayoutControl1";
+         // 
+         // lblError
+         // 
+         this.lblError.Location = new System.Drawing.Point(12, 12);
+         this.lblError.Name = "lblError";
+         this.lblError.Size = new System.Drawing.Size(63, 13);
+         this.lblError.StyleController = this.errorLayoutControl;
+         this.lblError.TabIndex = 5;
+         this.lblError.Text = "labelControl2";
+         // 
+         // Root
+         // 
+         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.Root.GroupBordersVisible = false;
+         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.emptySpaceItem1,
+            this.errorLayoutItem});
+         this.Root.Name = "Root";
+         this.Root.Size = new System.Drawing.Size(389, 468);
+         this.Root.TextVisible = false;
+         // 
+         // emptySpaceItem1
+         // 
+         this.emptySpaceItem1.AllowHotTrack = false;
+         this.emptySpaceItem1.Location = new System.Drawing.Point(67, 0);
+         this.emptySpaceItem1.Name = "emptySpaceItem1";
+         this.emptySpaceItem1.Size = new System.Drawing.Size(302, 448);
+         this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
+         // 
+         // layoutControlItem1
+         // 
+         this.errorLayoutItem.Control = this.lblError;
+         this.errorLayoutItem.Location = new System.Drawing.Point(0, 0);
+         this.errorLayoutItem.Name = "errorLayoutItem";
+         this.errorLayoutItem.Size = new System.Drawing.Size(67, 448);
+         this.errorLayoutItem.TextSize = new System.Drawing.Size(0, 0);
+         this.errorLayoutItem.TextVisible = false;
+         // 
          // SensitivityAnalysisResultsView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.errorLayoutControl);
          this.Controls.Add(this.layoutControl);
          this.Name = "SensitivityAnalysisResultsView";
          this.Size = new System.Drawing.Size(389, 468);
@@ -131,18 +191,27 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameters)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemExportToExcel)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorLayoutControl)).EndInit();
+         this.errorLayoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorLayoutItem)).EndInit();
          this.ResumeLayout(false);
 
       }
 
       #endregion
-
-      private DevExpress.XtraLayout.LayoutControl layoutControl;
       private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
       private PKAnalysisPivotGridControl pivotGrid;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemParameters;
       private DevExpress.XtraEditors.SimpleButton btnExportToExcel;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemExportToExcel;
       private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem;
+      private UxLayoutControl layoutControl;
+      private UxLayoutControl errorLayoutControl;
+      private DevExpress.XtraLayout.LayoutControlGroup Root;
+      private DevExpress.XtraEditors.LabelControl lblError;
+      private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
+      private DevExpress.XtraLayout.LayoutControlItem errorLayoutItem;
    }
 }

--- a/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.cs
+++ b/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using DevExpress.Data.PivotGrid;
 using DevExpress.Utils;
 using DevExpress.XtraEditors;
@@ -25,7 +26,7 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
       {
          _toolTipCreator = toolTipCreator;
          InitializeComponent();
-         _lblInfo = new LabelControl {Parent = this};
+         _lblInfo = new LabelControl { Parent = this };
          pivotGrid.ToolTipController = new ToolTipController();
 
          configureFields();
@@ -110,12 +111,22 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
          return pivotGrid.GetCellsSummary();
       }
 
+      public void ShowErrors(IReadOnlyList<string> errorMessages)
+      {
+         showResult = false;
+         _lblInfo.Visible = false;
+         var text = Captions.SensitivityAnalysis.SensitivityAnalsysisErrorMessage(errorMessages);
+         lblError.Text = text;
+         errorLayoutControl.Visible = true;
+      }
+
       private bool showResult
       {
          set
          {
             layoutControl.Visible = value;
             _lblInfo.Visible = !layoutControl.Visible;
+            errorLayoutControl.Visible = false;
          }
       }
 
@@ -123,6 +134,11 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
       {
          base.InitializeResources();
          _lblInfo.AsFullViewText(Captions.SensitivityAnalysis.NoResultsAvailable);
+         errorLayoutControl.Visible = false;
+         errorLayoutItem.TextVisible = true;
+         errorLayoutItem.TextLocation = Locations.Top;
+         errorLayoutItem.AllowHtmlStringInCaption = true;
+         errorLayoutItem.Text = Captions.SensitivityAnalysis.ErrorsDuringPreviousRun;
          layoutItemParameters.TextVisible = false;
          btnExportToExcel.InitWithImage(ApplicationIcons.Excel, text: Captions.SensitivityAnalysis.ExportPKAnalysesSensitivityToExcel);
          layoutItemExportToExcel.AdjustLargeButtonSize(layoutControl);

--- a/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.cs
+++ b/src/OSPSuite.UI/Views/SensitivityAnalyses/SensitivityAnalysisResultsView.cs
@@ -115,7 +115,7 @@ namespace OSPSuite.UI.Views.SensitivityAnalyses
       {
          showResult = false;
          _lblInfo.Visible = false;
-         var text = Captions.SensitivityAnalysis.SensitivityAnalsysisErrorMessage(errorMessages);
+         var text = Captions.SensitivityAnalysis.SensitivityAnalysisErrorMessage(errorMessages);
          lblError.Text = text;
          errorLayoutControl.Visible = true;
       }

--- a/tests/OSPSuite.Core.Tests/Domain/SensitivityAnalysisEngineSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SensitivityAnalysisEngineSpecs.cs
@@ -73,7 +73,7 @@ namespace OSPSuite.Core.Domain
          A.CallTo(() => _populationRunner.RunPopulationAsync(_modelCoreSimulation, _runOptions,  _dataTable, null, null)).ReturnsAsync(_populationRunResult);
 
          _sensitivityAnalysisResults=new SensitivityAnalysisRunResult();
-         A.CallTo(() => _runResultCalculator.CreateFor(_sensitivityAnalysis, _variationData, _populationRunResult.Results, false)).Returns(_sensitivityAnalysisResults);
+         A.CallTo(() => _runResultCalculator.CreateFor(_sensitivityAnalysis, _variationData, _populationRunResult.Results, A<IReadOnlyList<IndividualRunInfo>>._, false)).Returns(_sensitivityAnalysisResults);
 
       }
 

--- a/tests/OSPSuite.Core.Tests/Services/SensitivityAnalysisRunResultCalculatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SensitivityAnalysisRunResultCalculatorSpecs.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using System.Collections.Generic;
+using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -89,7 +90,7 @@ namespace OSPSuite.Core.Services
 
       protected override void Because()
       {
-         _result = sut.CreateFor(_sensitivityAnalysis, _variationData, _simulationResults, addOutputParameterSensitivitiesToResult: false);
+         _result = sut.CreateFor(_sensitivityAnalysis, _variationData, _simulationResults, new List<IndividualRunInfo>(), addOutputParameterSensitivitiesToResult: false);
       }
 
       [Observation]
@@ -206,7 +207,7 @@ namespace OSPSuite.Core.Services
 
       protected override void Because()
       {
-         _result = sut.CreateFor(_sensitivityAnalysis, _variationData, _simulationResults, addOutputParameterSensitivitiesToResult: true);
+         _result = sut.CreateFor(_sensitivityAnalysis, _variationData, _simulationResults, new List<IndividualRunInfo>(), addOutputParameterSensitivitiesToResult: true);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2351

# Description
Sensitivity analysis quietly fails if any individual run does not produce a result. The errors were not transferred to the `RunResults` so just making those available to the presenter allowed a view to show any errors.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8f6e4e9d-2104-414b-8be6-61098ff03463)


# Questions (if appropriate):