### PR TITLE
Fixes #2353 Container not shown in diagram

### DIFF
--- a/src/OSPSuite.Core/Domain/Container.cs
+++ b/src/OSPSuite.Core/Domain/Container.cs
@@ -98,9 +98,9 @@ namespace OSPSuite.Core.Domain
    public class Container : Entity, IContainer
    {
       private readonly List<IEntity> _children = new List<IEntity>();
-      
+
       private ContainerMode _mode = ContainerMode.Logical;
-      
+
       private ContainerType _containerType;
 
       //Path to parent container is null by default. In this case, it will be evaluated from container structure
@@ -128,8 +128,12 @@ namespace OSPSuite.Core.Domain
             return;
          }
 
+         if (newChild is IContainer childContainer)
+            childContainer.ParentPath = null;
+
          _children.Add(newChild);
          newChild.ParentContainer = this;
+
          OnChanged();
       }
 
@@ -143,7 +147,7 @@ namespace OSPSuite.Core.Domain
 
       public ObjectPath ParentPath
       {
-         get => _parentPath;
+         get => ParentContainer == null ? _parentPath : null;
          set => SetProperty(ref _parentPath, value);
       }
 

--- a/tests/OSPSuite.Core.Tests/Domain/ContainerSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ContainerSpecs.cs
@@ -261,6 +261,29 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_adding_a_container_to_a_parent_container : concern_for_Container
+   {
+      private Container _subContainer;
+
+      protected override void Context()
+      {
+         base.Context();
+         _subContainer = new Container().WithName("subcontainer");
+         _subContainer.ParentPath = new ObjectPath("the", "path");
+      }
+
+      protected override void Because()
+      {
+         sut.Add(_subContainer);
+      }
+
+      [Observation]
+      public void the_child_container_should_have_parent_path_cleared()
+      {
+         _subContainer.ParentPath.ShouldBeNull();
+      }
+   }
+
    public class When_updating_properties_from_another_container : concern_for_Container
    {
       [Observation]


### PR DESCRIPTION
Fixes #2353

# Description
Fix is not in the diagram code, but in the container code. We should not allow containers to have a `ParentContainer` and `ParentPath`. So, if you add a container to another container, the child container will have the `ParentPath` property cleared and the `ParentContainer` property set at the same time.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):