### PR TITLE
#2361 copy path of a parameter container in the simulation

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/NeighborhoodBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/NeighborhoodBuilder.cs
@@ -95,8 +95,8 @@ namespace OSPSuite.Core.Domain.Builder
          if (sourceNeighborhood == null)
             return;
 
-         FirstNeighborPath = sourceNeighborhood.FirstNeighborPath;
-         SecondNeighborPath = sourceNeighborhood.SecondNeighborPath;
+         FirstNeighborPath = sourceNeighborhood.FirstNeighborPath.Clone<ObjectPath>();
+         SecondNeighborPath = sourceNeighborhood.SecondNeighborPath.Clone<ObjectPath>();
       }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/SpatialStructureSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/SpatialStructureSpecs.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -87,6 +89,21 @@ namespace OSPSuite.Core
       {
          sut.Neighborhoods.Each(neighbor => neighbor.FirstNeighborPath.ShouldNotBeNull());
          sut.Neighborhoods.Each(neighbor => neighbor.SecondNeighborPath.ShouldNotBeNull());
+      }
+
+      [Observation]
+      public void neighbor_paths_should_be_cloned_not_shared()
+      {
+         var sourceNeighborhood = _sourceSpatialStructure.Neighborhoods.First();
+         var clonedNeighborhood = sut.Neighborhoods.First();
+
+         // Check that paths are different instances
+         clonedNeighborhood.FirstNeighborPath.ShouldNotBeEqualTo(sourceNeighborhood.FirstNeighborPath);
+         clonedNeighborhood.SecondNeighborPath.ShouldNotBeEqualTo(sourceNeighborhood.SecondNeighborPath);
+
+         // Check that path values remain the same
+         clonedNeighborhood.FirstNeighborPath.PathAsString.ShouldBeEqualTo(sourceNeighborhood.FirstNeighborPath.PathAsString);
+         clonedNeighborhood.SecondNeighborPath.PathAsString.ShouldBeEqualTo(sourceNeighborhood.SecondNeighborPath.PathAsString);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2361 

# Description

Fixed an issue where renaming organs in a cloned spatial structure affected the original structure. The problem occurred because ObjectPaths in neighborhoods were shared (referenced) between original and cloned structures instead of being properly cloned.

Added proper path cloning in NeighborhoodBuilder.UpdatePropertiesFrom 
Validated through extended unit test.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):