### PR TITLE
#2707 assign variable after altering the container path

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/PathAndValueEntity.cs
+++ b/src/OSPSuite.Core/Domain/Builder/PathAndValueEntity.cs
@@ -30,7 +30,7 @@ namespace OSPSuite.Core.Domain.Builder
             var containerPath = fullPath.Clone<ObjectPath>();
             if (containerPath.Count > 0)
                containerPath.RemoveAt(containerPath.Count - 1);
-            ContainerPath = containerPath;
+            ContainerPath = containerPath; //this fires
          }
          else
          {
@@ -38,7 +38,6 @@ namespace OSPSuite.Core.Domain.Builder
             ContainerPath = ObjectPath.Empty;
          }
       }
-
 
       public ObjectPath ContainerPath
       {


### PR DESCRIPTION
Fixes #2707

# Description

Given this issue on MoBi:
https://github.com/Open-Systems-Pharmacology/MoBi/issues/2168
The property is set before removing the last part of the path, therefore there is an event which is firing and holds the entire path.
This creates a DTO which has an extra property and therefore, the UI shows the wrong data.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):