### PR TITLE
Fixes #2585 Data importer - wrong behavior #2

### DIFF
--- a/src/OSPSuite.Core/Import/Column.cs
+++ b/src/OSPSuite.Core/Import/Column.cs
@@ -10,7 +10,7 @@ namespace OSPSuite.Core.Import
    {
       public static readonly string InvalidUnit = "?";
 
-      public string SelectedUnit { get; private set; }
+      public string SelectedUnit { get; }
 
       public string ColumnName { get; }
 
@@ -18,13 +18,14 @@ namespace OSPSuite.Core.Import
       {
          ColumnName = "";
       }
+
       public UnitDescription(string defUnit, string columnName = "")
       {
          SelectedUnit = defUnit;
          ColumnName = columnName;
       }
 
-      public string ExtractUnit(Func<string,int> index, IEnumerable<string> row)
+      public string ExtractUnit(Func<string, int> index, IEnumerable<string> row)
       {
          if (string.IsNullOrEmpty(ColumnName))
          {
@@ -48,6 +49,19 @@ namespace OSPSuite.Core.Import
 
    public class Column
    {
+      public Column()
+      {
+      }
+
+      public Column(Column baseColumn)
+      {
+         Name = baseColumn.Name;
+         Unit = baseColumn.Unit;
+         Dimension = baseColumn.Dimension;
+         LloqColumn = baseColumn.LloqColumn;
+         ErrorStdDev = baseColumn.ErrorStdDev;
+      }
+
       public string Name { get; set; }
 
       public UnitDescription Unit { get; set; }
@@ -64,14 +78,14 @@ namespace OSPSuite.Core.Import
 
       public bool MissingUnitMapping()
       {
-         return 
+         return
             //manual selection: selected unit not set and the column is not a Geometric Standard Deviation
             (Unit.SelectedUnit == UnitDescription.InvalidUnit &&
-                  (ErrorStdDev == null || ErrorStdDev.Equals(Constants.STD_DEV_ARITHMETIC)))
+             (ErrorStdDev == null || ErrorStdDev.Equals(Constants.STD_DEV_ARITHMETIC)))
             ||
             //select from a column: selected unit is null (not set) and no column has been selected
-            (Unit.SelectedUnit == null  &&
-                  Unit.ColumnName == string.Empty);
+            (Unit.SelectedUnit == null &&
+             Unit.ColumnName == string.Empty);
       }
    }
 }

--- a/src/OSPSuite.Infrastructure.Import/Core/DataFormat/AbstractColumnsDataFormat.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataFormat/AbstractColumnsDataFormat.cs
@@ -326,7 +326,7 @@ namespace OSPSuite.Infrastructure.Import.Core.DataFormat
             (
                new ExtendedColumn
                {
-                  Column = currentParameter.MappedColumn,
+                  Column = new Column(currentParameter.MappedColumn),
                   ColumnInfo = columnInfo,
                   ErrorDeviation = currentParameter.MappedColumn.ErrorStdDev
                },

--- a/src/OSPSuite.Presentation/DTO/DimensionSelectionDTO.cs
+++ b/src/OSPSuite.Presentation/DTO/DimensionSelectionDTO.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Infrastructure.Import.Core;
+using OSPSuite.Core.Import;
 
 namespace OSPSuite.Presentation.DTO
 {
@@ -10,18 +10,18 @@ namespace OSPSuite.Presentation.DTO
       public string SheetName { get; }
       private readonly string _description;
 
-      public DimensionSelectionDTO(string sheetName, IReadOnlyList<string> description, ColumnInfo columnInfo, IReadOnlyList<IDimension> supportingDimensions)
+      public DimensionSelectionDTO(string sheetName, IReadOnlyList<string> description, Column column, IReadOnlyList<IDimension> supportingDimensions)
       {
          SheetName = sheetName;
          _description = string.Join(" - ", description);
          Dimensions = supportingDimensions;
-         Column = columnInfo;
+         Column = column;
 
-         if(supportingDimensions.Count == 1)
+         if (supportingDimensions.Count == 1)
             SelectedDimension = supportingDimensions.Single();
       }
 
-      public ColumnInfo Column { get; }
+      public Column Column { get; }
 
       public IReadOnlyList<IDimension> Dimensions { get; }
       public IDimension SelectedDimension { get; set; }

--- a/src/OSPSuite.Presentation/Presenters/Importer/ImporterPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ImporterPresenter.cs
@@ -259,7 +259,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
             _dimensionMappingPresenter.EditUnitToDimensionMap(ambiguousDimensionDTOs);
          }
 
-         dimensionDTOs.Each(dto => dto.Column.MappedDimension = dto.SelectedDimension);
+         dimensionDTOs.Each(dto => dto.Column.Dimension = dto.SelectedDimension);
 
          errors.Add(validateDataSource(_dataSource));
          errors.Add(validateAmbiguousDimensions(ambiguousDimensionDTOs, _dataSource));
@@ -296,9 +296,9 @@ namespace OSPSuite.Presentation.Presenters.Importer
          return errors;
       }
 
-      private static void addError(IDataSource dataSource, ParseErrors errors, DimensionSelectionDTO dto) => errors.Add(dataSource.DataSets[dto.SheetName], new NoMappedDimensionForColumn(dto.SheetName, dto.Column.DisplayName));
+      private static void addError(IDataSource dataSource, ParseErrors errors, DimensionSelectionDTO dto) => errors.Add(dataSource.DataSets[dto.SheetName], new NoMappedDimensionForColumn(dto.SheetName, dto.Column.Name));
 
-      private static bool dimensionNotMapped(DimensionSelectionDTO x) => x.Column.MappedDimension == null;
+      private static bool dimensionNotMapped(DimensionSelectionDTO x) => x.Column.Dimension == null;
 
       private void onFormatChanged(object sender, FormatChangedEventArgs e)
       {

--- a/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
@@ -42,7 +42,7 @@ namespace OSPSuite.Presentation.Services
 
       private DimensionSelectionDTO dimensionsSupporting(IReadOnlyList<string> units, ExtendedColumn extendedColumn, string sheetName, IReadOnlyList<string> description)
       {
-         return new DimensionSelectionDTO(sheetName, description, extendedColumn.ColumnInfo, 
+         return new DimensionSelectionDTO(sheetName, description, extendedColumn.Column, 
             extendedColumn.Column.Dimension != null ? 
                new List<IDimension> { extendedColumn.Column.Dimension } : 
                extendedColumn.ColumnInfo.SupportedDimensions.Where(dimension => supportsAllUnits(dimension, units)).ToList());

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/DimensionMappingPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/DimensionMappingPresenterSpecs.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Infrastructure.Import.Core;
+using OSPSuite.Core.Import;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Presenters.Importer;
 using OSPSuite.Presentation.Views.Importer;
@@ -27,7 +26,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
    {
       private List<DimensionSelectionDTO> _dimensionDTOs;
       private IReadOnlyList<IDimension> _possibleDimensions;
-      private ColumnInfo _column;
+      private Column _column;
       private IDimension _pickedDimension;
 
       protected override void Context()
@@ -35,7 +34,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
          base.Context();
          _pickedDimension = new Dimension(new BaseDimensionRepresentation(), "Mass", "mg");
          _possibleDimensions = new List<IDimension>();
-         _column = new ColumnInfo();
+         _column = new Column();
          _dimensionDTOs = new List<DimensionSelectionDTO> { new DimensionSelectionDTO("sheet", new[] { string.Empty }, _column, _possibleDimensions) };
 
          A.CallTo(() => _view.BindTo(_dimensionDTOs)).Invokes(x => _dimensionDTOs.Single().SelectedDimension = _pickedDimension);
@@ -59,7 +58,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
    {
       private List<DimensionSelectionDTO> _dimensionDTOs;
       private IReadOnlyList<IDimension> _possibleDimensions;
-      private ColumnInfo _column;
+      private Column _column;
       private IDimension _pickedDimension;
 
       protected override void Context()
@@ -67,7 +66,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
          base.Context();
          _pickedDimension = new Dimension(new BaseDimensionRepresentation(), "Mass", "mg");
          _possibleDimensions = new List<IDimension>();
-         _column = new ColumnInfo();
+         _column = new Column();
          _dimensionDTOs = new List<DimensionSelectionDTO> { new DimensionSelectionDTO("sheet", new [] {string.Empty}, _column, _possibleDimensions) };
 
          A.CallTo(() => _view.BindTo(_dimensionDTOs)).Invokes(x => _dimensionDTOs.Single().SelectedDimension = _pickedDimension);
@@ -90,7 +89,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
    {
       
       private List<IDimension> _possibleDimensions;
-      private ColumnInfo _column;
+      private Column _column;
       private List<DimensionSelectionDTO> _dimensionDTOs;
       private DimensionSelectionDTO _dimensionSelect1;
       private DimensionSelectionDTO _dimensionSelect2;
@@ -113,7 +112,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
          };
 
          _otherPossibleDimensions = new List<IDimension> { _doseDimension, _massDimension, new Dimension(new BaseDimensionRepresentation(), "Time", "h") };
-         _column = new ColumnInfo();
+         _column = new Column();
          
          _dimensionSelect1 = new DimensionSelectionDTO("sheet", new[] { string.Empty }, _column, _possibleDimensions);
          _dimensionSelect2 = new DimensionSelectionDTO("sheet", new[] { string.Empty }, _column, _possibleDimensions);

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ImporterPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ImporterPresenterSpecs.cs
@@ -329,13 +329,13 @@ namespace OSPSuite.Presentation.Importer.Presenters
    public class When_mapping_completed_with_loaded_data : concern_for_ImporterPresenter
    {
       protected Cache<string, DataSheet> _sheets;
-      private ColumnInfo _columnInfo;
+      private Column _columnInfo;
 
       protected override void Context()
       {
          base.Context();
          _sheets = new Cache<string, DataSheet> { { "sheet1", A.Fake<DataSheet>() } };
-         _columnInfo = new ColumnInfo();
+         _columnInfo = new Column();
          var dto = new DimensionSelectionDTO("sheet", new[] { string.Empty }, _columnInfo, new List<IDimension> { DomainHelperForSpecs.ConcentrationDimensionForSpecs(), DomainHelperForSpecs.ConcentrationMassDimensionForSpecs() });
 
          A.CallTo(() => _dataSourceToDimensionSelectionDTOMapper.MapFrom(A<IDataSource>._, A<IReadOnlyList<string>>._)).Returns(new List<DimensionSelectionDTO> { dto });
@@ -348,7 +348,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
       [Observation]
       public void the_column_dimension_should_be_set_to_the_selected_dimension_of_the_dto()
       {
-         _columnInfo.MappedDimension.ShouldBeEqualTo(DomainHelperForSpecs.ConcentrationDimensionForSpecs());
+         _columnInfo.Dimension.ShouldBeEqualTo(DomainHelperForSpecs.ConcentrationDimensionForSpecs());
       }
 
       [Observation]

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DimensionSelectionDTOSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DimensionSelectionDTOSpecs.cs
@@ -2,7 +2,7 @@
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Infrastructure.Import.Core;
+using OSPSuite.Core.Import;
 using OSPSuite.Presentation.DTO;
 
 namespace OSPSuite.Presentation.Presentation
@@ -11,12 +11,12 @@ namespace OSPSuite.Presentation.Presentation
    {
       protected override void Context()
       {
-         sut = new DimensionSelectionDTO(SheetName, Description, ColumnInfo, SupportingDimensions);
+         sut = new DimensionSelectionDTO(SheetName, Description, Column, SupportingDimensions);
       }
 
       protected abstract IReadOnlyList<IDimension> SupportingDimensions { get; }
 
-      protected abstract ColumnInfo ColumnInfo { get; } 
+      protected abstract Column Column { get; } 
 
       protected abstract IReadOnlyList<string> Description { get; }
 
@@ -26,7 +26,7 @@ namespace OSPSuite.Presentation.Presentation
    public class When_selecting_dimension_and_sheet_name_is_empty : concern_for_DimensionSelectionDTO
    {
       protected override IReadOnlyList<IDimension> SupportingDimensions { get; } = new List<IDimension>();
-      protected override ColumnInfo ColumnInfo { get; } = new ColumnInfo() {Name = "column"};
+      protected override Column Column { get; } = new Column() {Name = "column"};
       protected override IReadOnlyList<string> Description { get; } = new[] { "group 1" };
       protected override string SheetName { get; } = string.Empty;
 
@@ -40,7 +40,7 @@ namespace OSPSuite.Presentation.Presentation
    public class When_selecting_dimension_and_sheet_name_is_not_empty : concern_for_DimensionSelectionDTO
    {
       protected override IReadOnlyList<IDimension> SupportingDimensions { get; } = new List<IDimension>();
-      protected override ColumnInfo ColumnInfo { get; } = new ColumnInfo() { Name = "column" };
+      protected override Column Column { get; } = new Column() { Name = "column" };
       protected override IReadOnlyList<string> Description { get; } = new[] { "group 1" };
       protected override string SheetName { get; } = "sheet";
 
@@ -54,7 +54,7 @@ namespace OSPSuite.Presentation.Presentation
    public class When_selecting_dimension_and_group_is_empty : concern_for_DimensionSelectionDTO
    {
       protected override IReadOnlyList<IDimension> SupportingDimensions { get; } = new List<IDimension>();
-      protected override ColumnInfo ColumnInfo { get; } = new ColumnInfo() { Name = "column" };
+      protected override Column Column { get; } = new Column() { Name = "column" };
       protected override IReadOnlyList<string> Description { get; } = new List<string>();
       protected override string SheetName { get; } = "sheet";
 


### PR DESCRIPTION
Fixes #2585

# Description
All `Column` objects were shared among all imported sheets and that meant once you decide for a sheet that the measurement dimension is Dimensionless, it will be the same for all sheets.

I added a clone-constructor so that I could use the MappedColumn as a template, but have different instances to accept different dimensions per sheet.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):