### PR TITLE
Fixes #2527 Mouseover outside diagram causes all point locations to be recalculated

### DIFF
--- a/src/OSPSuite.UI/Services/DiagramZoomRectangleService.cs
+++ b/src/OSPSuite.UI/Services/DiagramZoomRectangleService.cs
@@ -55,7 +55,7 @@ namespace OSPSuite.UI.Services
       public void OnMouseDown(object sender, MouseEventArgs e)
       {
          if (!isZooming(e)) return;
-         if (!mouseIsOverChart(e)) return;
+         if (!mouseIsOverDiagram(e)) return;
          if (isInLegend(e)) return;
 
          _firstSelectionCorner = _lastSelectionCorner = e.Location;
@@ -70,7 +70,7 @@ namespace OSPSuite.UI.Services
 
       public void OnMouseMove(object sender, MouseEventArgs e)
       {
-         if (isInLegend(e) || !mouseIsOverChart(e))
+         if (isInLegend(e) || !mouseIsOverDiagram(e))
          {
             _chartControl.Cursor = Cursors.Default;
             return;
@@ -107,25 +107,10 @@ namespace OSPSuite.UI.Services
          return !_selectionRectangle.IsEmpty && _selectionRectangle.Height > 3 && _selectionRectangle.Width > 3;
       }
 
-      private bool mouseIsOverChart(MouseEventArgs e)
+      private bool mouseIsOverDiagram(MouseEventArgs e)
       {
-         var pointLocation = pointLocationAt(e);
-         return pointLocation != null && !pointLocation.IsEmpty;
-      }
-
-      private DiagramCoordinates pointLocationAt(MouseEventArgs e)
-      {
-         if (_chartControl.XYDiagram == null)
-            return null;
-
-         try
-         {
-            return _chartControl.XYDiagram.PointToDiagram(new Point(e.X, e.Y));
-         }
-         catch (Exception)
-         {
-            return null;
-         }
+         var hitInfo = _chartControl.CalcHitInfo(e.Location);
+         return hitInfo.InDiagram;
       }
 
       private bool isZooming(MouseEventArgs e)


### PR DESCRIPTION
Fixes #2527

# Description
Discovery is that we need to use `PointToDiagram` and `DiagramToPoint` sparingly because it can trigger a recalculation of all the datapoints in the chart. 

In this example, mouseover in the gutter regions of the diagram force an all-points calculation to happen since the mouse location is not found in the XYDiagram. Luckily, there's a much faster test for this.

![image](https://github.com/user-attachments/assets/4b5ac1d3-c494-4ad9-b53b-1df920771ed7)


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):