### PR TITLE
#2745 display name for building blocks

### DIFF
--- a/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
@@ -99,6 +99,10 @@ namespace OSPSuite.Presentation.Mappers
 
       private string objectNameFrom(DiffItem diffItem)
       {
+         var ancestorBuildingBlock = diffItem.CommonAncestor as IBuildingBlock;
+         if (ancestorBuildingBlock != null)
+            return displayNameFor(ancestorBuildingBlock);
+
          return
             displayIf<SimulationConfiguration>(diffItem, x => ancestorDisplayName(diffItem)) ??
             displayIf<IFormula>(diffItem, x => ancestorDisplayName(diffItem)) ??

--- a/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
+++ b/src/OSPSuite.Presentation/Mappers/DiffItemToDiffItemDTOMapper.cs
@@ -99,8 +99,7 @@ namespace OSPSuite.Presentation.Mappers
 
       private string objectNameFrom(DiffItem diffItem)
       {
-         var ancestorBuildingBlock = diffItem.CommonAncestor as IBuildingBlock;
-         if (ancestorBuildingBlock != null)
+         if (diffItem.CommonAncestor is IBuildingBlock ancestorBuildingBlock)
             return displayNameFor(ancestorBuildingBlock);
 
          return

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DiffItemToDiffItemDTOMapperSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DiffItemToDiffItemDTOMapperSpecs.cs
@@ -383,4 +383,34 @@ namespace OSPSuite.Presentation.Presentation
          _dto.PathElements.ShouldBeEmpty();
       }
    }
+
+   public class When_mapping_a_property_diff_item_with_a_building_block_ancestor_should_use_its_module_qualified_display_name : concern_for_DiffItemToDiffItemDTOMapper
+   {
+      private MoleculeBuildingBlock _bb;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         var module = new Module().WithName("ModA");
+         _bb = new MoleculeBuildingBlock().WithName("BB1");
+         _bb.Module = module;
+
+         _diffItem = new PropertyValueDiffItem
+         {
+            Object1 = new Parameter().WithName("P1"),
+            Object2 = new Parameter().WithName("P1"),
+            FormattedValue1 = "x",
+            FormattedValue2 = "y",
+            CommonAncestor = _bb,
+            PropertyName = "Value"
+         };
+      }
+
+      [Observation]
+      public void should_use_the_ancestor_building_block_display_name_including_module()
+      {
+         _dto.ObjectName.ShouldBeEqualTo("ModA - BB1");
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2745

# Description

When comparing two building blocks with the same name coming from different modules, it is not possible to distinguish the BBs:

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="803" height="343" alt="image" src="https://github.com/user-attachments/assets/285d1f4a-7dfd-4555-aafa-bea72f04ebe1" />


# Questions (if appropriate):