### PR TITLE
Fixes #2453 Allow calculation of Thalf for data sets with as few as 3 data points

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/PKValuesCalculator.cs
+++ b/src/OSPSuite.Core/Domain/Services/PKValuesCalculator.cs
@@ -408,7 +408,7 @@ namespace OSPSuite.Core.Domain.Services
          }
 
          /// <summary>
-         ///    Creates a polynomial fit of order 1 for the last 10% or last 4 points
+         ///    Creates a polynomial fit of order 1 for the last 10% or last 3 points
          ///    of the data whichever is greater and returns the two coefficient
          ///    (c_0 and C_1 of the fit)
          /// </summary>

--- a/src/OSPSuite.Core/Domain/Services/PKValuesCalculator.cs
+++ b/src/OSPSuite.Core/Domain/Services/PKValuesCalculator.cs
@@ -173,7 +173,7 @@ namespace OSPSuite.Core.Domain.Services
 
          //only one interval, return the full range
          if (options.SingleDosing)
-            return new[] {fullRange};
+            return new[] { fullRange };
 
          //Two or more intervals
          var intervals = new[]
@@ -408,14 +408,18 @@ namespace OSPSuite.Core.Domain.Services
          }
 
          /// <summary>
-         ///    Creates a polynomial fit of order 1 for the last 10% of the data.
-         ///    and returns the two coefficient (c_0 and C_1 of the fit)
+         ///    Creates a polynomial fit of order 1 for the last 10% or last 4 points
+         ///    of the data whichever is greater and returns the two coefficient
+         ///    (c_0 and C_1 of the fit)
          /// </summary>
          private Tuple<double, double> straightLineFit()
          {
             var errorResult = new Tuple<double, double>(0, 0);
 
-            int numOfPoints = (int) Math.Floor(_time.Count / 10.0);
+            int numOfPoints = (int)Math.Floor(_time.Count / 10.0);
+            if (numOfPoints < 3 && _time.Count >= 3)
+               numOfPoints = 3;
+
             //the number of point is zero. We return a slope of 0. this should never happen
             if (numOfPoints == 0)
                return errorResult;

--- a/tests/OSPSuite.Core.IntegrationTests/PKValuesCalculatorSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/PKValuesCalculatorSpecs.cs
@@ -48,9 +48,9 @@ namespace OSPSuite.Core
          {
             TotalDrugMassPerBodyWeight = 10,
          };
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 0, EndValue = 8, DrugMassPerBodyWeight = _firstDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 8, EndValue = 16, DrugMassPerBodyWeight = _oneMinusLastDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose});
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 0, EndValue = 8, DrugMassPerBodyWeight = _firstDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 8, EndValue = 16, DrugMassPerBodyWeight = _oneMinusLastDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose });
       }
 
       protected override void Because()
@@ -140,24 +140,24 @@ namespace OSPSuite.Core
          {
             TotalDrugMassPerBodyWeight = 10,
          };
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 0, EndValue = 8, DrugMassPerBodyWeight = _firstDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 8, EndValue = 16, DrugMassPerBodyWeight = _oneMinusLastDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose});
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 0, EndValue = 8, DrugMassPerBodyWeight = _firstDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 8, EndValue = 16, DrugMassPerBodyWeight = _oneMinusLastDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose });
 
