### PR TITLE
Fixes #2372 Create all processes for a simulation

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -26,6 +26,8 @@ namespace OSPSuite.Core.Domain.Builder
          performMerge();
       }
 
+      public bool CreateAllProcessRateParameters => _simulationConfiguration.CreateAllProcessRateParameters;
+
       public IObjectBase BuilderFor(IObjectBase modelObject) => _builderCache[modelObject];
 
       internal void AddBuilderReference(IObjectBase modelObject, IObjectBase builder)

--- a/src/OSPSuite.Core/Domain/Builder/SimulationConfiguration.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationConfiguration.cs
@@ -17,6 +17,7 @@ namespace OSPSuite.Core.Domain.Builder
       public bool ShouldValidate { get; set; } = true;
       public bool ShowProgress { get; set; } = true;
       public bool PerformCircularReferenceCheck { get; set; } = true;
+      public bool CreateAllProcessRateParameters { get; set; }
 
       public virtual IndividualBuildingBlock Individual { get; set; }
       public virtual SimulationSettings SimulationSettings { get; set; }
@@ -55,6 +56,7 @@ namespace OSPSuite.Core.Domain.Builder
          sourceConfiguration.ModuleConfigurations.Each(x => AddModuleConfiguration(cloneManager.Clone(x)));
          SimulationSettings = cloneManager.Clone(sourceConfiguration.SimulationSettings);
          Individual = cloneManager.Clone(sourceConfiguration.Individual);
+         CreateAllProcessRateParameters = sourceConfiguration.CreateAllProcessRateParameters;
       }
 
       /// <summary>

--- a/src/OSPSuite.Core/Domain/Mappers/ReactionBuilderToReactionMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ReactionBuilderToReactionMapper.cs
@@ -46,7 +46,7 @@ namespace OSPSuite.Core.Domain.Mappers
 
          reaction.AddChildren(_parameterMapper.MapLocalFrom(reactionBuilder, simulationBuilder));
 
-         if (reactionBuilder.CreateProcessRateParameter)
+         if (reactionBuilder.CreateProcessRateParameter || simulationBuilder.CreateAllProcessRateParameters)
             reaction.Add(processRateParameterFor(reactionBuilder, simulationBuilder));
 
          simulationBuilder.AddBuilderReference(reaction, reactionBuilder);

--- a/src/OSPSuite.Core/Domain/Mappers/TransportBuilderToTransportMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/TransportBuilderToTransportMapper.cs
@@ -45,7 +45,7 @@ namespace OSPSuite.Core.Domain.Mappers
          addLocalParameters(transport, transportBuilder, simulationBuilder);
 
          //lastly, add parameter rate transporter if required
-         if (transportBuilder.CreateProcessRateParameter)
+         if (transportBuilder.CreateProcessRateParameter || simulationBuilder.CreateAllProcessRateParameters)
             transport.Add(processRateParameterFor(transportBuilder, simulationBuilder));
 
          return transport;

--- a/src/OSPSuite.Core/Serialization/Xml/SimulationConfigurationXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/SimulationConfigurationXmlSerializer.cs
@@ -16,6 +16,7 @@ namespace OSPSuite.Core.Serialization.Xml
       {
          Map(x => x.Individual);
          Map(x => x.SimulationSettings);
+         Map(x => x.CreateAllProcessRateParameters);
          MapEnumerable(x => x.ModuleConfigurations, x => x.AddModuleConfiguration);
          MapEnumerable(x => x.ExpressionProfiles, x => x.AddExpressionProfile);
          MapEnumerable(x => x.AllCalculationMethods, x => x.AddCalculationMethod);

--- a/tests/OSPSuite.Core.Tests/Mappers/ReactionBuilderToReactionMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/ReactionBuilderToReactionMapperSpecs.cs
@@ -159,4 +159,42 @@ namespace OSPSuite.Core.Mappers
          _processRateParameter.Persistable.ShouldBeTrue();
       }
    }
+
+   internal class When_mapping_a_reaction_builder_to_a_reaction_for_which_all_parameter_rates_should_be_generated : concern_for_ReactionBuilderToReactionMapper
+   {
+      private IFormula _kinetic;
+      private IParameter _processRateParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _kinetic = A.Fake<IFormula>();
+         _reactionBuilder.CreateProcessRateParameter = false;
+         A.CallTo(() => _formulaMapper.MapFrom(_kinetic, _simulationBuilder)).ReturnsLazily(x => new ExplicitFormula("clone"));
+         _reactionBuilder.Name = "Reaction";
+         _reactionBuilder.Formula = _kinetic;
+         A.CallTo(() => _parameterMapper.MapFrom(_reactionBuilder.Parameters, _simulationBuilder)).Returns(new List<IParameter>());
+         _processRateParameter = new Parameter();
+         A.CallTo(() => _objectBaseFactory.Create<IParameter>()).Returns(_processRateParameter);
+         _simulationConfiguration.CreateAllProcessRateParameters = true;
+      }
+
+      protected override void Because()
+      {
+         _reaction = sut.MapFromLocal(_reactionBuilder, _container, _simulationBuilder);
+         _processRateParameter = _reaction.GetSingleChildByName<IParameter>(Constants.Parameters.PROCESS_RATE);
+      }
+
+      [Observation]
+      public void should_have_created_the_parameter()
+      {
+         _processRateParameter.ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void created_Parameter_should_not_be_persistable()
+      {
+         _processRateParameter.Persistable.ShouldBeFalse();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2372

# Description
Add a flag to `SimulationConfiguration` that overrides reaction builder and transport builder to create all process rates in a simulation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):