### PR TITLE
Fixes #2400 errors in pi sensitivity calculation are not obvious to the user

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1025,6 +1025,14 @@ namespace OSPSuite.Assets
             return $"Parameter identification '{parameterIdentificationName}' finished in {duration}";
          }
 
+
+         public static string SensitivityCalculationFailed(string parameterIdentificationName, IReadOnlyList<string> errorMessages, string duration = null)
+         {
+            return string.IsNullOrEmpty(duration) ? 
+               $"Parameter identification '{parameterIdentificationName}' finished but sensitivity calculation failed.\n\n {string.Join("\n\n", errorMessages)}" : 
+               $"Parameter identification '{parameterIdentificationName}' finished in {duration} but sensitivity calculation failed.\n\n {string.Join("\n\n", errorMessages)}";
+         }
+
          public static string LinkedParametersIn(string name)
          {
             return $"{LinkedParameters} in {name}";
@@ -1884,6 +1892,21 @@ namespace OSPSuite.Assets
       public static string NeighborhoodDefinition(string neighborhoodName, string firstNeighbor, string secondNeighbor, string spatialStructure)
       {
          return $"Neighborhood '{neighborhoodName}' connects '{firstNeighbor}' and '{secondNeighbor}' in '{spatialStructure}'";
+      }
+
+      public static string CouldNotCalculateSensitivity(IReadOnlyList<string> runResultErrorMessages)
+      {
+         return $"Error calculating sensitivity\n{listErrorMessages(runResultErrorMessages)}";
+      }
+
+      private static string listErrorMessages(IReadOnlyList<string> runResultErrorMessages)
+      {
+         var sb = new StringBuilder();
+         foreach (var errorMessage in runResultErrorMessages)
+         {
+            sb.AppendLine($"- {errorMessage}");
+         }
+         return sb.ToString();
       }
    }
 

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/OptimizationRunResult.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/OptimizationRunResult.cs
@@ -67,6 +67,8 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
          get { return AllOutputResiduals.SelectMany(y => y).Select(y => y.Value).ToArray(); }
       }
 
+      public IReadOnlyList<string> ErrorMessages { get; set; }
+
       public virtual DataColumn SimulationResultFor(string fullOutputPath)
       {
          return SimulationResults.SelectMany(x => x.Columns).FirstOrDefault(x => string.Equals(x.PathAsString, fullOutputPath));

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/RunStatus.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/RunStatus.cs
@@ -12,7 +12,8 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
       RanToCompletion,
       Canceled,
       Faulted,
-      CalculatingSensitivity
+      CalculatingSensitivity,
+      SensitivityCalculationFailed
    }
 
    public class RunStatus: IWithIcon
@@ -42,6 +43,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
       public static RunStatus Canceled = create(RunStatusId.Canceled, IconNames.STOP);
       public static RunStatus Faulted = create(RunStatusId.Faulted, IconNames.ERROR);
       public static RunStatus CalculatingSensitivity = create(RunStatusId.CalculatingSensitivity, IconNames.SOLVER);
