### PR TITLE
Fixes #2368 Changed simulation value not properly shown when sending simulation from PK-Sim to Mobi

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
@@ -182,12 +182,22 @@ namespace OSPSuite.Core.Domain.Services
          var parameterValue = CreateParameterValue(parameterPath, 0.0, parameter.Dimension, parameter.DisplayUnit, parameter.ValueOrigin,
             parameter.IsDefault);
 
-         if (parameter.Formula != null && !parameter.Formula.IsConstant())
-            parameterValue.Formula = _cloneManager.Clone(parameter.Formula, new FormulaCache());
-         else
+         if (shouldSetValue(parameter))
+         {
             parameterValue.Value = parameter.Value;
-
+            parameterValue.Formula = null;
+         }
+         else
+         {
+            parameterValue.Formula = _cloneManager.Clone(parameter.Formula, new FormulaCache());
+            parameterValue.Value = null;
+         }
          return parameterValue;
+      }
+
+      private static bool shouldSetValue(IParameter parameter)
+      {
+         return parameter.IsFixedValue || parameter.Formula == null || parameter.Formula.IsConstant();
       }
 
       public ParameterValue CreateEmptyStartValue(IDimension dimension) => CreateParameterValue(ObjectPath.Empty, 0.0, dimension);

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCreatorSpecs.cs
@@ -29,6 +29,38 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   internal class When_creating_a_parameter_value_for_a_parameter_with_formula_and_object_path : concern_for_ParameterValuesCreator
+   {
+      private ObjectPath _objectPath;
+      private IParameter _parameter;
+      private ParameterValue _psv;
+
+      protected override void Context()
+      {
+         base.Context();
+         _objectPath = new ObjectPath("A", "B", "C");
+         _parameter = new Parameter().WithDimension(DomainHelperForSpecs.FractionDimensionForSpecs());
+         _parameter.Formula = new ExplicitFormula("t");
+      }
+
+      protected override void Because()
+      {
+         _psv = sut.CreateParameterValue(_objectPath, _parameter);
+      }
+
+      [Observation]
+      public void the_value_should_be_null()
+      {
+         _psv.Value.ShouldBeNull();
+      }
+
+      [Observation]
+      public void the_formula_should_be_set()
+      {
+         _psv.Formula.IsExplicit().ShouldBeTrue();
+      }
+   }
+
    internal class When_creating_a_parameter_value_for_a_parameter_and_object_path : concern_for_ParameterValuesCreator
    {
       private ObjectPath _objectPath;
@@ -40,11 +72,18 @@ namespace OSPSuite.Core.Domain
          base.Context();
          _objectPath = new ObjectPath("A", "B", "C");
          _parameter = DomainHelperForSpecs.ConstantParameterWithValue(5).WithDimension(DomainHelperForSpecs.FractionDimensionForSpecs());
+         _parameter.Formula = new ExplicitFormula("5");
       }
 
       protected override void Because()
       {
          _psv = sut.CreateParameterValue(_objectPath, _parameter);
+      }
+
+      [Observation]
+      public void the_formula_should_be_null()
+      {
+         _psv.Formula.ShouldBeNull();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2368

# Description
The logic of setting/clearing values and formulas in ParameterValues was not correct when creating from a Parameter

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):