### PR TITLE
Fixes #2563 Pull up SimulationExportOptions from PK-sim

### DIFF
--- a/src/OSPSuite.CLI.Core/Services/SimulationExportOptions.cs
+++ b/src/OSPSuite.CLI.Core/Services/SimulationExportOptions.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility;
+
+namespace OSPSuite.CLI.Core.Services
+{
+   public class SimulationExportOptions
+   {
+      private string _logCategory;
+      public SimulationExportMode ExportMode { get; set; }
+      public string ProjectName { get; set; }
+      public string Category { get; set; }
+      public bool UseDefaultExportName { get; set; } = true;
+      public string OutputFolder { get; set; }
+      public bool PrependProjectName { get; set; } = false;
+
+      public string LogCategory
+      {
+         set => _logCategory = value;
+         get => _logCategory ?? ProjectName;
+      }
+
+      public string TargetPathFor(ISimulation simulation, string extension) =>
+         TargetPathFor(simulation.Name, extension);
+
+      public string TargetPathFor(string fileName, string extension) =>
+         pathUnder(fileName, extension);
+
+      public string TargetCSVPathFor(string fileName) => TargetPathFor(fileName, Constants.Filter.CSV_EXTENSION);
+
+      private string pathUnder(string fileName, string extension)
+      {
+         var fileNameWithPrefix = fileName;
+         if (PrependProjectName && !string.IsNullOrEmpty(ProjectName))
+            fileNameWithPrefix = $"{ProjectName}-{fileName}";
+
+         return Path.Combine(OutputFolder, $"{FileHelper.RemoveIllegalCharactersFrom(fileNameWithPrefix)}{extension}");
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2563

# Description
This is convenient to reuse some of the path calculations when exporting simulations

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe): Task

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):