### PR TITLE
Fixes #2465 TIME alias resetted

### DIFF
--- a/src/OSPSuite.Core/Serialization/Xml/ObjectPathXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/ObjectPathXmlSerializer.cs
@@ -88,7 +88,7 @@ namespace OSPSuite.Core.Serialization.Xml
 
       public override void PerformMapping()
       {
-         //Nothing to do, a new timepath object is enough
+         Map(x => x.Alias);
       }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/TimePathXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/TimePathXmlSerializerSpecs.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Helpers;
+using OSPSuite.Utility.Container;
+
+namespace OSPSuite.Core.Serializers
+{
+   internal class TimePathXmlSerializerSpecs : ModellingXmlSerializerBaseSpecs
+   {
+      [Test]
+      public void TestSerialization()
+      {
+         var objectPathFactory = IoC.Resolve<IObjectPathFactory>();
+         TimePath x1 = objectPathFactory.CreateTimePath(DimensionTime);
+         x1.Alias = "t";
+         var x2 = SerializeAndDeserialize(x1);
+         AssertForSpecs.AreEqual(x1, x2);
+         x2.Alias.ShouldBeEqualTo("t");
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2465

# Description
I think mapping the alias property in the serializer should be ok.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):