### PR TITLE
#2509 when renaming a simulation results paths should not contain old name

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2396,10 +2396,8 @@ namespace OSPSuite.Assets
          return $"Renamed observed data from '{oldName}' to '{newName}'";
       }
 
-      public static string RenameSimulation(string oldName, string newName)
-      {
-         return $"Renamed simulation from '{oldName}' to '{newName}'";
-      }
+      public static string RenameSimulation(string oldName, string newName) =>
+         $"Renamed simulation from '{oldName}' to '{newName}'";
 
       public static string UpdateValueOriginFrom(string oldValueOrigin, string newValueOrigin, string withValueOriginType, string withValueOriginDisplay, string containerType, string containerDisplay)
       {

--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2396,6 +2396,11 @@ namespace OSPSuite.Assets
          return $"Renamed observed data from '{oldName}' to '{newName}'";
       }
 
+      public static string RenameSimulation(string oldName, string newName)
+      {
+         return $"Renamed simulation from '{oldName}' to '{newName}'";
+      }
+
       public static string UpdateValueOriginFrom(string oldValueOrigin, string newValueOrigin, string withValueOriginType, string withValueOriginDisplay, string containerType, string containerDisplay)
       {
          string withObjectTypeInfo = $"for {withValueOriginType} '{withValueOriginDisplay}' in {containerType} '{containerDisplay}'";

--- a/src/OSPSuite.Core/Commands/RenameModelCommand.cs
+++ b/src/OSPSuite.Core/Commands/RenameModelCommand.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using OSPSuite.Assets;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Utility.Extensions;
+using Command = OSPSuite.Assets.Command;
+
+namespace OSPSuite.Core.Commands
+{
+   public class RenameModelCommand : OSPSuiteReversibleCommand<IOSPSuiteExecutionContext>
+   {
+      private IModel _model;
+
+      private readonly string _modelId;
+      private readonly string _newName;
+      private readonly string _oldName;
+
+      public RenameModelCommand(IModel model, string newName)
+      {
+         _model = model;
+         _newName = newName;
+         _oldName = model.Name;
+         _modelId = model.Id;
+         ObjectType = ObjectTypes.Model;
+         CommandType = Command.CommandTypeRename;
+         Description = Command.RenameSimulation(_oldName, _newName);
+      }
+
+      protected override void ExecuteWith(IOSPSuiteExecutionContext context)
+      {
+         _model.Name = _newName;
+         var root = _model.Root;
+         root.Name = _newName;
+
+         updateFormulasInContainer(root);
+         updateFormulasInContainer(_model.Neighborhoods);
+
+         var allEventAssignments = root.GetAllChildren<EventAssignment>();
+         allEventAssignments.Each(ea => updateObjectPath(ea.ObjectPath));
+      }
+
+      protected override void ClearReferences()
+      {
+         _model = null;
+      }
+
+      private void updateFormulasInContainer(IContainer root)
+      {
+         var allFormulas = root.GetAllChildren<IUsingFormula>(uf => !uf.Formula.IsConstant()).Select(uf => uf.Formula);
+         allFormulas.Each(updateObjectPaths);
+         allFormulas = root.GetAllChildren<IParameter>(p => p.RHSFormula != null).Select(p => p.RHSFormula);
+         allFormulas.Each(updateObjectPaths);
+      }
+
+      private void updateObjectPaths(IFormula formula)
+      {
+         formula.ObjectPaths.Each(updateObjectPath);
+      }
+
+      private void updateObjectPath(ObjectPath path)
+      {
+         if (!path.First().Equals(_oldName)) return;
+         path.Remove(_oldName);
+         path.AddAtFront(_newName);
+      }
+
+      protected override ICommand<IOSPSuiteExecutionContext> GetInverseCommand(IOSPSuiteExecutionContext context)
+      {
+         throw new NotImplementedException();
+      }
+
+      public override void RestoreExecutionData(IOSPSuiteExecutionContext context)
+      {
+         throw new NotImplementedException();
+      }
+   }
+}

--- a/src/OSPSuite.Core/Commands/RenameModelCommand.cs
+++ b/src/OSPSuite.Core/Commands/RenameModelCommand.cs
@@ -66,14 +66,13 @@ namespace OSPSuite.Core.Commands
          path.AddAtFront(_newName);
       }
 
