### PR TITLE
Fixes #2485 Add the completion date/time to the PI result summary

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -175,6 +175,7 @@ namespace OSPSuite.Assets
       public const string RemoveButtonText = "Remove";
       public static readonly string EnterAValue = "<enter a value>";
       public static readonly string NaN = "<NaN>";
+      public static readonly string NA = "<NA>";
       public static readonly string Analysis = "Analysis";
       public static readonly string CopyAsImage = "Copy as image";
       public static readonly string InvalidObject = "Invalid Object";
@@ -954,6 +955,7 @@ namespace OSPSuite.Assets
          public static readonly string ResidualCount = "# of Residuals";
          public static readonly string Results = "Results";
          public static readonly string NumberOfEvaluations = "Number of Evaluations";
+         public static readonly string CompletedDate = "Completed Date";
          public static readonly string TotalError = "Total Error";
          public static readonly string Status = "Status";
          public static readonly string RunMessage = "Message";

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/OptimizationRunProperties.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/OptimizationRunProperties.cs
@@ -5,6 +5,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
    public class OptimizationRunProperties
    {
       public virtual int NumberOfEvaluations { get; }
+      public DateTime DateTimeCompleted { get; set; }
 
       [Obsolete("For serialization")]
       public OptimizationRunProperties()
@@ -14,6 +15,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
       public OptimizationRunProperties(int numberOfEvaluations)
       {
          NumberOfEvaluations = numberOfEvaluations;
+         DateTimeCompleted = DateTime.Now;
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentificationRunResult.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentificationRunResult.cs
@@ -11,6 +11,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
 
       public virtual double TotalError => BestResult.TotalError;
       public virtual int NumberOfEvaluations => Properties.NumberOfEvaluations;
+      public virtual DateTime DateTimeCompleted => Properties.DateTimeCompleted;
       public virtual RunStatus Status { get; set; }
       public virtual string Message { get; set; }
       public virtual JacobianMatrix JacobianMatrix { get; set; }

--- a/src/OSPSuite.Core/Serialization/Xml/OptimizationRunPropertiesXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/OptimizationRunPropertiesXmlSerializer.cs
@@ -7,6 +7,7 @@ namespace OSPSuite.Core.Serialization.Xml
       public override void PerformMapping()
       {
          Map(x => x.NumberOfEvaluations);
+         Map(x => x.DateTimeCompleted);
       }
    }
 }

--- a/src/OSPSuite.Core/Services/DateTimeFormatter.cs
+++ b/src/OSPSuite.Core/Services/DateTimeFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OSPSuite.Assets;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Format;
 
@@ -15,7 +16,7 @@ namespace OSPSuite.Core.Services
 
       public string Format(DateTime dateTime)
       {
-         return dateTime.ToIsoFormat(withTime: _displayTime);
+         return dateTime == default ? Captions.NA : dateTime.ToIsoFormat(withTime: _displayTime);
       }
    }
 }

--- a/src/OSPSuite.Presentation/DTO/ParameterIdentifications/ParameterIdentificationRunResultDTO.cs
+++ b/src/OSPSuite.Presentation/DTO/ParameterIdentifications/ParameterIdentificationRunResultDTO.cs
@@ -15,6 +15,7 @@ namespace OSPSuite.Presentation.DTO.ParameterIdentifications
       public string Description => RunResult.Description;
       public double TotalError => RunResult.TotalError;
       public int NumberOfEvaluations => RunResult.NumberOfEvaluations;
+      public DateTime DateTimeCompleted => RunResult.DateTimeCompleted;
       public TimeSpan Duration => RunResult.Duration;
       public string Message => RunResult.Message;
       public override RunStatus Status => RunResult.Status;

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationRunPropertiesPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationRunPropertiesPresenter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.DTO.ParameterIdentifications;
 using OSPSuite.Presentation.Formatters;
-using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views.ParameterIdentifications;
 
 namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
