### PR TITLE
Fixes #2550 Throw a warning message for non-existing neighbourhood

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2152,6 +2152,7 @@ namespace OSPSuite.Assets
       public static string LargeNumberOfOutputPoints(int numberOfPoints) =>
          $"The selected output resolution will generate {numberOfPoints} points and may severely impact the software performance.\nAre you sure you want to run with these setting? If not, consider changing output resolution in simulations settings";
 
+      public static string NeighborhoodWasNotFoundInModel(string neighborhoodName, string buildingBlockName) => $"The neighborhood '{neighborhoodName}' from building block '{buildingBlockName}' was not added to the simulation";
    }
 
    public static class RibbonCategories

--- a/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
@@ -145,13 +145,13 @@ namespace OSPSuite.Core.Domain.Mappers
 
    internal class NeighborhoodMapResult
    {
-      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _ignoredNeighborHoods;
+      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _ignoredNeighborhoods;
       private readonly IContainer _container;
 
       public NeighborhoodMapResult(IContainer container)
       {
          _container = container;
-         _ignoredNeighborHoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
+         _ignoredNeighborhoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
       }
 
       /// <summary>
@@ -160,13 +160,13 @@ namespace OSPSuite.Core.Domain.Mappers
       /// </summary>
       public void Add(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
       {
-         _ignoredNeighborHoods.Add((builder, buildingBlock));
+         _ignoredNeighborhoods.Add((builder, buildingBlock));
       }
 
       internal void Deconstruct(out IContainer container, out IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> ignoredNeighborhoods)
       {
          container = _container;
-         ignoredNeighborhoods = _ignoredNeighborHoods;
+         ignoredNeighborhoods = _ignoredNeighborhoods;
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
@@ -10,13 +10,11 @@ using OSPSuite.Utility.Extensions;
 namespace OSPSuite.Core.Domain.Mappers
 {
    /// <summary>
-   ///    Maps collection of neighborhood builder objects.
-   ///    <para></para>
-   ///    Creates Top-Container named "NEIGHBORHOODS", all mapped neighborhoods
-   ///    <para></para>
-   ///    are added as children of this top container
+   ///    Returns a result that includes a top container named "NEIGHBORHOODS" with all mapped neighborhoods
+   ///    and a list of all neighborhoods that were not included because one or both neighbors were not found in the
+   ///    simulation spatial structure
    /// </summary>
-   internal interface INeighborhoodCollectionToContainerMapper : IMapper<ModelConfiguration, IContainer>
+   internal interface INeighborhoodCollectionToContainerMapper : IMapper<ModelConfiguration, NeighborhoodMapResult>
    {
    }
 
@@ -36,37 +34,47 @@ namespace OSPSuite.Core.Domain.Mappers
          _containerMergeTask = containerMergeTask;
       }
 
-      public IContainer MapFrom(ModelConfiguration modelConfiguration)
+      public NeighborhoodMapResult MapFrom(ModelConfiguration modelConfiguration)
       {
          var (_, simulationBuilder) = modelConfiguration;
 
          var neighborhoodsParentContainer = _objectBaseFactory.Create<IContainer>()
             .WithMode(ContainerMode.Logical)
             .WithName(Constants.NEIGHBORHOODS);
+         var neighborhoodMapResult = new NeighborhoodMapResult(neighborhoodsParentContainer);
 
          var allSpatialStructureAndMergeBehaviors = simulationBuilder.SpatialStructureAndMergeBehaviors;
          if (!allSpatialStructureAndMergeBehaviors.Any())
-            return neighborhoodsParentContainer;
+            return neighborhoodMapResult;
 
          var mapToNeighborhood = mapToNeighborhoodDef(modelConfiguration);
 
-         IReadOnlyList<Neighborhood> mapNeighborhoods(SpatialStructure spatialStructure) =>
-            spatialStructure.Neighborhoods.Select(mapToNeighborhood).Where(x => x != null).ToList();
+         IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborHoodsFrom(SpatialStructure spatialStructure) =>
+            spatialStructure.Neighborhoods.Select(x => (builder: x, neighborhood: mapToNeighborhood(x))).ToList();
+
+         IReadOnlyList<Neighborhood> definedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => allNeighborhoods.Where(x => x.neighborhood != null).Select(x => x.neighborhood).ToList();
+         IReadOnlyList<NeighborhoodBuilder> notDefinedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => allNeighborhoods.Where(x => x.neighborhood == null).Select(x => x.builder).ToList();
 
          //we use a cache to ensure that we are replacing neighborhoods defined in multiple structures
          var firstSpatialStructure = allSpatialStructureAndMergeBehaviors[0].spatialStructure;
          var allOtherSpatialStructuresWithMergeBehavior = allSpatialStructureAndMergeBehaviors.Skip(1).ToList();
 
-
          //first step: Add the neighborhoods from the first structure
-         neighborhoodsParentContainer.AddChildren(mapNeighborhoods(firstSpatialStructure));
+         var allNeighbors = allNeighborHoodsFrom(firstSpatialStructure);
+         neighborhoodsParentContainer.AddChildren(definedNeighborhoods(allNeighbors));
+
+         notDefinedNeighborhoods(allNeighbors).Each(x => neighborhoodMapResult.Add(x, firstSpatialStructure));
 
          //now merge all other neighborhoods
          allOtherSpatialStructuresWithMergeBehavior
-            .Select(x => new {x.mergeBehavior, neighborhoods = mapNeighborhoods(x.spatialStructure)})
-            .Each(x => mergeNeighborhoodsInStructure(neighborhoodsParentContainer, x.neighborhoods, x.mergeBehavior));
+            .Select(x => new { x.mergeBehavior, neighborhoods = allNeighborHoodsFrom(x.spatialStructure), x.spatialStructure })
+            .Each(x =>
+            {
+               mergeNeighborhoodsInStructure(neighborhoodsParentContainer, definedNeighborhoods(x.neighborhoods), x.mergeBehavior);
+               notDefinedNeighborhoods(x.neighborhoods).Each(n => neighborhoodMapResult.Add(n, x.spatialStructure));
+            });
 
-         return neighborhoodsParentContainer;
+         return neighborhoodMapResult;
       }
 
       private void mergeNeighborhoodsInStructure(IContainer neighborhoods, IReadOnlyList<Neighborhood> neighborhoodsToMerge, MergeBehavior mergeBehavior)
@@ -132,6 +140,33 @@ namespace OSPSuite.Core.Domain.Mappers
 
          return moleculesStartValuesForFloatingMolecules[pathToFirstNeighbor]
             .Intersect(moleculesStartValuesForFloatingMolecules[pathToSecondNeighbor]).ToList();
+      }
+   }
+
+   internal class NeighborhoodMapResult
+   {
+      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _ignoredNeighborHoods;
+      private readonly IContainer _container;
+
+      public NeighborhoodMapResult(IContainer container)
+      {
+         _container = container;
+         _ignoredNeighborHoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
+      }
+
+      /// <summary>
+      ///    Adds the ignored <paramref name="builder" /> and the source <paramref name="buildingBlock" /> to the list of ignored
+      ///    neighborhoods
+      /// </summary>
+      public void Add(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
+      {
+         _ignoredNeighborHoods.Add((builder, buildingBlock));
+      }
+
+      internal void Deconstruct(out IContainer container, out IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> ignoredNeighborhoods)
+      {
+         container = _container;
+         ignoredNeighborhoods = _ignoredNeighborHoods;
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
+++ b/src/OSPSuite.Core/Domain/Services/SpatialStructureMerger.cs
@@ -12,7 +12,7 @@ namespace OSPSuite.Core.Domain.Services
    internal interface ISpatialStructureMerger
    {
       IContainer MergeContainerStructure(ModelConfiguration modelConfiguration);
-      IContainer MergeNeighborhoods(ModelConfiguration modelConfiguration);
+      NeighborhoodMapResult MergeNeighborhoods(ModelConfiguration modelConfiguration);
    }
 
    internal class SpatialStructureMerger : ISpatialStructureMerger
@@ -147,7 +147,7 @@ namespace OSPSuite.Core.Domain.Services
             _containerMergeTask.AddOrReplaceInContainer(parentContainer, containerToMerge);
       }
 
-      public IContainer MergeNeighborhoods(ModelConfiguration modelConfiguration) => _neighborhoodsMapper.MapFrom(modelConfiguration);
+      public NeighborhoodMapResult MergeNeighborhoods(ModelConfiguration modelConfiguration) => _neighborhoodsMapper.MapFrom(modelConfiguration);
    }
 
    internal class ContainerNotFoundException : OSPSuiteException

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -38,9 +39,10 @@ namespace OSPSuite.Core
    internal class When_running_the_case_study_for_module_integration : concern_for_ModuleIntegration
    {
       [Observation]
-      public void should_return_a_successful_validation()
+      public void should_return_a_successful_validation_with_warning()
       {
-         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.Valid, _result.ValidationResult.Messages.Select(m => m.Text).ToString("\n"));
+         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.ValidWithWarnings, _result.ValidationResult.Messages.Select(m => m.Text).ToString("\n"));
+         _result.ValidationResult.Messages.Single().Text.ShouldBeEqualTo(Warning.NeighborhoodWasNotFoundInModel("does_not_match_existing", "Module1 - SPATIAL STRUCTURE MODULE 1"));
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2550

# Description
Adding warning messages when a neighborhood is not included in a simulation due to one or both neighborhoods containers not found

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/e2ec2159-a6f4-41ce-aca8-1aa731b6d4f5)


# Questions (if appropriate):