### PR TITLE
#1717 Allow enablingAutoReduceTolerances on sumulator options

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/SimModelManager.cs
+++ b/src/OSPSuite.Core/Domain/Services/SimModelManager.cs
@@ -92,6 +92,7 @@ namespace OSPSuite.Core.Domain.Services
          options.ShowProgress = true;
          options.ExecutionTimeLimit = _executionTimeLimit;
          options.CheckForNegativeValues = _simulationRunOptions.CheckForNegativeValues;
+         options.AutoReduceTolerances = _simulationRunOptions.AutoReduceTolerances;
 
          try
          {

--- a/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
@@ -17,6 +17,11 @@ namespace OSPSuite.Core.Domain
       /// </summary>
       public bool CheckForNegativeValues { get; set; }
 
+      /// <summary>
+      ///   Specifies whether auto reduce tolerance should be applied
+      /// </summary>
+      public bool AutoReduceTolerances { get; set; }
+
       public SimulationRunOptions()
       {
          SimModelExportMode = SimModelExportMode.Full;

--- a/src/OSPSuite.R/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.R/Domain/SimulationRunOptions.cs
@@ -13,5 +13,10 @@ namespace OSPSuite.R.Domain
       ///    Specifies whether progress bar should be shown during simulation run. Default is <c>true</c>
       /// </summary>
       public bool ShowProgress { get; set; } = true;
+
+      /// <summary>
+      ///   Specifies whether auto reduce tolerance should be applied
+      /// </summary>
+      public bool AutoReduceTolerances { get; set; }
    }
 }

--- a/src/OSPSuite.R/Services/SimulationRunner.cs
+++ b/src/OSPSuite.R/Services/SimulationRunner.cs
@@ -131,7 +131,8 @@ namespace OSPSuite.R.Services
          return new Core.Domain.SimulationRunOptions
          {
             CheckForNegativeValues = options.CheckForNegativeValues,
-            SimModelExportMode = SimModelExportMode.Optimized
+            SimModelExportMode = SimModelExportMode.Optimized,
+            AutoReduceTolerances = options.AutoReduceTolerances
          };
       }
 


### PR DESCRIPTION
Fixes #1717 Allow enabling AutoReduceTolerances on simulator options

# Description

Expose Euto Reduce Tolerance option for simulations

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):