### PR TITLE
Fixes #2599 Extend PV BB with expression profiles - wrong formula expression in plasma

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterValuesCreator.cs
@@ -149,14 +149,26 @@ namespace OSPSuite.Core.Domain.Services
       {
          var formulaSource = pathMatchedExpressionParameterFor(nameMatchedExpressionParameters, formulaTarget);
 
-         if (formulaSource == null && hasCompartment(formulaTarget))
-            formulaSource = compartmentMatchedExpressionParameterFor(formulaTarget, nameMatchedExpressionParameters);
-
-         return formulaSource;
+         if (formulaSource != null || !hasCompartment(formulaTarget)) 
+            return formulaSource;
+         
+         var potentialSources = compartmentMatchedExpressionParametersFor(formulaTarget, nameMatchedExpressionParameters);
+         return !potentialSources.Any() ? null : mostFrequentFormulaExpression(potentialSources);
       }
 
-      private static ExpressionParameter compartmentMatchedExpressionParameterFor(ParameterValue formulaTarget, List<ExpressionParameter> nameMatchedExpressionParameters) =>
-         nameMatchedExpressionParameters.Where(hasCompartment).FirstOrDefault(x => Equals(compartmentFor(x), compartmentFor(formulaTarget)));
+      private static ExpressionParameter mostFrequentFormulaExpression(IReadOnlyList<ExpressionParameter> potentialSources)
+      {
+         // Group the potential sources by formula name, order the groups by the count, flatten the groups, take the first expression parameter
+         return potentialSources.GroupBy(formulaGroupingName).OrderByDescending(x => x.Count()).SelectMany(x => x).First();
+      }
+
+      /// <summary>
+      /// Returns a name for the <paramref name="expressionParameter"/> formula. Expression parameters with value return the value as string
+      /// </summary>
+      private static string formulaGroupingName(ExpressionParameter expressionParameter) => expressionParameter.Formula == null ? expressionParameter.Value.ToString() : expressionParameter.Formula.Name;
+
+      private static IReadOnlyList<ExpressionParameter> compartmentMatchedExpressionParametersFor(ParameterValue formulaTarget, List<ExpressionParameter> nameMatchedExpressionParameters) =>
+         nameMatchedExpressionParameters.Where(x => hasCompartment(x) && Equals(compartmentFor(x), compartmentFor(formulaTarget))).ToList();
 
       private static string compartmentFor(ParameterValue formulaTarget) => formulaTarget.Path[compartmentIndex(formulaTarget)];
 

--- a/tests/OSPSuite.Infrastructure.Tests/Import/DataSetToDataRepositoryMapperSpecs.cs
+++ b/tests/OSPSuite.Infrastructure.Tests/Import/DataSetToDataRepositoryMapperSpecs.cs
@@ -320,7 +320,6 @@ namespace OSPSuite.Infrastructure.Import
       }
 
       private ImportedDataSet _importedDataSet;
-      private DataSetToDataRepositoryMappingResult _result;
 
       protected override void Because()
       {


### PR DESCRIPTION
Fixes #2599 

# Description
Let's select the most frequently occurring formula for the nex ParameterValue from the matching ExpressionParameters.
Including values, so if there's a formula or value that occurs more than others, we will use that.

This is when we extend a ParameterValueBB to include expression parameters for a container and molecule.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):