### PR TITLE
 Wrong dimension prompt for GeoStd error when importing observed data

### DIFF
--- a/OSPSuite.Core.sln
+++ b/OSPSuite.Core.sln
@@ -7,9 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSPSuite.Core", "src\OSPSui
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{25A7357D-0812-44F3-AF90-244FD752FAE2}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\build-and-publish.yml = .github\workflows\build-and-publish.yml
-		.github\workflows\coverage.yml = .github\workflows\coverage.yml
+		.github\workflows\build-and-publish_12.2.yml = .github\workflows\build-and-publish_12.2.yml
 		.github\workflows\build-pr_12.2.yml = .github\workflows\build-pr_12.2.yml
+		.github\workflows\coverage.yml = .github\workflows\coverage.yml
 		logo.png = logo.png
 		rakefile.rb = rakefile.rb
 		SolutionInfo.cs = SolutionInfo.cs

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Core functionalities of the Open Systems Pharmacology Suite.
 
 ## Code Status
-[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite.Core/build-and-publish.yml?logo=nuget&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/actions/workflows/build-and-publish.yml)
+[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite.Core/build-and-publish_12.2.yml?logo=nuget&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/actions/workflows/build-and-publish_12.2.yml)
 [![Coverage status](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite.Core/branch/develop/graph/badge.svg)](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite.Core)
 
 ## Code of conduct

--- a/src/OSPSuite.Infrastructure.Import/Core/DataSource.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSource.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using OSPSuite.Core.Domain;
+﻿using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Import;
 using OSPSuite.Infrastructure.Import.Core.Exceptions;
 using OSPSuite.Infrastructure.Import.Services;
 using OSPSuite.Utility.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using static Org.BouncyCastle.Bcpg.Attr.ImageAttrib;
 
 namespace OSPSuite.Infrastructure.Import.Core
 {
@@ -59,6 +60,7 @@ namespace OSPSuite.Infrastructure.Import.Core
       ImportedDataSet ImportedDataSetAt(int index);
       IDataSet DataSetAt(int index);
       ParseErrors ValidateDataSourceUnits(ColumnInfoCache columnInfos);
+      
    }
 
    public class DataSource : IDataSource
@@ -85,10 +87,11 @@ namespace OSPSuite.Infrastructure.Import.Core
       }
 
       public NanSettings NanSettings { get; set; }
-
+      
       public ParseErrors AddSheets(DataSheetCollection dataSheets, ColumnInfoCache columnInfos, string filter)
       {
          _importer.AddFromFile(_configuration.Format, dataSheets.Filter(filter), columnInfos, this);
+         
          if (NanSettings == null || !double.TryParse(NanSettings.Indicator, out var indicator))
             indicator = double.NaN;
          var errors = new ParseErrors();

--- a/src/OSPSuite.Infrastructure.Import/Core/IDataSet.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/IDataSet.cs
@@ -21,6 +21,7 @@ namespace OSPSuite.Infrastructure.Import.Core
       void ClearNan(double indicator);
       bool NanValuesExist(double indicator);
       void AddData(IEnumerable<ParsedDataSet> range);
+      void ClearData();
    }
 
    public class DataSet : IDataSet
@@ -29,10 +30,9 @@ namespace OSPSuite.Infrastructure.Import.Core
 
       public IReadOnlyList<ParsedDataSet> Data => _data;
 
-      public void AddData(IEnumerable<ParsedDataSet> range)
-      {
-         _data.AddRange(range);
-      }
+      public void AddData(IEnumerable<ParsedDataSet> range) => _data.AddRange(range);
+
+      public void ClearData() => _data.Clear();
 
       public bool NanValuesExist(double indicator)
       {

--- a/src/OSPSuite.Infrastructure.Import/Services/Importer.cs
+++ b/src/OSPSuite.Infrastructure.Import/Services/Importer.cs
@@ -96,6 +96,9 @@ namespace OSPSuite.Infrastructure.Import.Services
                alreadyExisting.DataSets.Add(key, current);
             }
 
+            // current is an IDataSet that may have already existing data from a previous attempt importing a sheet.
+            // It should be emptied before the new data sets from the sheet are added, perhaps with a revised configuration
+            current.ClearData();
             current.AddData(dataSets[key].Data);
          }
       }