-      protected override ICommand<IOSPSuiteExecutionContext> GetInverseCommand(IOSPSuiteExecutionContext context)
-      {
-         throw new NotImplementedException();
-      }
+      protected override ICommand<IOSPSuiteExecutionContext> GetInverseCommand(IOSPSuiteExecutionContext context) =>
+         new RenameModelCommand(_model, _oldName).AsInverseFor(this);
+      
 
       public override void RestoreExecutionData(IOSPSuiteExecutionContext context)
       {
-         throw new NotImplementedException();
+         _model = context.Get<IModel>(_modelId);
       }
    }
 }

--- a/src/OSPSuite.Core/Commands/RenameModelCommand.cs
+++ b/src/OSPSuite.Core/Commands/RenameModelCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
@@ -61,14 +60,15 @@ namespace OSPSuite.Core.Commands
 
       private void updateObjectPath(ObjectPath path)
       {
-         if (!path.First().Equals(_oldName)) return;
+         if (!path.First().Equals(_oldName))
+            return;
+
          path.Remove(_oldName);
          path.AddAtFront(_newName);
       }
 
       protected override ICommand<IOSPSuiteExecutionContext> GetInverseCommand(IOSPSuiteExecutionContext context) =>
          new RenameModelCommand(_model, _oldName).AsInverseFor(this);
