### PR TITLE
Comparison of passive transports: difference in "Create process rate" flag is not shown #2394

### DIFF
--- a/src/OSPSuite.Core/Comparison/ReactionBuilderDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/ReactionBuilderDiffBuilder.cs
@@ -24,6 +24,7 @@ namespace OSPSuite.Core.Comparison
          _enumerableComparer.CompareEnumerables(comparison, x => x.Products, item => item.MoleculeName);
          _enumerableComparer.CompareEnumerables(comparison, x => x.ModifierNames, item => item, missingItemType: ObjectTypes.Modifier);
          CompareValues(x => x.ContainerCriteria, x => x.ContainerCriteria, comparison);
+         CompareValues(x => x.CreateProcessRateParameter, x => x.CreateProcessRateParameter, comparison);
          _objectComparer.Compare(comparison.DimensionComparison());
       }
    }

--- a/src/OSPSuite.Core/Comparison/TransporterBuilderDiffBuilder.cs
+++ b/src/OSPSuite.Core/Comparison/TransporterBuilderDiffBuilder.cs
@@ -22,6 +22,7 @@ namespace OSPSuite.Core.Comparison
          CompareValues(x => x.TargetCriteria, x => x.TargetCriteria, comparison);
          _objectComparer.Compare(comparison.DimensionComparison());
          _moleculeDependentBuilderDiffBuilder.Compare(comparison);
+         CompareValues(x => x.CreateProcessRateParameter, x => x.CreateProcessRateParameter, comparison);
          _objectComparer.Compare(comparison.FormulaComparison());
       }
    }

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ReactionBuilderDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/ReactionBuilderDiffBuilderSpecs.cs
@@ -44,6 +44,35 @@ namespace OSPSuite.Core.DiffBuilders
       }
    }
 
+   public class When_comparing_reactions_having_different_create_process_rate_parameter_values : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var f1 = new ExplicitFormula("CL*conc").WithName("formula");
+         var r1 = new ReactionBuilder().WithName("Reaction").WithFormula(f1);
+         r1.AddEduct(new ReactionPartnerBuilder("Drug", 1));
+         r1.AddEduct(new ReactionPartnerBuilder("Metab", 1));
+         var p11 = new Parameter().WithName("P1").WithFormula(new ConstantFormula(2)).WithParentContainer(r1);
+         r1.CreateProcessRateParameter = true;
+
+         var f2 = new ExplicitFormula("CL*conc").WithName("formula");
+         var r2 = new ReactionBuilder().WithName("Reaction").WithFormula(f2);
+         r2.AddEduct(new ReactionPartnerBuilder("Drug", 1));
+         r2.AddEduct(new ReactionPartnerBuilder("Metab", 1));
+         var p12 = new Parameter().WithName("P1").WithFormula(new ConstantFormula(2)).WithParentContainer(r2);
+
+         _object1 = r1;
+         _object2 = r2;
+      }
+
+      [Observation]
+      public void should_report_the_differences_accordingly()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+      }
+   }
+
    public class When_comparing_reactions_having_the_same_formula_but_different_modifiers : concern_for_ObjectComparer
    {
       protected override void Context()

--- a/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TransportBuilderDiffBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/DiffBuilders/TransportBuilderDiffBuilderSpecs.cs
@@ -29,6 +29,26 @@ namespace OSPSuite.Core.DiffBuilders
       }
    }
 
+   public class When_comparing_Transports_with_different_for_create_process_rate : concern_for_ObjectComparer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var t1 = new TransportBuilder().WithName("Passive");
+         var t2 = new TransportBuilder().WithName("Passive");
+         t1.CreateProcessRateParameter = true;
+
+         _object1 = t1;
+         _object2 = t2;
+      }
+
+      [Observation]
+      public void should_report_the_differences_accordingly()
+      {
+         _report.Count.ShouldBeEqualTo(1);
+      }
+   }
+
    public class When_comparing_Transports_with_different_for_all_settings : concern_for_ObjectComparer
    {
       protected override void Context()


### PR DESCRIPTION
Fixes #2394 Comparison of passive transports: difference in "Create process rate" flag is not shown 

# Description

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):