### PR TITLE
Potential fix for code scanning alert no. 3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -41,7 +41,7 @@ end
 
 private
 def find_token(file, regex)
-  file_content = str = IO.read(file)
+  file_content = str = File.read(file)
   matches = file_content.match(regex)
 
   if(matches.nil?)


### PR DESCRIPTION
Potential fix for [https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/security/code-scanning/3](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/security/code-scanning/3)

The best fix is to change the call to `IO.read(file)` on line 44 to `File.read(file)`. This exactly preserves the existing functionality, as both methods return the content of the file at the given path, but `File.read` lacks the dangerous ability to spawn a shell if the filename starts with a pipe. This change should be made only on the line(s) shown, without altering any other part of the file. No new imports or dependencies are necessary, as `File` is part of Ruby's standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
