### PR TITLE
Fixes #2376 Consolidate invalid project version messages

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1374,21 +1374,17 @@ namespace OSPSuite.Assets
 
       private static string projectNameAndVersionAsString(string versionDisplay, int version) => $"V{versionDisplay} {numberDisplay(version)}";
 
-      public static string ProjectVersionCannotBeLoaded(int projectVersion, 
-         string oldestSupportedDisplayVersion, int oldestSupportedVersion, 
-         string currentSupportedDisplayVersion,int currentSupportedVersion,
-         bool projectIsTooOld, 
+      public static string ProjectVersionCannotBeLoaded(
+         int projectVersion, 
+         string oldestSupportedDisplayVersion, 
+         int oldestSupportedVersion, 
+         string currentSupportedDisplayVersion,
+         int currentSupportedVersion,
          string downloadUrl)
       {
          var compositeOldestVersion = projectNameAndVersionAsString(oldestSupportedDisplayVersion, oldestSupportedVersion);
          var compositeCurrentVersion = projectNameAndVersionAsString(currentSupportedDisplayVersion, currentSupportedVersion);
          var preamble = $"This application is compatible with projects created between {compositeOldestVersion} and {compositeCurrentVersion}";
-         if (projectIsTooOld)
-         {
-            return $"{preamble}.\n\n" +
-                   $"The version of this project {numberDisplay(projectVersion)} is too old and cannot be loaded.\n\n" +
-                   $"Visit our download page at {downloadUrl} to download an older version of the software compatible with this project.";
-         }
 
          if (projectVersion > currentSupportedVersion)
          {
@@ -1397,7 +1393,9 @@ namespace OSPSuite.Assets
                    $"Visit our download page at {downloadUrl}";
          }
 
-         return $"Work in progress.\nThis project file is too old {numberDisplay(projectVersion)} and cannot be loaded.\nSorry :-(";
+         return $"{preamble}.\n\n" +
+                $"The version of this project {numberDisplay(projectVersion)} is too old and cannot be loaded.\n\n" +
+                $"Visit our download page at {downloadUrl} to download an older version of the software compatible with this project.";
       }
    }
 

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1369,6 +1369,36 @@ namespace OSPSuite.Assets
 
          }
       }
+
+      private static string numberDisplay(int version) => $"(#{version})";
+
+      private static string projectNameAndVersionAsString(string versionDisplay, int version) => $"V{versionDisplay} {numberDisplay(version)}";
+
+      public static string ProjectVersionCannotBeLoaded(int projectVersion, 
+         string oldestSupportedDisplayVersion, int oldestSupportedVersion, 
+         string currentSupportedDisplayVersion,int currentSupportedVersion,
+         bool projectIsTooOld, 
+         string downloadUrl)
+      {
+         var compositeOldestVersion = projectNameAndVersionAsString(oldestSupportedDisplayVersion, oldestSupportedVersion);
+         var compositeCurrentVersion = projectNameAndVersionAsString(currentSupportedDisplayVersion, currentSupportedVersion);
+         var preamble = $"This application is compatible with projects created between {compositeOldestVersion} and {compositeCurrentVersion}";
+         if (projectIsTooOld)
+         {
+            return $"{preamble}.\n\n" +
+                   $"The version of this project {numberDisplay(projectVersion)} is too old and cannot be loaded.\n\n" +
+                   $"Visit our download page at {downloadUrl} to download an older version of the software compatible with this project.";
+         }
+
+         if (projectVersion > currentSupportedVersion)
+         {
+            return $"{preamble}.\n\n" +
+                   $"The version of this project {numberDisplay(projectVersion)} is newer and cannot be loaded.\n\n" +
+                   $"Visit our download page at {downloadUrl}";
+         }
+
+         return $"Work in progress.\nThis project file is too old {numberDisplay(projectVersion)} and cannot be loaded.\nSorry :-(";
+      }
    }
 
    public static class Error


### PR DESCRIPTION
Fixes #2376

# Description
There are currently separate implementations of this message in PK-Sim and MoBi. They are the same, but it makes sense only to define it once.

Also, this changes the message to add the display versions to the message where possible.

## Type of change
purely caption

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ce9011e6-f4ac-46c0-9f41-0d2ff1e26a16)

![image](https://github.com/user-attachments/assets/8511001b-36f4-48dc-b41b-acbed1164f6a)

# Questions (if appropriate):