+      public static RunStatus SensitivityCalculationFailed = create(RunStatusId.SensitivityCalculationFailed, IconNames.WARNING);
 
       private static RunStatus create(RunStatusId id, string icon, string displayName = null)
       {

--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRunner.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRunner.cs
@@ -53,7 +53,11 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
                await parameterIdentificationEngine.StartAsync(parameterIdentification);
                var end = SystemTime.UtcNow();
                var timeSpent = end - begin;
-               _dialogCreator.MessageBoxInfo(Captions.ParameterIdentification.ParameterIdentificationFinished(parameterIdentification.Name, timeSpent.ToDisplay()));
+
+               var faultedRunResults = parameterIdentification.Results.Where(x => x.Status == RunStatus.SensitivityCalculationFailed).ToList();
+               _dialogCreator.MessageBoxInfo(faultedRunResults.Any() ? 
+                  Captions.ParameterIdentification.SensitivityCalculationFailed(parameterIdentification.Name, faultedRunResults.Select(x => x.Message).ToList(), timeSpent.ToDisplay()) : 
+                  Captions.ParameterIdentification.ParameterIdentificationFinished(parameterIdentification.Name, timeSpent.ToDisplay()));
             }
          }
          catch (OperationCanceledException)

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationMatrixAnalysisPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationMatrixAnalysisPresenter.cs
@@ -59,6 +59,12 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
 
       protected virtual void UpdateAnalysis()
       {
+         var parameterIdentificationRunResults = _parameterIdentification.Results.Where(x => x.Status == RunStatus.SensitivityCalculationFailed).ToList();
+         if(parameterIdentificationRunResults.Any())
+         {
+            _matrixPresenter.ShowCalculationError(Captions.ParameterIdentification.SensitivityCalculationFailed(_parameterIdentification.Name, parameterIdentificationRunResults.Select(x => x.Message).ToList()));
+            return;
+         }
          try
          {
             var matrix = CalculateMatrix();
@@ -79,7 +85,8 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
          AllRunResults = _parameterIdentification.Results.OrderBy(x => x.TotalError).ToList();
          _view.CanSelectRunResults = AllRunResults.Count > 1;
 
-         if (!AllRunResults.Any()) return;
+         if (!AllRunResults.Any()) 
+            return;
 
          SelectedRunResults = AllRunResults.First();
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationCovarianceMatrixPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationCovarianceMatrixPresenterSpecs.cs
@@ -1,6 +1,6 @@
-using System.Data;
 using System.Linq;
 using FakeItEasy;
+using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.Core.Chart.ParameterIdentifications;
 using OSPSuite.Core.Domain;
@@ -15,11 +15,10 @@ namespace OSPSuite.Presentation.Presentation
    public abstract class concern_for_ParameterIdentificationCovarianceMatrixPresenter : ContextSpecification<ParameterIdentificationCovarianceAnalysisPresenter>
    {
       private IPresentationSettingsTask _presentationSettingsTask;
-      protected IParameterIdentificationSingleRunAnalysisView _view;
-      protected DataTable _dataTable;
-      protected ParameterIdentification _parameterIdentification;
-      protected ParameterIdentificationCovarianceMatrix _correlationCovarianceMatrix;
-      protected IMatrixCalculator _matrixCalculator;
+      private IParameterIdentificationSingleRunAnalysisView _view;
+      private ParameterIdentification _parameterIdentification;
+      private ParameterIdentificationCovarianceMatrix _correlationCovarianceMatrix;
+      private IMatrixCalculator _matrixCalculator;
       private IParameterIdentificationMatrixPresenter _matrixPresenter;
       private IParameterIdentificationCovarianceAnalysisView _covarianceView;
       private IParameterIdentificationConfidenceIntervalPresenter _confidenceIntervalPresenter;
@@ -31,14 +30,14 @@ namespace OSPSuite.Presentation.Presentation
          _matrixCalculator = A.Fake<IMatrixCalculator>();
          _parameterIdentification = A.Fake<ParameterIdentification>();
          _correlationCovarianceMatrix = A.Fake<ParameterIdentificationCovarianceMatrix>();
-         _matrixPresenter= A.Fake<IParameterIdentificationMatrixPresenter>();
-         _covarianceView= A.Fake<IParameterIdentificationCovarianceAnalysisView>();
-         _confidenceIntervalPresenter= A.Fake<IParameterIdentificationConfidenceIntervalPresenter>();
+         _matrixPresenter = A.Fake<IParameterIdentificationMatrixPresenter>();
+         _covarianceView = A.Fake<IParameterIdentificationCovarianceAnalysisView>();
+         _confidenceIntervalPresenter = A.Fake<IParameterIdentificationConfidenceIntervalPresenter>();
          A.CallTo(() => _parameterIdentification.Results).Returns(new[] { new ParameterIdentificationRunResult { JacobianMatrix = new JacobianMatrix(new[] { "A" }) } });
          var matrix = new Matrix(new[] { "A" }, new[] { "A" });
          matrix.SetRow(0, new[] { 1d });
          A.CallTo(_matrixCalculator).WithReturnType<Matrix>().Returns(matrix);
-         sut = new ParameterIdentificationCovarianceAnalysisPresenter(_view,_covarianceView, _matrixPresenter, _presentationSettingsTask,  _matrixCalculator,_confidenceIntervalPresenter);
+         sut = new ParameterIdentificationCovarianceAnalysisPresenter(_view, _covarianceView, _matrixPresenter, _presentationSettingsTask, _matrixCalculator, _confidenceIntervalPresenter);
       }
 
       public class When_displaying_an_analysis_for_a_parameter_identification : concern_for_ParameterIdentificationCovarianceMatrixPresenter
@@ -59,6 +58,31 @@ namespace OSPSuite.Presentation.Presentation
          {
             A.CallTo(() => _covarianceView.SetMatrixView(_matrixPresenter.View)).MustHaveHappened();
             A.CallTo(() => _covarianceView.SetConfidenceIntevalView(_confidenceIntervalPresenter.View)).MustHaveHappened();
+         }
+      }
+
+      public class When_displaying_a_covariance_analysis_for_a_parameter_identification_when_sensitivity_calculation_has_failed : concern_for_ParameterIdentificationCovarianceMatrixPresenter
+      {
+         protected override void Context()
+         {
+            base.Context();
+            _parameterIdentification.Results.First().Status = RunStatus.SensitivityCalculationFailed;
+         }
+
+         protected override void Because()
+         {
+            sut.InitializeAnalysis(_correlationCovarianceMatrix, _parameterIdentification);
+         }
+
+         [Observation]
+         public void should_show_the_sensitivity_error_in_the_presenter()
+         {
+            A.CallTo(() => _matrixPresenter.ShowCalculationError(A<string>.That.Matches(x => errorMessageMatchesExpected(x)))).MustHaveHappened();
+         }
+
+         private bool errorMessageMatchesExpected(string s)
+         {
+            return s.Equals(Captions.ParameterIdentification.SensitivityCalculationFailed(_parameterIdentification.Name, new[] { _parameterIdentification.Results.First().Message }));
          }
       }
    }


### PR DESCRIPTION
Fixes #2400 

# Description
During sensitivity calculations in a PI, errors are not propagated to the user. This is a special step that is not a "PI Error" so it's shown as a warning. The PI is still valid if it completed.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
See #2400 

# Questions (if appropriate):