### PR TITLE
Fixes #88 Invalid Parameter Identification finishes "successfully"

### DIFF
--- a/src/OSPSuite.Core/OSPSuite.Core.csproj
+++ b/src/OSPSuite.Core/OSPSuite.Core.csproj
@@ -44,7 +44,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
     <PackageReference Include="OSPSuite.Serializer" Version="3.0.0.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
   </ItemGroup>

--- a/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
+++ b/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
@@ -46,8 +46,6 @@
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/OSPSuite.Core.Tests/OSPSuite.Core.Tests.csproj
+++ b/tests/OSPSuite.Core.Tests/OSPSuite.Core.Tests.csproj
@@ -23,8 +23,6 @@
     </PackageReference>
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/OSPSuite.Core.Tests/Services/ResidualCalculatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ResidualCalculatorSpecs.cs
@@ -543,8 +543,6 @@ namespace OSPSuite.Core.Services
       {
          base.Context();
          sut = new ResidualCalculatorForOnlyObservedData(new TimeGridRestrictor(), _dimensionFactory);
-         sut.Initialize(RemoveLLOQModes.Always);
-         _outputMapping.Scaling = Scalings.Linear;
          
       }
 

--- a/tests/OSPSuite.Core.Tests/Services/ResidualCalculatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ResidualCalculatorSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
+using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -533,6 +534,36 @@ namespace OSPSuite.Core.Services
          _outputResiduals.Residuals[0].Value.ShouldBeEqualTo(Math.Log10(ToDouble(_simulationDataColumn.GetValue(_observedDataColumn.BaseGrid[1]))) - Math.Log10(ToDouble(_observedDataColumn[1])));
          _outputResiduals.Residuals[1].Value.ShouldBeEqualTo(Math.Log10(ToDouble(_simulationDataColumn.GetValue(_observedDataColumn.BaseGrid[2]))) - Math.Log10(ToDouble(_observedDataColumn[2])));
       }
+   }
+
+   public class When_calculating_the_residuals_with_invalid_simulation_values : concern_for_ResidualCalculator
+   {
+
+      protected override void Context()
+      {
+         base.Context();
+         sut = new ResidualCalculatorForOnlyObservedData(new TimeGridRestrictor(), _dimensionFactory);
+         sut.Initialize(RemoveLLOQModes.Always);
+         _outputMapping.Scaling = Scalings.Linear;
+         
+      }
+
+      protected override void UpdateObservedDataValues()
+      {
+         _observedDataColumn.BaseGrid.Values = new[] { 1f, 2f, 3f };
+         _observedDataColumn.Values = new[] { 1.1f, 1.2f, 1.3f };
+      }
+
+      [TestCase(float.PositiveInfinity, double.PositiveInfinity)]
+      [TestCase(float.NegativeInfinity, double.NegativeInfinity)]
+      [TestCase(float.NaN, double.NaN)]
+      public void test_invalid_value(float simulationValue, double expectedResidualValue)
+      {
+         _simulationResults.FirstDataColumn()[1] = simulationValue;
+         var outputResiduals = sut.Calculate(_simulationRunResultsList, _outputMappings).AllOutputResidualsFor(_fullOutputPath).First();
+         outputResiduals.Residuals[0].Value.ShouldBeEqualTo(expectedResidualValue);
+      }
+
    }
 
    public class When_calculating_the_residuals_with_observed_data_containing_NaN_values : concern_for_ResidualCalculator

--- a/tests/OSPSuite.Presentation.Tests/OSPSuite.Presentation.Tests.csproj
+++ b/tests/OSPSuite.Presentation.Tests/OSPSuite.Presentation.Tests.csproj
@@ -37,7 +37,6 @@
     </PackageReference>
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
   </ItemGroup>

--- a/tests/OSPSuite.R.Performance/OSPSuite.R.Performance.csproj
+++ b/tests/OSPSuite.R.Performance/OSPSuite.R.Performance.csproj
@@ -56,8 +56,6 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />

--- a/tests/OSPSuite.R.Tests/OSPSuite.R.Tests.csproj
+++ b/tests/OSPSuite.R.Tests/OSPSuite.R.Tests.csproj
@@ -34,8 +34,6 @@
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/OSPSuite.Starter/OSPSuite.Starter.csproj
+++ b/tests/OSPSuite.Starter/OSPSuite.Starter.csproj
@@ -57,8 +57,6 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />


### PR DESCRIPTION
Fixes #2408 

# Description
We don't want to ignore simulation outputs that are calculated as Infinity. We do want to ignore observed data that are outside the simulation time.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
Using Monte Carlo

![Image](https://github.com/user-attachments/assets/9a74b9e8-d5cf-48ac-a273-80cd675e8f18)

Using LM

![Image](https://github.com/user-attachments/assets/7aefecaf-c00c-4a72-8256-4c636f4e0365)

Using NM

![Image](https://github.com/user-attachments/assets/fd5548dc-d10b-48e9-9936-eb6f0f99398c)
# Questions (if appropriate):