### PR TITLE
Fixes 2404 allow faster cancel from PI

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
@@ -25,6 +25,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       private readonly ICoreUserSettings _coreUserSettings;
       private ParameterIdentification _parameterIdentification;
       private readonly CancellationTokenSource _cancellationTokenSource;
+      private List<IParameterIdentificationRun> _parameterIdentificationRuns;
 
       public ParameterIdentificationEngine(
          IEventPublisher eventPublisher, 
@@ -44,14 +45,14 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          _eventPublisher.PublishEvent(new ParameterIdentificationStartedEvent(parameterIdentification));
 
          var results = new ConcurrentBag<ParameterIdentificationRunResult>();
-         var parameterIdentificationRuns = new List<IParameterIdentificationRun>();
+         _parameterIdentificationRuns = new List<IParameterIdentificationRun>();
          try
          {
-            parameterIdentificationRuns.AddRange(await createParameterIdentificationRuns(token));
-            parameterIdentificationRuns.Each(notifyRun);
+            _parameterIdentificationRuns.AddRange(await createParameterIdentificationRuns(token));
+            _parameterIdentificationRuns.Each(notifyRun);
             var parallelOptions = createParallelOptions(token);
 
-            await Task.Run(() => Parallel.ForEach(parameterIdentificationRuns, parallelOptions,
+            await Task.Run(() => Parallel.ForEach(_parameterIdentificationRuns, parallelOptions,
                run =>
                {
                   parallelOptions.CancellationToken.ThrowIfCancellationRequested();
@@ -68,8 +69,9 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          }
          finally
          {
-            parameterIdentificationRuns.Each(x => x.Dispose());
+            _parameterIdentificationRuns.Each(x => x.Dispose());
             _eventPublisher.PublishEvent(new ParameterIdentificationTerminatedEvent(parameterIdentification));
+            _parameterIdentificationRuns = null;
          }
       }
 
@@ -102,6 +104,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       public void Stop()
       {
          _cancellationTokenSource.Cancel();
+         _parameterIdentificationRuns?.Each(x => x.Cancel());
       }
 
       private async Task<IReadOnlyList<IParameterIdentificationRun>> createParameterIdentificationRuns(CancellationToken cancellationToken)

--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
@@ -71,6 +71,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          {
             _parameterIdentificationRuns.Each(x => x.Dispose());
             _eventPublisher.PublishEvent(new ParameterIdentificationTerminatedEvent(parameterIdentification));
+            _parameterIdentificationRuns.Clear();
          }
       }
 

--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
@@ -33,6 +33,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       ParameterIdentificationRunResult RunResult { get; }
       IReadOnlyList<float> TotalErrorHistory { get; }
       IReadOnlyCollection<IdentificationParameterHistory> ParametersHistory { get; }
+      void Cancel();
    }
 
    public class ParameterIdentificationRun : IParameterIdentificationRun
@@ -54,6 +55,11 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       public ParameterIdentificationRunResult RunResult { get; } = new ParameterIdentificationRunResult();
       public IReadOnlyList<float> TotalErrorHistory => _totalErrorHistory;
       public IReadOnlyCollection<IdentificationParameterHistory> ParametersHistory => _parametersHistory;
+
+      public void Cancel()
+      {
+         _allSimModelBatches.Values.Each(x => x.StopSimulation());
+      }
 
       public event EventHandler<ParameterIdentificationRunStatusEventArgs> RunStatusChanged = delegate { };
 

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
@@ -168,20 +168,9 @@ namespace OSPSuite.Core.Domain
 
    public class When_canceling_a_run : concern_for_ParameterIdentificationRun
    {
-      private IReadOnlyList<string> _parameters;
-      private List<DataRepository> _observedDataList;
-
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _simModelBatch.InitializeWith(_modelCoreSimulation,
-               A<IReadOnlyList<string>>._,
-               A<IReadOnlyList<string>>._, A<bool>._, A<string>._))
-            .Invokes(x => _parameters = x.GetArgument<IReadOnlyList<string>>(1));
-
-         A.CallTo(() => _timeGridUpdater.UpdateSimulationTimeGrid(_modelCoreSimulation, RemoveLLOQModes.NoTrailing, A<IEnumerable<DataRepository>>._))
-            .Invokes(x => _observedDataList = x.GetArgument<IEnumerable<DataRepository>>(2).ToList());
-
          sut.Run(_cancellationToken);
       }
 

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
@@ -166,8 +166,39 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_canceling_a_run : concern_for_ParameterIdentificationRun
+   {
+      private IReadOnlyList<string> _parameters;
+      private List<DataRepository> _observedDataList;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _simModelBatch.InitializeWith(_modelCoreSimulation,
+               A<IReadOnlyList<string>>._,
+               A<IReadOnlyList<string>>._, A<bool>._, A<string>._))
+            .Invokes(x => _parameters = x.GetArgument<IReadOnlyList<string>>(1));
+
+         A.CallTo(() => _timeGridUpdater.UpdateSimulationTimeGrid(_modelCoreSimulation, RemoveLLOQModes.NoTrailing, A<IEnumerable<DataRepository>>._))
+            .Invokes(x => _observedDataList = x.GetArgument<IEnumerable<DataRepository>>(2).ToList());
+
+         sut.Run(_cancellationToken);
+      }
+
+      protected override void Because()
+      {
+         sut.Cancel();
+      }
+
+      [Observation]
+      public void the_batch_must_be_stopped()
+      {
+         A.CallTo(() => _simModelBatch.StopSimulation()).MustHaveHappened();
+      }
+   }
+
    public class
-      When_initializing_the_parameter_indentification_run_with_a_parameter_identification_with_multiple_simulations :
+      When_initializing_the_parameter_identification_run_with_a_parameter_identification_with_multiple_simulations :
          concern_for_ParameterIdentificationRun
    {
       private OutputMapping _outputMapping2;


### PR DESCRIPTION
Fixes #2404

# Description
We were canceling all future runs, but not stopping the current run. The runs can take quite a lot of time.

Conversely, canceling a simulation is very fast...

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):