### PR TITLE
Fixes #2500 Comparison table: remove row "Simulation"

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Comparisons/ComparisonPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Comparisons/ComparisonPresenter.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using OSPSuite.Utility;
-using OSPSuite.Utility.Extensions;
 using OSPSuite.Core.Comparison;
 using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Mappers;
 using OSPSuite.Presentation.Views.Comparisons;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Presentation.Presenters.Comparisons
 {
@@ -50,8 +50,14 @@ namespace OSPSuite.Presentation.Presenters.Comparisons
 
          //Always hide name
          _view.SetVisibility(PathElementId.Name, visible: false);
+
+         if (isSimulationComparison(leftObject, rightObject))
+            _view.SetVisibility(PathElementId.Simulation, visible: false);
+
          _view.DifferenceTableVisible = _allDiffItemDTO.Any();
       }
+
+      private bool isSimulationComparison(IObjectBase leftObject, IObjectBase rightObject) => leftObject is ModelCoreSimulation && rightObject is ModelCoreSimulation;
 
       public DataTable ComparisonAsTable()
       {

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ComparisonPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ComparisonPresenterSpecs.cs
@@ -42,6 +42,59 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
+   public class When_starting_the_comparison_between_two_simulations : concern_for_ComparisonPresenter
+   {
+      private DiffItem _diffItem1;
+      private DiffItem _diffItem2;
+      private DiffItemDTO _dto1;
+      private DiffItemDTO _dto2;
+      private List<DiffItemDTO> _allDiffItemDTO;
+
+      protected override void Context()
+      {
+         base.Context();
+         _diffItem1 = new PropertyValueDiffItem();
+         _diffItem2 = new PropertyValueDiffItem();
+         _dto1 = new DiffItemDTO();
+         _dto2 = new DiffItemDTO();
+
+         _dto1.PathElements[PathElementId.Name] = new PathElement { DisplayName = "A" };
+         _dto2.PathElements[PathElementId.Name] = new PathElement { DisplayName = "B" };
+
+         _dto1.PathElements[PathElementId.Molecule] = new PathElement { DisplayName = "Mol" };
+         _dto2.PathElements[PathElementId.Molecule] = new PathElement { DisplayName = "Mol2" };
+
+         _dto1.PathElements[PathElementId.TopContainer] = new PathElement { DisplayName = "A" };
+         _dto2.PathElements[PathElementId.TopContainer] = new PathElement { DisplayName = "A" };
+
+         _dto1.PathElements[PathElementId.BottomCompartment] = new PathElement { DisplayName = "" };
+         _dto2.PathElements[PathElementId.BottomCompartment] = new PathElement { DisplayName = "" };
+
+
+         _report.Add(_diffItem1);
+         _report.Add(_diffItem2);
+         A.CallTo(() => _diffItemDTOMapper.MapFrom(_diffItem1)).Returns(_dto1);
+         A.CallTo(() => _diffItemDTOMapper.MapFrom(_diffItem2)).Returns(_dto2);
+
+         A.CallTo(() => _view.BindTo(A<IEnumerable<DiffItemDTO>>._))
+            .Invokes(x => _allDiffItemDTO = x.GetArgument<IEnumerable<DiffItemDTO>>(0).ToList());
+
+         _object1 = new ModelCoreSimulation().WithName("sim1");
+         _object2 = new ModelCoreSimulation().WithName("sim2");
+      }
+
+      protected override void Because()
+      {
+         sut.StartComparison(_object1, _object2, _caption1, _caption2, _settings);
+      }
+
+      [Observation]
+      public void should_hide_the_simulation_column()
+      {
+         A.CallTo(() => _view.SetVisibility(PathElementId.Simulation, false)).MustHaveHappened();
+      }
+   }
+
    public class When_starting_the_comparison_between_two_objects : concern_for_ComparisonPresenter
    {
       private DiffItem _diffItem1;


### PR DESCRIPTION
Fixes #2500

# Description
When comparing simulations, the 'Simulation' column shows the name of only the first simulation.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):