### PR TITLE
Fixes #2580 export of comparison results fails

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/ComparisonCommonContextMenuItems.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/ComparisonCommonContextMenuItems.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.UICommands;
@@ -15,6 +17,11 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
       public static IMenuBarButton CompareObjectsMenu(IReadOnlyList<IObjectBase> objectsToCompare, IOSPSuiteExecutionContext context, IContainer container)
       {
          return CompareObjectsMenu(objectsToCompare, objectsToCompare.AllNames(), context, container);
+      }
+
+      public static IMenuBarButton CompareBuildingBlocksMenu(IReadOnlyList<IBuildingBlock> buildingBlocksToCompare, IOSPSuiteExecutionContext context, IContainer container)
+      {
+         return CompareObjectsMenu(buildingBlocksToCompare, buildingBlocksToCompare.Select(x => x.DisplayName).ToList(), context, container);
       }
 
       public static IMenuBarButton CompareObjectsMenu(IReadOnlyList<IObjectBase> objectsToCompare, IReadOnlyList<string> objectNames, IOSPSuiteExecutionContext context, IContainer container)


### PR DESCRIPTION
Fixes #2580

# Description
Comparison table should indicate the module when comparing building blocks. Otherwise it's confusing which is which. This cascades into a problem when exporting because the view can handle columns with the same name, but the datatable used for export to excel cannot.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

module name added for module building blocks

<img width="946" height="164" alt="image" src="https://github.com/user-attachments/assets/3babfdae-7113-4a57-a2c3-4d087930586b" />


# Questions (if appropriate):