--- a/src/OSPSuite.Presentation/Presenters/Importer/ImporterPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ImporterPresenter.cs
@@ -248,9 +248,9 @@ namespace OSPSuite.Presentation.Presenters.Importer
          _dataSource.SetMappings(dataSourceFile.Path, mappings);
          _dataSource.NanSettings = _nanPresenter.Settings;
          _dataSource.SetDataFormat(_columnMappingPresenter.GetDataFormat());
+
          var errors = _dataSource.AddSheets(sheets, _columnInfos, filter);
-
-
+         
          var dimensionDTOs = _dataSourceToDimensionSelectionDTOMapper.MapFrom(_dataSource, sheetNames);
 
          var ambiguousDimensionDTOs = dimensionDTOs.Where(x => x.Dimensions.Count > 1).ToList();

--- a/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Core.Import;
 using OSPSuite.Infrastructure.Import.Core;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Utility;
@@ -45,11 +46,15 @@ namespace OSPSuite.Presentation.Services
          return new DimensionSelectionDTO(sheetName, description, extendedColumn.Column, 
             extendedColumn.Column.Dimension != null ? 
                new List<IDimension> { extendedColumn.Column.Dimension } : 
-               extendedColumn.ColumnInfo.SupportedDimensions.Where(dimension => supportsAllUnits(dimension, units)).ToList());
+               extendedColumn.ColumnInfo.SupportedDimensions.Where(dimension => supportsAllUnits(extendedColumn.Column, dimension, units)).ToList());
       }
 
-      private bool supportsAllUnits(IDimension dimension, IReadOnlyList<string> units)
+      private bool supportsAllUnits(Column extendedColumn, IDimension dimension, IReadOnlyList<string> units)
       {
+         // For GeoStd, the only supporting dimension is NO_DIMENSION
+         // if (extendedColumn.ErrorStdDev == Constants.STD_DEV_GEOMETRIC)
+         //    return dimension == Constants.Dimension.NO_DIMENSION;
+         
          return units.All(x => dimension.SupportsUnit(x));
       }
    }

--- a/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Services/DataSourceToDimensionSelectionDTOMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Import;
 using OSPSuite.Infrastructure.Import.Core;
@@ -52,8 +53,8 @@ namespace OSPSuite.Presentation.Services
       private bool supportsAllUnits(Column extendedColumn, IDimension dimension, IReadOnlyList<string> units)
       {
          // For GeoStd, the only supporting dimension is NO_DIMENSION
-         // if (extendedColumn.ErrorStdDev == Constants.STD_DEV_GEOMETRIC)
-         //    return dimension == Constants.Dimension.NO_DIMENSION;
+         if (extendedColumn.ErrorStdDev == Constants.STD_DEV_GEOMETRIC)
+            return dimension == Constants.Dimension.NO_DIMENSION;
          
          return units.All(x => dimension.SupportsUnit(x));
       }

