### PR TITLE
Fixes #2382 Improve 'Cannot find quantity with path' message

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1776,6 +1776,7 @@ namespace OSPSuite.Assets
       public static string DuplicatedPKParameterSensitivityFor(string id) => $"PKParameter sensitivity results for '{id}' were defined more than once!";
 
       public static string CouldNotFindQuantityWithPath(string quantityPath) => $"Could not find quantity with path '{quantityPath}'.";
+      public static string CouldNotFindContainerWithPath(string quantityPath, string referringEntityPath) => $"Could not find container with path '{quantityPath}'.\n\nReferenced by '{referringEntityPath}'.";
 
       public static string IndividualResultsDoesNotHaveTheExpectedQuantity(int individualId, IReadOnlyList<string> expectedQuantities, IReadOnlyList<string> foundQuantities)
       {

--- a/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
@@ -298,10 +298,11 @@ namespace OSPSuite.Core.Domain.Services
 
       private IContainer getContainerOrThrow(IReadOnlyList<string> path, IEntity entity)
       {
+         var entityPath = _entityPathResolver.FullPathFor(entity);
          //we use resolve to that an exception is thrown
          var container = new ObjectPath(path).Resolve<IContainer>(entity);
          if (container == null)
-            throw new OSPSuiteException(Error.CouldNotFindQuantityWithPath(path.ToPathString()));
+            throw new OSPSuiteException(Error.CouldNotFindContainerWithPath(path.ToPathString(), entityPath));
 
          return container;
       }


### PR DESCRIPTION
Fixes #2382

# Description
Helps users find where the missing container is referenced from

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):