### PR TITLE
Fixes #2365 Validation of simulation fails if the same object fails

### DIFF
--- a/src/OSPSuite.Core/Domain/ValidationResult.cs
+++ b/src/OSPSuite.Core/Domain/ValidationResult.cs
@@ -21,7 +21,7 @@ namespace OSPSuite.Core.Domain
       public ValidationResult(IEnumerable<ValidationMessage> messages)
       {
          _messages = new Cache<IObjectBase, ValidationMessage>(x => x.Object);
-         _messages.AddRange(messages);
+         addMessages(messages);
       }
 
       public ValidationResult(params ValidationResult[] validationResults) : this(validationResults.SelectMany(x => x.Messages))
@@ -30,8 +30,13 @@ namespace OSPSuite.Core.Domain
 
       public ValidationResult AddMessagesFrom(ValidationResult validationResult)
       {
-         validationResult.Messages.Each(message => AddMessage(message.NotificationType, message.Object, message.Text, message.BuildingBlock, message.Details));
+         addMessages(validationResult.Messages);
          return this;
+      }
+
+      private void addMessages(IEnumerable<ValidationMessage> validationResultMessages)
+      {
+         validationResultMessages.Each(message => AddMessage(message.NotificationType, message.Object, message.Text, message.BuildingBlock, message.Details));
       }
 
       public virtual void AddMessage(NotificationType notificationType, IObjectBase invalidObject, string notification, IBuildingBlock buildingBlock = null, IEnumerable<string> details = null)

--- a/tests/OSPSuite.Core.Tests/Domain/ValidationResultSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ValidationResultSpecs.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -78,7 +79,35 @@ namespace OSPSuite.Core.Domain
       }
    }
 
-   public class When_adding_a_validation_message_for_an_obkect_for_which_a_validation_was_already_present : concern_for_ValidationResult
+   public class When_constructing_a_validation_message_with_messages_for_object_from_different_lists : concern_for_ValidationResult
+   {
+      private ValidationResult _validationResult1, _validationResult2;
+      private IObjectBase _invalidObject;
+
+      protected override void Context()
+      {
+         base.Context();
+         _invalidObject = A.Fake<IObjectBase>();
+         _validationResult1 = new ValidationResult();
+         _validationResult1.AddMessage(NotificationType.Error, _invalidObject, "Object Invalid", details: new[] { "Detail1", "Detail2" });
+
+         _validationResult2 = new ValidationResult();
+         _validationResult2.AddMessage(NotificationType.Error, _invalidObject, "It's invalid for another reason", details: new[] { "Detail3", "Detail4" });
+      }
+      protected override void Because()
+      {
+         sut = new ValidationResult(_validationResult1, _validationResult2);
+      }
+
+      [Observation]
+      public void should_add_the_details_of_the_new_message()
+      {
+         var message = sut.Messages.Find(x => x.Object == _invalidObject);
+         message.Details.ShouldOnlyContainInOrder("Detail1", "Detail2", "It's invalid for another reason", "Detail3", "Detail4");
+      }
+   }
+
+   public class When_adding_a_validation_message_for_an_object_for_which_a_validation_was_already_present : concern_for_ValidationResult
    {
       private ValidationResult _validationResult;
       private IObjectBase _invalidObject;


### PR DESCRIPTION
Fixes #2365

# Description
Just caching the objects incorrectly during construction

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):