### PR TITLE
Fixes #2231 Observed data: extended properties without name

### DIFF
--- a/src/OSPSuite.Core/Serialization/Xml/DataRepositoryXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/DataRepositoryXmlSerializer.cs
@@ -24,7 +24,12 @@ namespace OSPSuite.Core.Serialization.Xml
 
       private Action<IExtendedProperty> addFunction(DataRepository dataRepository)
       {
-         return dataRepository.ExtendedProperties.Add;
+         return x =>
+         {
+            if (string.IsNullOrEmpty(x.Name))
+               x.Name = $"Unnamed Property {dataRepository.ExtendedProperties.Count}";
+            dataRepository.ExtendedProperties.Add(x);
+         };
       }
 
       protected override void TypedDeserialize(DataRepository dataRepository, XElement outputToDeserialize, SerializationContext serializationContext)

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/DataRepositoryXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/DataRepositoryXmlSerializerSpecs.cs
@@ -1,10 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
 using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Helpers;
+using OSPSuite.Core.Serialization;
+using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Helpers;
+using OSPSuite.Serializer.Xml;
+using OSPSuite.Utility.Container;
 
 namespace OSPSuite.Core.Serializers
 {
@@ -69,6 +77,63 @@ namespace OSPSuite.Core.Serializers
       public void deserialized_repository_should_be_equal_to_original()
       {
          AssertForSpecs.AreEqualDataRepository(_originalRepository, _deserializedRepository);
+      }
+   }
+
+   public class When_serializing_unnamed_extended_property : concern_for_DataRepositoryXmlSerializer
+   {
+      private DataRepository _originalDataRepository;
+      private DataRepository _deserializedDataRepository;
+
+      protected override void Context()
+      {
+         base.Context();
+         _originalDataRepository = new DataRepository
+         {
+            Name = "Rene",
+            Description = "The best Repository"
+         };
+         _originalDataRepository.Add(_col1);
+         _originalDataRepository.Add(_baseGrid);
+         _originalDataRepository.Add(_col2);
+         _originalDataRepository.Add(_relCol);
+         _originalDataRepository.Add(_col3);
+         _originalDataRepository.ExtendedProperties.Add(new ExtendedProperty<int> { Name = "MyProperty", Value = 34 });
+      }
+
+      protected override void Because()
+      {
+         _deserializedDataRepository = mySerializeAndDeserialize(_originalDataRepository);
+      }
+
+      [Observation]
+      public void the_unnamed_property_should_be_renamed_with_a_placeholder()
+      {
+         _deserializedDataRepository.ExtendedProperties.Single().Name.ShouldBeEqualTo("Unnamed Property 0");
+      }
+
+      private T mySerializeAndDeserialize<T>(T x1)
+      {
+         XElement xel;
+         XElement formulaCacheElement;
+         var formulaCacheSerializer = SerializerRepository.SerializerFor<IFormulaCache>();
+         IXmlSerializer<SerializationContext> serializer;
+
+         using (var serializationContext = SerializationTransaction.Create(IoC.Container))
+         {
+            serializer = SerializerRepository.SerializerFor(x1);
+            xel = serializer.Serialize(x1, serializationContext);
+            formulaCacheElement = formulaCacheSerializer.Serialize(serializationContext.Formulas, serializationContext);
+         }
+
+         var propertyElement = (xel.LastNode as XElement).LastNode as XElement;
+         propertyElement.SetAttributeValue("name", null);
+
+         using (var serializationContext = NewDeserializationContext())
+         {
+            formulaCacheSerializer.Deserialize(serializationContext.Formulas, formulaCacheElement, serializationContext);
+            return serializer.Deserialize<T>(xel, serializationContext);
+         }
       }
    }
 


### PR DESCRIPTION
Fixes #2231

# Description
Tolerating imported observed data when an extended property does not have a name. This creates a placeholder name where one is missing. See the screenshot

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/55a77b9a-c3e3-43c5-bf1c-a53f539169a2)


# Questions (if appropriate):