--- a/tests/OSPSuite.Presentation.Tests/Importer/Services/DataSourceToDimensionSelectionDTOMapperSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Services/DataSourceToDimensionSelectionDTOMapperSpecs.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
-using NPOI.POIFS.NIO;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -10,6 +9,7 @@ using OSPSuite.Infrastructure.Import.Core;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Presentation.Importer.Services
 {
@@ -34,7 +34,11 @@ namespace OSPSuite.Presentation.Importer.Services
       protected override void Context()
       {
          base.Context();
-         _columns = new List<ExtendedColumn> { new ExtendedColumn { ColumnInfo = new ColumnInfo {SupportedDimensions = { Constants.Dimension.NO_DIMENSION }}, Column = new Column()} };
+         _columns = new List<ExtendedColumn>
+         {
+            new ExtendedColumn { ColumnInfo = new ColumnInfo {SupportedDimensions = { Constants.Dimension.NO_DIMENSION }}, Column = new Column() },
+            new ExtendedColumn { ColumnInfo = new ColumnInfo {SupportedDimensions = { Constants.Dimension.NO_DIMENSION }}, Column = new Column {ErrorStdDev = Constants.STD_DEV_GEOMETRIC} }
+         };
          var dataSet = A.Fake<IDataSet>();
          _datasets = new Cache<string, IDataSet>
          {
@@ -42,8 +46,8 @@ namespace OSPSuite.Presentation.Importer.Services
          };
          var dictionary = new Dictionary<ExtendedColumn, IList<SimulationPoint>>
          {
-            { _columns.First(), new List<SimulationPoint>() }
-
+            { _columns[0], new List<SimulationPoint>() },
+            { _columns[1], new List<SimulationPoint>() }
          };
 
          _parsedData = new ParsedDataSet(new List<string>(), new DataSheet(), new List<UnformattedRow>(), dictionary);
@@ -57,9 +61,16 @@ namespace OSPSuite.Presentation.Importer.Services
       }
 
       [Observation]
+      public void the_dimension_for_geo_std_should_be_no_dimension()
+      {
+         _dtos.Where(x => x.Column.ErrorStdDev == Constants.STD_DEV_GEOMETRIC).Each(x => x.SelectedDimension.ShouldBeEqualTo(Constants.Dimension.NO_DIMENSION));
+         _dtos.Count(x => x.Column.ErrorStdDev == Constants.STD_DEV_GEOMETRIC).ShouldBeEqualTo(1);
+      }
+
+      [Observation]
       public void the_dimension_map_should_contain_the_columns_and_dimensions()
       {
-         _dtos.Single().SelectedDimension.ShouldBeEqualTo(Constants.Dimension.NO_DIMENSION);
+         _dtos[0].SelectedDimension.ShouldBeEqualTo(Constants.Dimension.NO_DIMENSION);
       }
 
       [Observation]

--- a/tests/OSPSuite.Presentation.Tests/Importer/Services/ImporterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Services/ImporterSpecs.cs
@@ -35,7 +35,7 @@ namespace OSPSuite.Presentation.Importer.Services
       }
    }
 
-   public abstract class ConcernForImporter : ContextSpecification<OSPSuite.Infrastructure.Import.Services.Importer>
+   public abstract class concern_for_Importer : ContextSpecification<OSPSuite.Infrastructure.Import.Services.Importer>
    {
       protected DataSheet _basicFormat;
       protected IContainer _container;
@@ -73,7 +73,7 @@ namespace OSPSuite.Presentation.Importer.Services
       }
    }
 
-   public class When_checking_data_format : ConcernForImporter
+   public class When_checking_data_format : concern_for_Importer
    {
       [TestCase]
       public void identify_basic_format()
@@ -83,7 +83,48 @@ namespace OSPSuite.Presentation.Importer.Services
       }
    }
 
-   public class When_getting_name_from_convention : ConcernForImporter
+   public class When_adding_parsed_data_and_the_sheet_data_is_already_present : concern_for_Importer
+   {
+      private IDataSource _dataSource;
+      private DataSheetCollection _dataSheets;
+      private IDataFormat _format;
+      private DataSheet _dataSheet;
+      private ParsedDataSet _parsedDataSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dataSheets = new DataSheetCollection();
+         _dataSource = new DataSource(sut);
+         _format = A.Fake<IDataFormat>();
+         _format.SetParameters(_basicFormat, _columnInfos, null);
+         _parsedDataSet = new ParsedDataSetTest();
+         _dataSheet = new DataSheet
+         {
+            SheetName = "sheet3",
+            
+         };
+
+         _dataSheets.AddSheet(_dataSheet);
+
+         A.CallTo(() => _format.Parse(_dataSheet, _columnInfos)).Returns(new[] { _parsedDataSet });
+
+         sut.AddFromFile(_format, _dataSheets, _columnInfos, _dataSource);
+      }
+
+      protected override void Because()
+      {
+         sut.AddFromFile(_format, _dataSheets, _columnInfos, _dataSource);
+      }
+
+      [Observation]
+      public void the_number_of_data_sets_should_not_be_doubled_after_second_add()
+      {
+         _dataSource.DataSets["sheet3"].Data.Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_getting_name_from_convention : concern_for_Importer
    {
       private string _fileName;
       private string _fileExtension;
@@ -460,7 +501,7 @@ namespace OSPSuite.Presentation.Importer.Services
       }
    }
 
-   public class When_description_and_mappings_have_different_lengths : ConcernForImporter
+   public class When_description_and_mappings_have_different_lengths : concern_for_Importer
    {
       private string _fileName;
       private Cache<string, IDataSet> _dataSets;


### PR DESCRIPTION
Fixes #2639

# Description
We can make a special allowance for GeoStd for the dimension picker because it should always be no_dimension.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):