-         _cmax_tD1_tD2 = new UserDefinedPKParameter {StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxD1D2"};
-         _cmax_tD1_tD2_DOSE_BW = new UserDefinedPKParameter {StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxD1D2_Normalized", NormalizationFactor = _firstDose};
-         _cmax_tD1_tD2_DOSE_BW_auto = new UserDefinedPKParameter {StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max_norm, Name = "MyCmaxD1D2_Normalized_auto"};
+         _cmax_tD1_tD2 = new UserDefinedPKParameter { StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxD1D2" };
+         _cmax_tD1_tD2_DOSE_BW = new UserDefinedPKParameter { StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxD1D2_Normalized", NormalizationFactor = _firstDose };
+         _cmax_tD1_tD2_DOSE_BW_auto = new UserDefinedPKParameter { StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.C_max_norm, Name = "MyCmaxD1D2_Normalized_auto" };
 
-         _tmax_tD1_tD2 = new UserDefinedPKParameter {StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.t_max, Name = "MyTmaxD1D2"};
+         _tmax_tD1_tD2 = new UserDefinedPKParameter { StartApplicationIndex = 0, EndApplicationIndex = 1, StandardPKParameter = StandardPKParameter.t_max, Name = "MyTmaxD1D2" };
 
-         _cmax_t1_t2 = new UserDefinedPKParameter {StartTime = 0, EndTime = 8, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1T2"};
-         _cmax_t1_t2_offset = new UserDefinedPKParameter {StartTime = 0, StartTimeOffset = 16, EndTime = 48, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1T2offset"};
-         _cmax_t1_offset_no_end = new UserDefinedPKParameter {StartTime = 0, StartTimeOffset = 16, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1offset_no_end"};
-         _tThreshold = new UserDefinedPKParameter {StartApplicationIndex = 0, StandardPKParameter = StandardPKParameter.Tthreshold, Name = "Threshold", ConcentrationThreshold = 4};
-         _tThreshold_last = new UserDefinedPKParameter {StartApplicationIndex = 2, StandardPKParameter = StandardPKParameter.Tthreshold, Name = "Threshold_last", ConcentrationThreshold = 5};
+         _cmax_t1_t2 = new UserDefinedPKParameter { StartTime = 0, EndTime = 8, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1T2" };
+         _cmax_t1_t2_offset = new UserDefinedPKParameter { StartTime = 0, StartTimeOffset = 16, EndTime = 48, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1T2offset" };
+         _cmax_t1_offset_no_end = new UserDefinedPKParameter { StartTime = 0, StartTimeOffset = 16, StandardPKParameter = StandardPKParameter.C_max, Name = "MyCmaxT1offset_no_end" };
+         _tThreshold = new UserDefinedPKParameter { StartApplicationIndex = 0, StandardPKParameter = StandardPKParameter.Tthreshold, Name = "Threshold", ConcentrationThreshold = 4 };
+         _tThreshold_last = new UserDefinedPKParameter { StartApplicationIndex = 2, StandardPKParameter = StandardPKParameter.Tthreshold, Name = "Threshold_last", ConcentrationThreshold = 5 };
 
 
-         _allDynamicPkParameters = new[] {_cmax_tD1_tD2, _tmax_tD1_tD2, _cmax_t1_t2, _cmax_t1_t2_offset, _cmax_t1_offset_no_end, _cmax_tD1_tD2_DOSE_BW, _tThreshold, _tThreshold_last, _cmax_tD1_tD2_DOSE_BW_auto};
+         _allDynamicPkParameters = new[] { _cmax_tD1_tD2, _tmax_tD1_tD2, _cmax_t1_t2, _cmax_t1_t2_offset, _cmax_t1_offset_no_end, _cmax_tD1_tD2_DOSE_BW, _tThreshold, _tThreshold_last, _cmax_tD1_tD2_DOSE_BW_auto };
       }
 
       protected override void Because()
@@ -170,7 +170,7 @@ namespace OSPSuite.Core
       {
          _pk[C_max].Value.ShouldBeEqualTo(23.07205582f, 1e-2);
          _pk[C_max_tD1_tD2].Value.ShouldBeEqualTo(_pk[_cmax_tD1_tD2.Name].Value, 1e-2);
-         _pk[_cmax_tD1_tD2_DOSE_BW.Name].Value.ShouldBeEqualTo((float) (_pk[_cmax_tD1_tD2.Name].Value / _firstDose), 1e-2);
+         _pk[_cmax_tD1_tD2_DOSE_BW.Name].Value.ShouldBeEqualTo((float)(_pk[_cmax_tD1_tD2.Name].Value / _firstDose), 1e-2);
          _pk[_cmax_tD1_tD2_DOSE_BW_auto.Name].Value.ShouldBeEqualTo(_pk[_cmax_tD1_tD2_DOSE_BW.Name].Value, 1e-2);
          _pk[C_max_tD1_tD2].Value.ShouldBeEqualTo(_pk[_cmax_t1_t2.Name].Value, 1e-2);
          _pk[Tmax_tD1_tD2].Value.ShouldBeEqualTo(_pk[_tmax_tD1_tD2.Name].Value, 1e-2);
@@ -276,9 +276,9 @@ namespace OSPSuite.Core
             TotalDrugMassPerBodyWeight = 10,
          };
 
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 0, EndValue = 8.1f, DrugMassPerBodyWeight = _firstDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 8.1f, EndValue = 16f, DrugMassPerBodyWeight = _oneMinusLastDose});
-         _pkOptions.AddInterval(new DosingInterval {StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose});
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 0, EndValue = 8.1f, DrugMassPerBodyWeight = _firstDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 8.1f, EndValue = 16f, DrugMassPerBodyWeight = _oneMinusLastDose });
+         _pkOptions.AddInterval(new DosingInterval { StartValue = 16, EndValue = 48, DrugMassPerBodyWeight = _lastDose });
       }
 
       protected override void Because()
@@ -318,8 +318,8 @@ namespace OSPSuite.Core
       protected override void Context()
       {
          base.Context();
-         _baseGrid = new BaseGrid("BaseGrid", NO_DIMENSION) {Values = Array.Empty<float>()};
-         _emptyColumns = new DataColumn("TEST", NO_DIMENSION, _baseGrid) {Values = Array.Empty<float>()};
+         _baseGrid = new BaseGrid("BaseGrid", NO_DIMENSION) { Values = Array.Empty<float>() };
+         _emptyColumns = new DataColumn("TEST", NO_DIMENSION, _baseGrid) { Values = Array.Empty<float>() };
          _pkOptions = new PKCalculationOptions
          {
             TotalDrugMassPerBodyWeight = 10,
@@ -335,6 +335,36 @@ namespace OSPSuite.Core
       public void should_return_an_empty_pk_calculation()
       {
          _pk.HasValueFor(C_max).ShouldBeFalse();
+      }
+   }
+
+   public class When_calculating_pk_values_for_a_column_with_few_values : concern_for_PKValuesCalculator
+   {
+      private PKValues _pk;
+      private DataColumn _emptyColumns;
+      private PKCalculationOptions _pkOptions;
+      private BaseGrid _baseGrid;
+
+      protected override void Context()
+      {
+         base.Context();
+         _baseGrid = new BaseGrid("BaseGrid", NO_DIMENSION) { Values = new[] { 0f, 1f, 2f } };
+         _emptyColumns = new DataColumn("TEST", NO_DIMENSION, _baseGrid) { Values = new[] { 3f, 2f, 0.1f } };
+         _pkOptions = new PKCalculationOptions
+         {
+            TotalDrugMassPerBodyWeight = 10,
+         };
+      }
+
+      protected override void Because()
+      {
+         _pk = sut.CalculatePK(_emptyColumns, _pkOptions);
+      }
+
+      [Observation]
+      public void should_return_an_empty_pk_calculation()
+      {
+         _pk.ValueFor(Thalf).ShouldNotBeEqualTo(float.PositiveInfinity);
       }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/PKValuesCalculatorSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/PKValuesCalculatorSpecs.cs
@@ -341,7 +341,7 @@ namespace OSPSuite.Core
    public class When_calculating_pk_values_for_a_column_with_few_values : concern_for_PKValuesCalculator
    {
       private PKValues _pk;
-      private DataColumn _emptyColumns;
+      private DataColumn _dataColumn;
       private PKCalculationOptions _pkOptions;
       private BaseGrid _baseGrid;
 
@@ -349,7 +349,7 @@ namespace OSPSuite.Core
       {
          base.Context();
          _baseGrid = new BaseGrid("BaseGrid", NO_DIMENSION) { Values = new[] { 0f, 1f, 2f } };
-         _emptyColumns = new DataColumn("TEST", NO_DIMENSION, _baseGrid) { Values = new[] { 3f, 2f, 0.1f } };
+         _dataColumn = new DataColumn("TEST", NO_DIMENSION, _baseGrid) { Values = new[] { 3f, 2f, 0.1f } };
          _pkOptions = new PKCalculationOptions
          {
             TotalDrugMassPerBodyWeight = 10,
@@ -358,11 +358,11 @@ namespace OSPSuite.Core
 
       protected override void Because()
       {
-         _pk = sut.CalculatePK(_emptyColumns, _pkOptions);
+         _pk = sut.CalculatePK(_dataColumn, _pkOptions);
       }
 
       [Observation]
-      public void should_return_an_empty_pk_calculation()
+      public void should_have_non_infinity_value_for_Thalf()
       {
          _pk.ValueFor(Thalf).ShouldNotBeEqualTo(float.PositiveInfinity);
       }


### PR DESCRIPTION
Fixes #2453 

# Description


## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
Before and After
![image](https://github.com/user-attachments/assets/c3931ef9-4836-4a91-b822-9ca5e0a2f878)

# Questions (if appropriate):