-      
 
       public override void RestoreExecutionData(IOSPSuiteExecutionContext context)
       {

--- a/src/OSPSuite.R/Domain/Simulation.cs
+++ b/src/OSPSuite.R/Domain/Simulation.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using OSPSuite.Core.Chart;
+using OSPSuite.Core.Commands;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.R.MinimalImplementations;
 using OSPSuite.Utility.Visitor;
 
 namespace OSPSuite.R.Domain
@@ -56,7 +58,11 @@ namespace OSPSuite.R.Domain
       public string Name
       {
          get => CoreSimulation.Name;
-         set => CoreSimulation.Name = value;
+         set
+         {
+            CoreSimulation.Name = value;
+            new RenameModelCommand(CoreSimulation.Model, value).Execute(new RExecutionContext());
+         }
       }
 
       public string Id
@@ -129,7 +135,7 @@ namespace OSPSuite.R.Domain
       public IParameter BodyWeight => CoreSimulation.BodyWeight;
 
       public IParameter TotalDrugMassFor(string moleculeName) => CoreSimulation.TotalDrugMassFor(moleculeName);
-   
+
       public double? MolWeightFor(IQuantity quantity) => CoreSimulation.MolWeightFor(quantity);
 
       public double? MolWeightFor(string quantityPath) => CoreSimulation.MolWeightFor(quantityPath);

--- a/tests/OSPSuite.Core.Tests/Commands/RenameModelCommandSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Commands/RenameModelCommandSpecs.cs
@@ -1,0 +1,96 @@
+﻿using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+
+namespace OSPSuite.Core.Commands
+{
+   public abstract class concern_for_RenameModelCommandSpecs : ContextSpecification<RenameModelCommand>
+   {
+      protected IModel _model;
+      protected string _newName = "new";
+      protected string _oldName = "old";
+      protected FormulaUsablePath _changedObjectPath;
+      protected FormulaUsablePath _unchangedPath;
+      protected FormulaUsablePath _rhsPath;
+      protected FormulaUsablePath _neighborhoodPath;
+
+      protected override void Context()
+      {
+         _model = new Model().WithName(_oldName);
+         _model.Root = new Container().WithName(_oldName);
+         var explicitFormula = new ExplicitFormula("A+B");
+         _unchangedPath = new FormulaUsablePath(new[] { "A", "B" });
+         _changedObjectPath = new FormulaUsablePath(new[] { _oldName, "A" });
+         var rhsFormula = new ExplicitFormula("-C");
+         _rhsPath = new FormulaUsablePath(new[] { _oldName, "C" });
+         rhsFormula.AddObjectPath(_rhsPath);
+         explicitFormula.AddObjectPath(_changedObjectPath);
+         explicitFormula.AddObjectPath(_unchangedPath);
+         var parameter = new Parameter().WithName("P1").WithFormula(explicitFormula).WithRHS(rhsFormula);
+         _model.Root.Add(parameter);
+         _model.Neighborhoods = new Container().WithName(Constants.NEIGHBORHOODS);
+         var neighborhood = new Neighborhood().WithName("BLA");
+         var neighborhoodFormula = new ExplicitFormula("u");
+         _neighborhoodPath = new FormulaUsablePath(new[] { _oldName, _oldName, "u" });
+         neighborhoodFormula.AddObjectPath(_neighborhoodPath);
+         var neighborhoodParameter = new Parameter().WithFormula(neighborhoodFormula);
+         neighborhood.Add(neighborhoodParameter);
+         _model.Neighborhoods.Add(neighborhood);
+         sut = new RenameModelCommand(_model, _newName);
+      }
+   }
+
+   class When_executing_rename_model_command : concern_for_RenameModelCommandSpecs
+   {
+      private IOSPSuiteExecutionContext _context;
+
+      protected override void Context()
+      {
+         base.Context();
+         _context = A.Fake<IOSPSuiteExecutionContext>();
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void should_change_Model_Name()
+      {
+         _model.Name.ShouldBeEqualTo(_newName);
+      }
+
+      [Observation]
+      public void should_change_root_name()
+      {
+         _model.Root.Name.ShouldBeEqualTo(_newName);
+      }
+
+      [Observation]
+      public void should_change_changed_Path()
+      {
+         _changedObjectPath.ShouldOnlyContainInOrder(_newName, "A");
+      }
+
+      [Observation]
+      public void should_leave_unchanged_path_unchanged()
+      {
+         _unchangedPath.ShouldOnlyContainInOrder("A", "B");
+      }
+
+      [Observation]
+      public void should_change_rhs_path()
+      {
+         _rhsPath.ShouldOnlyContainInOrder(_newName, "C");
+      }
+
+      [Observation]
+      public void should_only_change_first_element_of_neighborhood_path()
+      {
+         _neighborhoodPath.ShouldOnlyContainInOrder(_newName, _oldName, "u");
+      }
+   }
+}

--- a/tests/OSPSuite.R.Tests/Services/SimulationRunnerIntegrationTests.cs
+++ b/tests/OSPSuite.R.Tests/Services/SimulationRunnerIntegrationTests.cs
@@ -51,7 +51,7 @@ namespace OSPSuite.R.Services
 
       protected override void Because()
       {
-         _results = sut.Run(new SimulationRunArgs {Simulation = _simulation, Population = _subPopulation });
+         _results = sut.Run(new SimulationRunArgs { Simulation = _simulation, Population = _subPopulation });
       }
 
       [Observation]
@@ -81,6 +81,32 @@ namespace OSPSuite.R.Services
       public void should_create_results_matching_the_individual_ids_in_the_population()
       {
          _results.AllIndividualIds().ShouldOnlyContain(Enumerable.Range(0, _population.Count));
+      }
+   }
+
+   public class When_performing_a_population_simulation_run_after_renaming : concern_for_SimulationRunnerIntegration
+   {
+      private IndividualValuesCache _population;
+      private SimulationResults _results;
+      private readonly string _newSimulationName = "New Name";
+
+      protected override void Context()
+      {
+         base.Context();
+         _population = _populationTask.ImportPopulation(_populationFile);
+      }
+
+      protected override void Because()
+      {
+         _simulation.Name = _newSimulationName;
+         _results = sut.Run(new SimulationRunArgs { Simulation = _simulation, Population = _population });
+      }
+
+      [Observation]
+      public void should_return_paths_with_new_simulation_name()
+      {
+         var paths = _results.AllQuantityPaths();
+         paths.Any(x => x.ToString().Contains(_newSimulationName)).ShouldBeFalse();
       }
    }
 }


### PR DESCRIPTION
Fixes #2509 

# Description

when renaming a simulation results paths should not contain old name

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):