### PR TITLE
Fixes #2627 Move PresenterLogger to core

### DIFF
--- a/src/OSPSuite.Infrastructure/Services/PresenterLogger.cs
+++ b/src/OSPSuite.Infrastructure/Services/PresenterLogger.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OSPSuite.Core.Events;
+using OSPSuite.Core.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+using System;
+
+namespace OSPSuite.Infrastructure.Services
+{
+   public class PresenterLogger : ILogger
+   {
+      private readonly IEventPublisher _eventPublisher;
+      public string Name { get; }
+
+      public PresenterLogger(string name)
+      {
+         _eventPublisher = IoC.Resolve<IEventPublisher>();
+         Name = name;
+      }
+
+      public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+      {
+         if (formatter == null)
+            throw new ArgumentNullException(nameof(formatter));
+
+         string message = formatter(state, exception);
+         if (string.IsNullOrEmpty(message) && exception == null)
+            return;
+
+         writeMessage(logLevel, Name, eventId.Id, message, exception);
+      }
+
+      private void writeMessage(LogLevel logLevel, string name, int eventIdId, string message, Exception exception)
+      {
+         var logEntry = new LogEntry(logLevel, message);
+         _eventPublisher.PublishEvent(new LogEntryEvent(logEntry));
+      }
+
+      public bool IsEnabled(LogLevel logLevel)
+      {
+         return true;
+      }
+
+      public IDisposable BeginScope<TState>(TState state)
+      {
+         return NullLogger.Instance.BeginScope(state);
+      }
+   }
+
+   public static class PresenterLoggingBuilderExtensions
+   {
+      public static ILoggingBuilder AddPresenter(this ILoggingBuilder builder)
+      {
+         builder.Services.AddSingleton<ILoggerProvider, PresenterLoggerProvider>(serviceProvider => new PresenterLoggerProvider());
+         return builder;
+      }
+   }
+}

--- a/src/OSPSuite.Infrastructure/Services/PresenterLoggerProvider.cs
+++ b/src/OSPSuite.Infrastructure/Services/PresenterLoggerProvider.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace OSPSuite.Infrastructure.Services
+{
+   public class PresenterLoggerProvider : ILoggerProvider
+   {
+      private readonly ConcurrentDictionary<string, PresenterLogger> _loggers = new ConcurrentDictionary<string, PresenterLogger>();
+
+      public ILogger CreateLogger(string categoryName)
+      {
+         return _loggers.GetOrAdd(categoryName, createLoggerImplementation);
+      }
+
+      private PresenterLogger createLoggerImplementation(string name)
+      {
+         return new PresenterLogger(name);
+      }
+
+      public void Dispose()
+      {
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2627

# Description
During refactoring and moving of snapshot infrastructure up to core from PK-Sim, this class was copy/pasted to MoBi instead of being pulled up.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):task

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):