### PR TITLE
Fixes #2475 Make default name for Reaction Building and Observer block plural

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -20,11 +20,11 @@ namespace OSPSuite.Assets
    {
       public static readonly string MoleculeBuildingBlock = "Molecules";
       public static readonly string Module = "Module";
-      public static readonly string ReactionBuildingBlock = "Reaction";
+      public static readonly string ReactionBuildingBlock = "Reactions";
       public static readonly string SpatialStructure = "Organism";
       public static readonly string PassiveTransportBuildingBlock = "Passive Transports";
       public static readonly string EventBuildingBlock = "Events";
-      public static readonly string ObserverBuildingBlock = "Observer";
+      public static readonly string ObserverBuildingBlock = "Observers";
       public static readonly string SimulationSettings = "Simulation Settings";
       public static readonly string ParameterValues = "Parameter Values";
       public static readonly string InitialConditions = "Initial Conditions";


### PR DESCRIPTION
Fixes #2475 

# Description
adding 's' on some strings

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):