### PR TITLE
Fixes #2631 StartableProcess with overridden priority

### DIFF
--- a/src/OSPSuite.Core/Services/StartableProcess.cs
+++ b/src/OSPSuite.Core/Services/StartableProcess.cs
@@ -36,9 +36,17 @@ namespace OSPSuite.Core.Services
       /// </summary>
       public int ReturnCode => _process.ExitCode;
 
-      public virtual void Start()
+      /// <summary>
+      /// Starts the process with the specified <paramref name="priority"/>, if provided. Otherwise, the current process priority is inherited
+      /// </summary>
+      public virtual void Start(ProcessPriorityClass? priority = null)
       {
          _process?.Start();
+         if (!priority.HasValue) 
+            return;
+         
+         if(_process != null) 
+            _process.PriorityClass = priority.Value;
       }
 
       public void Dispose()


### PR DESCRIPTION
Fixes #2631

# Description
Allow caller to specify a priority when starting a new process.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):