### PR TITLE
Fixes #2721 Path of a parameter of a Passive Transport cannot be resolved when "Create process rate" is enabled

### DIFF
--- a/src/OSPSuite.Core/Domain/Mappers/ProcessRateParameterCreator.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ProcessRateParameterCreator.cs
@@ -57,19 +57,16 @@ namespace OSPSuite.Core.Domain.Mappers
          if (!objectPath.Any())
             return;
 
+         // if the path starts with the  process name then we need to replace the name with ".."
+         // to compensate. That's because a container name can be ignored when a path is resolved from within that container
+         if (objectPath.Count == 2 && string.Equals(objectPath[0], processName))
+            objectPath.RemoveAt(0);
+
          // if the path starts with ".."  or if the objectPath only has the name of the reference then it
          // should be adjusted to have an additional ".." at the front
          if (objectPath[0] == ObjectPath.PARENT_CONTAINER || objectPath.Count == 1)
          {
             objectPath.AddAtFront(ObjectPath.PARENT_CONTAINER);
-            return;
-         }
-
-         // if the path contains two elements and the first one is the process name then we need to move up two containers at the front
-         // to compensate. That's because a container name can be ignored when a path is resolved from within that container
-         if (objectPath.Count == 2 && string.Equals(objectPath[0], processName))
-         {
-            objectPath.AddAtFront(new ObjectPath(ObjectPath.PARENT_CONTAINER, ObjectPath.PARENT_CONTAINER));
          }
       }
    }

--- a/tests/OSPSuite.Core.Tests/Domain/ProcessRateParameterCreatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ProcessRateParameterCreatorSpecs.cs
@@ -90,7 +90,7 @@ namespace OSPSuite.Core.Domain
       {
          _formulaUsablePathA.ShouldOnlyContainInOrder(ObjectPath.PARENT_CONTAINER, ObjectPath.PARENT_CONTAINER, "A");
          _formulaUsablePathB.ShouldOnlyContainInOrder(ObjectPath.PARENT_CONTAINER, "B");
-         _formulaUsablePathC.ShouldOnlyContainInOrder(ObjectPath.PARENT_CONTAINER, ObjectPath.PARENT_CONTAINER, _processBuilderName, "C");
+         _formulaUsablePathC.ShouldOnlyContainInOrder(ObjectPath.PARENT_CONTAINER, "C");
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2721

# Description
The path resolver can resolve paths that start with the container name, but the process rate parameter creation will not create the correct path adjustment for the process rate parameter.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):