### PR TITLE
Performance issue with creating a simulation using Expression Profiles for proteins that are not part of the model

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2154,6 +2154,8 @@ namespace OSPSuite.Assets
          $"The selected output resolution will generate {numberOfPoints} points and may severely impact the software performance.\nAre you sure you want to run with these setting? If not, consider changing output resolution in simulations settings";
 
       public static string NeighborhoodWasNotFoundInModel(string neighborhoodName, string buildingBlockName) => $"The neighborhood '{neighborhoodName}' from building block '{buildingBlockName}' was not added to the simulation";
+
+      public static string ExpressionMoleculeNotFoundInSimulation(string moleculeName) => $"The molecule '{moleculeName}' is not part of the simulation structure";
    }
 
    public static class RibbonCategories

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -75,26 +75,22 @@ namespace OSPSuite.Core.Domain.Services
          var (modelConfiguration, validationResult) = valueUpdater;
 
          var allPresentMoleculeNames = allMoleculeNames(modelConfiguration.SimulationConfiguration);
-
          var expressionProfiles = modelConfiguration.SimulationConfiguration.ExpressionProfiles;
-         var absentProteins = expressionProfiles.Where(x => !proteinIsInModel(x, allPresentMoleculeNames)).ToList();
+         var expressionsOfAbsentMolecules = expressionProfiles.Where(x => !allPresentMoleculeNames.Contains(x.MoleculeName)).ToList();
 
-         addMessagesForMissingProteins(absentProteins, validationResult);
+         addMessagesForMissingExpressionMolecules(expressionsOfAbsentMolecules, validationResult);
 
          var addOrUpdateParameter = addOrUpdateParameterFromParameterValue(valueUpdater);
 
-         expressionProfiles.Except(absentProteins).SelectMany(x => x.ExpressionParameters)
+         expressionProfiles.Except(expressionsOfAbsentMolecules).SelectMany(x => x.ExpressionParameters)
             .Each(addOrUpdateParameter);
       }
 
-      private void addMessagesForMissingProteins(IEnumerable<ExpressionProfileBuildingBlock> absentProteins, ValidationResult validationResult) =>
-         absentProteins.Each(x => validationResult.AddMessage(NotificationType.Warning, x, Warning.ExpressionMoleculeNotFoundInSimulation(x.MoleculeName), x));
+      private void addMessagesForMissingExpressionMolecules(IReadOnlyList<ExpressionProfileBuildingBlock> absentExpressionProfiles, ValidationResult validationResult) =>
+         absentExpressionProfiles.Each(x => validationResult.AddMessage(NotificationType.Warning, x, Warning.ExpressionMoleculeNotFoundInSimulation(x.MoleculeName), x));
 
       private IReadOnlyList<string> allMoleculeNames(SimulationConfiguration configuration) =>
          configuration.ModuleConfigurations.Where(x => x.Module.Molecules != null).SelectMany(x => x.Module.Molecules.AllNames()).Distinct().ToList();
-
-      private bool proteinIsInModel(ExpressionProfileBuildingBlock expressionProfileBuildingBlock, IReadOnlyList<string> allMoleculeNames) =>
-         allMoleculeNames.Contains(expressionProfileBuildingBlock.MoleculeName);
 
       private void updateParameterFromIndividualValues(ValueUpdaterParams valueUpdater)
       {

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -90,7 +90,7 @@ namespace OSPSuite.Core.Domain.Services
          absentExpressionProfiles.Each(x => validationResult.AddMessage(NotificationType.Warning, x, Warning.ExpressionMoleculeNotFoundInSimulation(x.MoleculeName), x));
 
       private IReadOnlyList<string> allMoleculeNames(SimulationConfiguration configuration) =>
-         configuration.ModuleConfigurations.Where(x => x.Module.Molecules != null).SelectMany(x => x.Module.Molecules.AllNames()).Distinct().ToList();
+         configuration.All<MoleculeBuildingBlock>().SelectMany(x => x.AllNames()).Distinct().ToList();
 
       private void updateParameterFromIndividualValues(ValueUpdaterParams valueUpdater)
       {

--- a/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
@@ -1,4 +1,6 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System.Linq;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -72,6 +74,8 @@ namespace OSPSuite.Core.Services
       private ModuleConfiguration _moduleConfiguration;
       private ParameterValue _meanParameterValue;
       private ParameterValue _distributedParameterValue;
+      private ValidationResult _result;
+      private ExpressionProfileBuildingBlock _expressionProfileBuildingBlock;
 
       protected override void Context()
       {
@@ -96,13 +100,21 @@ namespace OSPSuite.Core.Services
 
          _moduleConfiguration = new ModuleConfiguration(_module, null, _parameterValues);
          _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration);
+         _expressionProfileBuildingBlock = new ExpressionProfileBuildingBlock().WithName("molecule|species|category");
+         _simulationConfiguration.AddExpressionProfile(_expressionProfileBuildingBlock);
          _simulationBuilder = new SimulationBuilder(_simulationConfiguration);
          _modelConfiguration = new ModelConfiguration(_model, _simulationConfiguration, _simulationBuilder);
       }
 
       protected override void Because()
       {
-         sut.UpdateQuantitiesValues(_modelConfiguration);
+         _result = sut.UpdateQuantitiesValues(_modelConfiguration);
+      }
+
+      [Observation]
+      public void the_validation_result_indicates_missing_protein_for_present_expression()
+      {
+         _result.Messages.Single(x => x.BuildingBlock.Equals(_expressionProfileBuildingBlock)).Text.ShouldBeEqualTo(Warning.ExpressionMoleculeNotFoundInSimulation(_expressionProfileBuildingBlock.MoleculeName));
       }
 
       [Observation]

--- a/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Services/QuantityValuesUpdaterIntegrationTests.cs
@@ -77,9 +77,9 @@ namespace OSPSuite.Core.Services
       private ValidationResult _result;
       private ExpressionProfileBuildingBlock _expressionProfileBuildingBlock;
 
-      protected override void Context()
+      public override void GlobalContext()
       {
-         base.Context();
+         base.GlobalContext();
 
          _distributedParameterValue = new ParameterValue
          {


### PR DESCRIPTION
Fixes #2646

# Description
Rather than look for all individual Expression Parameters in a simulation, first check if the molecule is present and give a single warning if not.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):