### PR TITLE
Fixes #2379 Support distinct copy and move operations when dropping nodes

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/AbstractExplorerPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/AbstractExplorerPresenter.cs
@@ -29,7 +29,7 @@ namespace OSPSuite.Presentation.Presenters
       /// <summary>
       ///    returns true is the <paramref name="dragNode" /> can be dragged under <paramref name="targetNode" /> otherwise false
       /// </summary>
-      bool CanDrop(ITreeNode dragNode, ITreeNode targetNode);
+      bool CanDrop(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyFlags);
 
       /// <summary>
       ///    Moves the <paramref name="dragNode" /> under the <paramref name="targetNode" />
@@ -38,6 +38,11 @@ namespace OSPSuite.Presentation.Presenters
       /// <param name="targetNode">Node under which the dragged node should be attached</param>
       /// <param name="keyFlags">enum representing keyState on the drop action</param>
       void DropNode(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyFlags = DragDropKeyFlags.None);
+
+      /// <summary>
+      ///   Returns <c>true</c> if the presenter supports separate copy and move operations, otherwise <c>false</c> for only move operations
+      /// </summary>
+      bool CopyAllowed();
    }
 
    public interface IExplorerPresenter :
@@ -377,6 +382,8 @@ namespace OSPSuite.Presentation.Presenters
          _classificationPresenter.MoveNode(classifiableNode, classificationNode);
       }
 
+      public abstract bool CopyAllowed();
+
       public virtual void RemoveNode(ITreeNode nodeToRemove)
       {
          _view.RemoveNode(nodeToRemove);
@@ -397,7 +404,7 @@ namespace OSPSuite.Presentation.Presenters
          _view.DestroyNode(nodeToDestroy);
       }
 
-      public virtual bool CanDrop(ITreeNode dragNode, ITreeNode targetNode)
+      public virtual bool CanDrop(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyFlags)
       {
          var targetClassificationNode = targetNode as ITreeNode<IClassification>;
          if (targetClassificationNode == null)

--- a/tests/OSPSuite.Starter/Presenters/ExplorerForTestPresenter.cs
+++ b/tests/OSPSuite.Starter/Presenters/ExplorerForTestPresenter.cs
@@ -29,6 +29,8 @@ namespace OSPSuite.Starter.Presenters
          return true;
       }
 
+      public override bool CopyAllowed() => false;
+
       public override void NodeDoubleClicked(ITreeNode node)
       {
       }


### PR DESCRIPTION
Fixes #2379

# Description
In module explorer users can drag and either move, or copy building blocks between modules. The distinction needs to be recognized in CanDrag because building blocks used in a simulation can be copied, but not moved.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):