### PR TITLE
Save dialogue missing after renaming parameter identification task

### DIFF
--- a/src/OSPSuite.Presentation/UICommands/RenameObjectBaseUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RenameObjectBaseUICommand.cs
@@ -31,6 +31,7 @@ namespace OSPSuite.Presentation.UICommands
             loadSubjectBeforeRenaming();
             Subject.Name = newName;
             _eventPublisher.PublishEvent(new RenamedEvent(Subject));
+            _context.ProjectChanged();
          }
 
       }

--- a/tests/OSPSuite.Presentation.Tests/UICommands/RenameParameterIdentificationUICommandSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/UICommands/RenameParameterIdentificationUICommandSpecs.cs
@@ -69,5 +69,11 @@ namespace OSPSuite.Presentation.UICommands
       {
          A.CallTo(() => _executionContext.Load(_parameterIdentification)).MustHaveHappened();
       }
+
+      [Observation]
+      public void the_project_should_be_marked_as_changed()
+      {
+         A.CallTo(() => _executionContext.ProjectChanged()).MustHaveHappened();
+      }
    }
 }


### PR DESCRIPTION
Fixes #2673 

# Description
This rename is done directly using the UI command and did not trigger a project change notification.

MoBi/PK-Sim for both Sensitivity Analysis and ParameterIdentifications

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):