### PR TITLE
Fixes #2461 Invalid paths in event assignments throws unhandled exception

### DIFF
--- a/src/OSPSuite.Core/Services/CircularReferenceChecker.cs
+++ b/src/OSPSuite.Core/Services/CircularReferenceChecker.cs
@@ -125,6 +125,9 @@ namespace OSPSuite.Core.Services
 
       private void buildAssignmentEntityCache(EventAssignment assignment, IEntity changedEntity)
       {
+         if (changedEntity == null)
+            return;
+
          var references = _entityReferenceCache.Contains(changedEntity) ? _entityReferenceCache[changedEntity] : new List<IEntity>();
          _entityReferenceCache[changedEntity] = references;
 

--- a/tests/OSPSuite.Core.Tests/Services/CircularReferenceCheckerSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/CircularReferenceCheckerSpecs.cs
@@ -212,6 +212,7 @@ namespace OSPSuite.Core.Services
    {
       private EventAssignment _assignment;
       private Event _event;
+      private EventAssignment _notWorkingAssignment;
 
       protected override void Context()
       {
@@ -222,6 +223,13 @@ namespace OSPSuite.Core.Services
          _event.AddAssignment(_assignment);
          _eventContainer.Add(_event);
          _assignment.ObjectPath = _parameter1.EntityPath().ToObjectPath();
+
+         _notWorkingAssignment = new EventAssignment { UseAsValue = UseAsValue }.WithName("notworking");
+         var formula = new ExplicitFormula("notworking");
+         formula.AddObjectPath(_objectPathFactory.CreateFormulaUsablePathFrom("ROOT", "C", "notworking").WithAlias("PAR2"));
+         _notWorkingAssignment.Formula = formula;
+
+         _event.AddAssignment(_notWorkingAssignment);
 
          var formula1 = new ExplicitFormula("PAR2");
          formula1.AddObjectPath(_objectPathFactory.CreateFormulaUsablePathFrom("ROOT", "C", "PARA2").WithAlias("PAR2"));
@@ -234,18 +242,19 @@ namespace OSPSuite.Core.Services
          A.CallTo(() => _objectTypeResolver.TypeFor<IUsingFormula>(_parameter1)).Returns("Parameter");
       }
 
-      public abstract bool UseAsValue { get; }
+      protected abstract bool UseAsValue { get; }
    }
 
    internal class When_validating_the_references_used_in_an_assignment_with_circular_references : When_validating_the_references_used_in_an_assignment
    {
+
       [Observation]
       public void should_return_the_expected_results()
       {
          _results.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
       }
 
-      public override bool UseAsValue => false;
+      protected override bool UseAsValue => false;
    }
 
    internal class When_validating_the_references_used_in_an_assignment_with_use_as_value : When_validating_the_references_used_in_an_assignment
@@ -256,7 +265,7 @@ namespace OSPSuite.Core.Services
          _results.ValidationState.ShouldBeEqualTo(ValidationState.Valid);
       }
 
-      public override bool UseAsValue => true;
+      protected override bool UseAsValue => true;
    }
 
    internal class When_validating_the_references_used_in_a_quantity_resulting_in_formula_with_circular_references : When_checking_circular_references_in_a_model


### PR DESCRIPTION
Fixes #2461

# Description
When checking circular references in event assignment do not throw exception for non-working assignments.

This kind of error (non-working assignments) are checked later and separately from circular reference checks

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):