### PR TITLE
2726 newly created curve chart curves do not match the curve editor

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -417,9 +417,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          columns.Each(column =>
          {
             if (used)
-            {
                AddCurveForColumn(column, isLinkedDataToSimulation: isLinkedDataToSimulations);
-            }
             else
                Chart.RemoveCurvesForColumn(column);
          });


### PR DESCRIPTION
Fixes #2726

# Description

The colors on the grid and editor were not matching after checking the "Use Selected" for the first time

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):