### PR TITLE
Fixes #2455 Remove tree nodes in bulk when clearing all nodes

### DIFF
--- a/src/OSPSuite.UI/Controls/UxTreeView.cs
+++ b/src/OSPSuite.UI/Controls/UxTreeView.cs
@@ -198,13 +198,24 @@ namespace OSPSuite.UI.Controls
          DoWithinBatchUpdate(() =>
             this.DoWithinLatch(() =>
             {
-               for (int i = Nodes.Count - 1; i >= 0; i--)
-               {
-                  removeNode(NodeFrom(Nodes[i]), deleteNodes);
-               }
+               for (var i = Nodes.Count - 1; i >= 0; i--) 
+                  detachTreeNodeEvents(i, deleteNodes);
 
+               ClearNodes();
                _allNodes.Clear();
             }));
+      }
+
+      private void detachTreeNodeEvents(int nodeIndex, bool deleteNodes)
+      {
+         var treeNode = NodeFrom(Nodes[nodeIndex]);
+         treeNode.TextChanged -= nodeTextChanged;
+         treeNode.IconChanged -= iconChanged;
+
+         Nodes[nodeIndex].Tag = null;
+                  
+         if (deleteNodes)
+            treeNode.Delete();
       }
 
       public bool IsNodeExpanded(ITreeNode treeNode)


### PR DESCRIPTION
Fixes #2455

# Description
When clearing them from the view, we can delete tree nodes in bulk instead of one by one.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe): Performance boost

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):