### PR TITLE
2656 unnecessary project has changed save changes prompt

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -406,7 +406,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       private void onDataBrowserUsedChanged(UsedColumnsEventArgs e)
       {
-         using (_chartUpdater.UpdateTransaction(Chart, e.Used ? CurveChartUpdateModes.Add : CurveChartUpdateModes.Remove))
+         using (_chartUpdater.UpdateTransaction(Chart, e.Used ? CurveChartUpdateModes.Add : CurveChartUpdateModes.Remove, false))
          {
             updateColumnUsedProperty(e.Columns, e.Used);
          }


### PR DESCRIPTION
Fixes Open-Systems-Pharmacology/MoBi#2135

# Description

When editing a simulation, an event was being fired that automatically set the flag ProjectHasChanged = true. This behavior was incorrect, because not every change during a simulation edit should be interpreted as a project-level modification.

Introduced a scoped suppression mechanism to prevent ProjectHasChanged from being set during simulation editing. 
The suppression is only active while the simulation is being loaded or edited, ensuring that normal changes outside of this context continue to correctly set the flag.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):