### PR TITLE
Fixes #2498 Allow simulation column to be hidden in quantity selection

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -40,12 +40,6 @@ jobs:
       - name: Pack the project
         run: dotnet pack .\OSPSuite.Core.sln --no-build --no-restore -o ./ -p:PackageVersion=${{env.APP_VERSION}} --configuration=Debug --no-build
 
-      - name: Push nupkg as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: OSPSuite.Core
-          path: ./*.nupkg
-
       - name: Push test log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/src/OSPSuite.Presentation/Presenters/QuantityListPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/QuantityListPresenter.cs
@@ -71,6 +71,11 @@ namespace OSPSuite.Presentation.Presenters
       bool AutomaticallyHideEmptyColumns { get; set; }
 
       /// <summary>
+      ///    Hides the simulation column if true
+      /// </summary>
+      bool HideSimulationColumn { get; set; }
+
+      /// <summary>
       ///    Returns true if the column for the path with element <paramref name="pathElementId" /> contains only empty value
       /// </summary>
       bool PathElementIsEmpty(PathElementId pathElementId);
@@ -92,6 +97,7 @@ namespace OSPSuite.Presentation.Presenters
       public bool IsLatched { get; set; }
       public bool ExpandAllGroups { get; set; }
       public bool AutomaticallyHideEmptyColumns { get; set; }
+      public bool HideSimulationColumn { get; set; }
 
       public QuantityListPresenter(IQuantityListView view, IQuantityToQuantitySelectionDTOMapper quantitySelectionDTOMapper) : base(view)
       {
@@ -148,8 +154,10 @@ namespace OSPSuite.Presentation.Presenters
 
       public void UpdatePathColumnsVisibility()
       {
-         if (!AutomaticallyHideEmptyColumns) return;
-         EnumHelper.AllValuesFor<PathElementId>().Each(updateColumnVisibility);
+         if (AutomaticallyHideEmptyColumns) 
+            EnumHelper.AllValuesFor<PathElementId>().Each(updateColumnVisibility);
+
+         _view.SetVisibility(PathElementId.Simulation, !HideSimulationColumn);
       }
 
       private void updateColumnVisibility(PathElementId pathElementId)

--- a/src/OSPSuite.Presentation/Presenters/QuantitySelectionPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/QuantitySelectionPresenter.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Assets;
-using OSPSuite.Utility.Extensions;
 using OSPSuite.Core.Domain;
-using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Views;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Presentation.Presenters
 {
@@ -65,8 +64,13 @@ namespace OSPSuite.Presentation.Presenters
       bool AutomaticallyHideEmptyColumns { get; set; }
 
       /// <summary>
-      /// Clears the current selection and refreshes using any quantities from <paramref name="selections"/>
-      /// that are available in the simulation where the paths match
+      ///    Hides the simulation column in both lists if true
+      /// </summary>
+      bool HideSimulationColumn { get; set; }
+
+      /// <summary>
+      ///    Clears the current selection and refreshes using any quantities from <paramref name="selections" />
+      ///    that are available in the simulation where the paths match
       /// </summary>
       void UpdateSelection(IReadOnlyList<QuantitySelection> selections);
    }
@@ -131,7 +135,7 @@ namespace OSPSuite.Presentation.Presenters
       {
          var dto = _allQuantityListPresenter.QuantityDTOByPath(outputSelection.Path);
 
-         if (dto == null) 
+         if (dto == null)
             return;
 
          _selectedQuantityListPresenter.Add(dto);
@@ -180,14 +184,14 @@ namespace OSPSuite.Presentation.Presenters
 
       public string Info
       {
-         get { return _view.Info; }
-         set { _view.Info = value; }
+         get => _view.Info;
+         set => _view.Info = value;
       }
 
       public string Description
       {
-         get { return View.Description; }
-         set { View.Description = value; }
+         get => View.Description;
+         set => View.Description = value;
       }
 
       public void GroupBy(PathElementId pathElementId)
@@ -198,13 +202,23 @@ namespace OSPSuite.Presentation.Presenters
 
       public bool ExpandAllGroups
       {
-         get { return _allQuantityListPresenter.ExpandAllGroups; }
-         set { _allQuantityListPresenter.ExpandAllGroups = value; }
+         get => _allQuantityListPresenter.ExpandAllGroups;
+         set => _allQuantityListPresenter.ExpandAllGroups = value;
+      }
+
+      public bool HideSimulationColumn
+      {
+         set
+         {
+            _allQuantityListPresenter.HideSimulationColumn = value;
+            _selectedQuantityListPresenter.HideSimulationColumn = value;
+         }
+         get => _allQuantityListPresenter.HideSimulationColumn;
       }
 
       public bool AutomaticallyHideEmptyColumns
       {
-         get { return _allQuantityListPresenter.AutomaticallyHideEmptyColumns; }
+         get => _allQuantityListPresenter.AutomaticallyHideEmptyColumns;
          set
          {
             _allQuantityListPresenter.AutomaticallyHideEmptyColumns = value;

--- a/src/OSPSuite.UI/Views/QuantityListView.cs
+++ b/src/OSPSuite.UI/Views/QuantityListView.cs
@@ -101,10 +101,7 @@ namespace OSPSuite.UI.Views
          _gridViewBinder.BindToSource(quantitySelectionDTOs);
       }
 
-      public void SetCaption(PathElementId pathElementId, string caption)
-      {
-         _pathElementsBinder.SetCaption(pathElementId, caption);
-      }
+      public void SetCaption(PathElementId pathElementId, string caption) => _pathElementsBinder.SetCaption(pathElementId, caption);
 
       private void sortByColumn()
       {
@@ -118,10 +115,7 @@ namespace OSPSuite.UI.Views
          xtraColumnBy(GroupPathElementId).GroupIndex = 0;
       }
 
-      private GridColumn xtraColumnBy(PathElementId pathElementId)
-      {
-         return _pathElementsBinder.ColumnAt(pathElementId).XtraColumn;
-      }
+      private GridColumn xtraColumnBy(PathElementId pathElementId) => _pathElementsBinder.ColumnAt(pathElementId).XtraColumn;
 
       public IEnumerable<QuantitySelectionDTO> SelectedQuantities
       {
@@ -147,10 +141,7 @@ namespace OSPSuite.UI.Views
          }
       }
 
-      public void SetVisibility(PathElementId pathElementId, bool visible)
-      {
-         _pathElementsBinder.SetVisibility(pathElementId, visible);
-      }
+      public void SetVisibility(PathElementId pathElementId, bool visible) => _pathElementsBinder.SetVisibility(pathElementId, visible);
 
       public override bool HasError => _gridViewBinder.HasError;
 

--- a/src/OSPSuite.UI/Views/QuantitySelectionView.cs
+++ b/src/OSPSuite.UI/Views/QuantitySelectionView.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using OSPSuite.Utility.Extensions;
 using DevExpress.XtraEditors.Controls;
 using OSPSuite.Assets;
 using OSPSuite.Presentation.Presenters;

--- a/tests/OSPSuite.Presentation.Tests/Presentation/QuantityListPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/QuantityListPresenterSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
+using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -11,7 +12,7 @@ using OSPSuite.Presentation.Views;
 
 namespace OSPSuite.Presentation.Presentation
 {
-   public abstract class concern_for_QuantityListPresenter : ContextSpecification<IQuantityListPresenter>
+   public abstract class concern_for_QuantityListPresenter : ContextSpecification<QuantityListPresenter>
    {
       protected IQuantityToQuantitySelectionDTOMapper _mapper;
       protected IQuantityListView _view;
@@ -57,9 +58,21 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
+   public class When_hiding_or_showing_the_simulation_column : concern_for_QuantityListPresenter
+   {
+      [TestCase(false)]
+      [TestCase(true)]
+      [Observation]
+      public void the_simulation_column_should_be_shown(bool hide)
+      {
+         sut.HideSimulationColumn = hide;
+         sut.Edit(new List<IQuantity>());
+         A.CallTo(() => _view.SetVisibility(PathElementId.Simulation, !hide)).MustHaveHappened();
+      }
+   }
+
    public class When_checking_if_a_path_column_is_empty: concern_for_QuantityListPresenter
    {
-
       protected override void Context()
       {
          base.Context();

--- a/tests/OSPSuite.Presentation.Tests/Presentation/QuantitySelectionPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/QuantitySelectionPresenterSpecs.cs
@@ -195,4 +195,19 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _selectedQuantityPresenter.UpdateSelection(A<IReadOnlyList<QuantitySelectionDTO>>._, false)).MustHaveHappened();
       }
    }
+
+   public class When_hiding_the_simulation_column : concern_for_QuantitySelectionPresenter
+   {
+      protected override void Because()
+      {
+         sut.HideSimulationColumn = true;
+      }
+
+      [Observation]
+      public void both_list_presenters_should_hide_columns()
+      {
+         _allQuantityPresenter.HideSimulationColumn.ShouldBeEqualTo(true);
+         _selectedQuantityPresenter.HideSimulationColumn.ShouldBeEqualTo(true);
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2498

# Description
Allow the caller to hide the simulation column when selecting quantities from a single simulation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):