### PR TITLE
Fixes #2589 Residuals vs. Time not displayed

### DIFF
--- a/src/OSPSuite.UI/Views/Charts/ChartEditorView.cs
+++ b/src/OSPSuite.UI/Views/Charts/ChartEditorView.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using OSPSuite.Utility.Extensions;
+using System.Windows.Forms;
 using DevExpress.Utils;
 using DevExpress.XtraBars;
 using DevExpress.XtraEditors;
@@ -14,6 +14,7 @@ using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Mappers;
 using OSPSuite.UI.Services;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.UI.Views.Charts
 {
@@ -50,6 +51,7 @@ namespace OSPSuite.UI.Views.Charts
          chkAutoUpdateCharts.Text = Captions.AutoUpdateChart;
          chkAutoUpdateCharts.SuperTip = new SuperToolTip().WithText(ToolTips.EnableOrDisableAutomaticUpdateOfTheChartForEachEdit);
          chkUsedIn.Text = Captions.UseSelected;
+         chkUsedIn.Properties.AllowGrayed = true;
          chkUsedIn.SuperTip = new SuperToolTip().WithText(ToolTips.UseSelectedCurvesToolTip);
          chkLinkSimulationObserved.Text = Captions.LinkDataToSimulations;
          chkLinkSimulationObserved.SuperTip = new SuperToolTip().WithText(ToolTips.LinkSimulationObservedToolTip);
@@ -72,7 +74,9 @@ namespace OSPSuite.UI.Views.Charts
          var checkEdit = sender as CheckEdit;
          if (checkEdit == null) return;
 
-         _presenter.UpdateUsedForSelection(checkEdit.Checked);
+         // Do not update selection for indeterminate state
+         if (checkEdit.CheckState == CheckState.Checked || checkEdit.CheckState == CheckState.Unchecked)
+            _presenter.UpdateUsedForSelection(checkEdit.Checked);
       }
 
       private void changeAutoUpdateCharts(object sender)
@@ -83,7 +87,7 @@ namespace OSPSuite.UI.Views.Charts
          _presenter.UpdateAutoUpdateChartMode(autoMode: checkEdit.Checked);
          btnApplyChartUpdates.Enabled = !checkEdit.Checked;
       }
-      
+
       private void changeLinkSimulationToData(object sender)
       {
          var checkEdit = sender as CheckEdit;
@@ -165,7 +169,13 @@ namespace OSPSuite.UI.Views.Charts
 
       public void SetlinkSimDataMenuItemVisisbility(bool isVisible) => layoutControlItemLink.Visibility = isVisible ? LayoutVisibility.Always : LayoutVisibility.Never;
 
-      public void SetSelectAllCheckBox(bool? checkedState) => chkUsedIn.EditValue = checkedState;
+      public void SetSelectAllCheckBox(bool? checkedState)
+      {
+         if (checkedState.HasValue)
+            chkUsedIn.CheckState = checkedState.Value ? CheckState.Checked : CheckState.Unchecked;
+         else
+            chkUsedIn.CheckState = CheckState.Indeterminate;
+      }
 
       public void SetAutoUpdateModeCheckBox(bool? checkedState) => chkAutoUpdateCharts.EditValue = checkedState;
 
@@ -182,6 +192,5 @@ namespace OSPSuite.UI.Views.Charts
       public void SetCurveColorGroupingView(IView view) => panelCurveColorGrouping.FillWith(view);
 
       public void SetChartExportSettingsView(IView view) => panelChartExportSettings.FillWith(view);
-
    }
 }


### PR DESCRIPTION
Fixes #2589

# Description
We are getting an event fire when a new data repository is added to the data browser. This caused all data to be removed from the chart because the checkedit was not checked. It actually should be indeterminate, but it was not checked that way.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):