### PR TITLE
Simulation runs in .NET Framework but not in .NET 8

### DIFF
--- a/src/OSPSuite.Core/Serialization/SimModel/Services/SimulationExportCreator.cs
+++ b/src/OSPSuite.Core/Serialization/SimModel/Services/SimulationExportCreator.cs
@@ -328,7 +328,8 @@ namespace OSPSuite.Core.Serialization.SimModel.Services
                return _tableFormulaExportMapper.MapFrom(tableFormula);
 
             default:
-               return new ExplicitFormulaExport {Equation = formula.Calculate(usingFormula).ToString(NumberFormatInfo.InvariantInfo)};
+               // We need to use the G15 format specifier to revert to the behavior of .NET Framework for compatibility
+               return new ExplicitFormulaExport {Equation = formula.Calculate(usingFormula).ToString("G15", NumberFormatInfo.InvariantInfo)};
          }
       }
 

--- a/src/OSPSuite.Core/Serialization/SimModel/Services/SimulationExportCreator.cs
+++ b/src/OSPSuite.Core/Serialization/SimModel/Services/SimulationExportCreator.cs
@@ -329,6 +329,7 @@ namespace OSPSuite.Core.Serialization.SimModel.Services
 
             default:
                // We need to use the G15 format specifier to revert to the behavior of .NET Framework for compatibility
+               // https://devblogs.microsoft.com/dotnet/floating-point-parsing-and-formatting-improvements-in-net-core-3-0/#potential-impact-to-existing-code
                return new ExplicitFormulaExport {Equation = formula.Calculate(usingFormula).ToString("G15", NumberFormatInfo.InvariantInfo)};
          }
       }

--- a/tests/OSPSuite.Core.Tests/OSPSuite.Core.Tests.csproj
+++ b/tests/OSPSuite.Core.Tests/OSPSuite.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/OSPSuite.Core.Tests/Services/SimulationExportCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SimulationExportCreatorSpecs.cs
@@ -55,7 +55,7 @@ namespace OSPSuite.Core.Services
          }
 
          [Observation]
-         public void the_serialized_value_should_be_equal_to_the_initial_string()
+         public void the_serialized_value_should_drop_precision()
          {
             var formulaExport = _modelExport.FormulaList.First() as ExplicitFormulaExport;
             // we are testing that precision beyond 15 significant digits is not preserved during serialization

--- a/tests/OSPSuite.Core.Tests/Services/SimulationExportCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SimulationExportCreatorSpecs.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Serialization.SimModel.DTO;
+using OSPSuite.Core.Serialization.SimModel.Services;
+using OSPSuite.Helpers;
+
+namespace OSPSuite.Core.Services
+{
+   internal class concern_for_SimulationExportCreator : ContextSpecification<SimulationExportCreator>
+   {
+      private IObjectPathFactory _objectPathFactory;
+      private ITableFormulaToTableFormulaExportMapper _tableFormulaExportMapper;
+      private IConcentrationBasedFormulaUpdater _concentrationBasedFormulaUpdater;
+      private IEntityPathResolver _entityPathResolver;
+      private IModel _model;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _model = new Model
+         {
+            Root = new ARootContainer()
+         };
+         _objectPathFactory = A.Fake<IObjectPathFactory>();
+         _tableFormulaExportMapper = A.Fake<ITableFormulaToTableFormulaExportMapper>();
+         _concentrationBasedFormulaUpdater = A.Fake<IConcentrationBasedFormulaUpdater>();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+
+         sut = new SimulationExportCreator(_objectPathFactory, _tableFormulaExportMapper, _concentrationBasedFormulaUpdater, _entityPathResolver);
+      }
+
+      public class When_visiting_parameter_with_explicit_formula_and_value : concern_for_SimulationExportCreator
+      {
+         private IParameter _parameter;
+         private SimulationExport _modelExport;
+
+         protected override void Context()
+         {
+            base.Context();
+            _parameter = new Parameter();
+            _parameter.Formula = A.Fake<IFormula>();
+            A.CallTo(() => _parameter.Formula.Calculate(A<IUsingFormula>._)).Returns(0.11704000000000003);
+            _model.Root.Add(_parameter);
+         }
+
+         protected override void Because()
+         {
+            _modelExport = sut.CreateExportFor(_model);
+         }
+
+         [Observation]
+         public void the_serialized_value_should_be_equal_to_the_initial_string()
+         {
+            var formulaExport = _modelExport.FormulaList.First() as ExplicitFormulaExport;
+            // we are testing that precision beyond 15 significant digits is not preserved during serialization
+            formulaExport.Equation.ShouldBeEqualTo("0.11704");
+         }
+      }
+   }
+}

--- a/tests/OSPSuite.HelpersForTests/OSPSuite.HelpersForTests.csproj
+++ b/tests/OSPSuite.HelpersForTests/OSPSuite.HelpersForTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>OSPSuite.HelpersForTests</AssemblyName>
     <RootNamespace>OSPSuite.Helpers</RootNamespace>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Fixes #2661 

# Description
Change the serialization of values exported to SimModel XML so that the strings match those exported with the .NET Framework

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):