@@ -38,6 +38,7 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
          _allProperties.Add(new RunPropertyDTO<int>(Captions.ParameterIdentification.NumberOfEvaluations, runResult.NumberOfEvaluations, new IntFormatter()));
          _allProperties.Add(new RunPropertyDTO<TimeSpan>(Captions.ParameterIdentification.Duration, runResult.Duration, new TimeSpanFormatter()));
          _allProperties.Add(new RunPropertyDTO<RunStatus>(Captions.ParameterIdentification.Status, runResult.Status, icon: icon));
+         _allProperties.Add(new RunPropertyDTO<DateTime>(Captions.ParameterIdentification.CompletedDate, runResult.DateTimeCompleted, new DateTimeFormatter(displayTime: true)));
 
          if (!string.IsNullOrEmpty(runResult.Message))
             _allProperties.Add(new RunPropertyDTO<string>(Captions.ParameterIdentification.RunMessage, runResult.Message, icon: icon));

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/MultipleParameterIdentificationResultsView.cs
@@ -9,6 +9,7 @@ using DevExpress.XtraGrid;
 using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraGrid.Views.Grid;
 using OSPSuite.Assets;
+using OSPSuite.Core.Services;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
@@ -210,6 +211,9 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
 
          bind(x => x.NumberOfEvaluations)
             .WithCaption(Captions.ParameterIdentification.NumberOfEvaluations);
+
+         bind(x => x.DateTimeCompleted)
+            .WithCaption(Captions.ParameterIdentification.CompletedDate).WithFormat(new DateTimeFormatter(displayTime:true));
 
          bind(x => x.Duration)
             .WithFormat(x => _timeSpanFormatter)

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationRunPropertiesPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationRunPropertiesPresenterSpecs.cs
@@ -7,6 +7,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.DTO.ParameterIdentifications;
 using OSPSuite.Presentation.Formatters;
 using OSPSuite.Presentation.Presenters.ParameterIdentifications;
@@ -52,7 +53,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_create_one_run_property_dto_per_property_to_be_displayed()
       {
-         _allRunPropertyDTO.Count.ShouldBeEqualTo(4);
+         _allRunPropertyDTO.Count.ShouldBeEqualTo(5);
          _allRunPropertyDTO[0].Name.ShouldBeEqualTo(Captions.ParameterIdentification.TotalError);
          _allRunPropertyDTO[0].FormattedValue.ShouldBeEqualTo(new DoubleFormatter().Format(_runResult.TotalError));
          _allRunPropertyDTO[0].Icon.ShouldBeNull();
@@ -68,6 +69,10 @@ namespace OSPSuite.Presentation.Presentation
          _allRunPropertyDTO[3].Name.ShouldBeEqualTo(Captions.ParameterIdentification.Status);
          _allRunPropertyDTO[3].FormattedValue.ShouldBeEqualTo(_runResult.Status.DisplayName);
          _allRunPropertyDTO[3].Icon.ShouldBeEqualTo(ApplicationIcons.OK);
+
+         _allRunPropertyDTO[4].Name.ShouldBeEqualTo(Captions.ParameterIdentification.CompletedDate);
+         _allRunPropertyDTO[4].FormattedValue.ShouldBeEqualTo(new DateTimeFormatter(displayTime:true).Format(_runResult.DateTimeCompleted));
+         _allRunPropertyDTO[4].Icon.ShouldBeNull();
       }
    }
 }	


### PR DESCRIPTION
Fixes #2485 

# Description
Adds the date to the summary

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
if it's missing
![image](https://github.com/user-attachments/assets/9113947d-2468-420c-9196-ff70b266adef)

if it's present
![image](https://github.com/user-attachments/assets/618b1cbd-7f16-4bd4-b928-7a67f3318484)

multiple without the date
![image](https://github.com/user-attachments/assets/cecc9c1e-f02f-4121-a614-8d7dceff795c)

multiple with the date
![image](https://github.com/user-attachments/assets/78ef2f94-2d1b-4bd0-959f-f5d9c8ee987d)


# Questions (if appropriate):