### PR TITLE
Fixes #2358 It should not be possible to create a simulation with multiple identical neighborhoods

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1845,6 +1845,16 @@ namespace OSPSuite.Assets
       public static string TypeNotSupported(string typeName) => $"{typeName} is not currently been handled";
 
       public static string CannotAccessValueByPathUsingWildCard(string path) => $"Accessing value by path is not supported for path containing wildcard ({path})";
+
+      public static string EquivalentNeighborhoodsAreDefinedFor(string firstNeighbor, string secondNeighbor)
+      {
+         return $"More than one neighborhood is defined connecting '{firstNeighbor}' and '{secondNeighbor}'";
+      }
+
+      public static string NeighborhoodDefinition(string neighborhoodName, string firstNeighbor, string secondNeighbor, string spatialStructure)
+      {
+         return $"Neighborhood '{neighborhoodName}' connects '{firstNeighbor}' and '{secondNeighbor}' in '{spatialStructure}'";
+      }
    }
 
    public static class Validation

--- a/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
@@ -16,6 +16,45 @@ namespace OSPSuite.Core.Services
       }
    }
 
+   internal class When_validating_a_simulation_configuration_with_colliding_neighborhoods : concern_for_SimulationConfigurationValidator
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private ValidationResult _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(moduleWithNeighborhood("name1")));
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(moduleWithNeighborhood("name2")));
+      }
+
+      private Module moduleWithNeighborhood(string neighborhoodName)
+      {
+         var spatialStructure = new SpatialStructure { NeighborhoodsContainer = new Container() };
+         spatialStructure.AddNeighborhood(new NeighborhoodBuilder { FirstNeighborPath = new ObjectPath("path1"), SecondNeighborPath = new ObjectPath("path2") }.WithName(neighborhoodName));
+
+         return new Module { spatialStructure };
+      }
+
+      protected override void Because()
+      {
+         _result = sut.Validate(_simulationConfiguration);
+      }
+
+      [Observation]
+      public void the_result_should_be_invalid()
+      {
+         _result.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+      }
+
+      [Observation]
+      public void the_error_should_only_be_reported_once_instead_of_for_both_neighborhoods()
+      {
+         _result.Messages.Count().ShouldBeEqualTo(1);
+      }
+   }
+
    internal class When_validating_a_simulation_configuration_with_an_incorrect_application : concern_for_SimulationConfigurationValidator
    {
       private SimulationConfiguration _simulationConfiguration;


### PR DESCRIPTION
Fixes #2358 

# Description
It's possible that two modules could define different neighborhoods that connect the same containers. This prevents the simulation from being created.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4bc45579-10d4-438e-8fcf-3f513254c408)

# Questions (if appropriate):