### PR TITLE
Fixes #2754 Parameter Identification: erroneous behavior of "Transfer results to Simulation" in combination with "Use as factor"

### DIFF
--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/IdentificationParameter.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/IdentificationParameter.cs
@@ -44,7 +44,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
             return;
 
          if (Dimension != null && !Equals(parameterSelection.Dimension, Dimension))
-            throw new DimensionMismatchException(new[] {parameterSelection.Dimension, Dimension});
+            throw new DimensionMismatchException(new[] { parameterSelection.Dimension, Dimension });
 
          _allLinkedParameters.Add(parameterSelection);
       }
@@ -122,10 +122,23 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
 
       public double OptimizedParameterValueFor(double optimalValue, ParameterSelection linkedParameter)
       {
-         if (UseAsFactor)
-            return optimalValue * linkedParameter.Parameter.Value;
+         if (!UseAsFactor) 
+            return optimalValue;
+         
+         if (linkedParameter.InitialValue.HasValue)
+            return optimalValue * linkedParameter.InitialValue.Value;
 
-         return optimalValue;
+         // Fall back to the old method if the PI was last run before this feature
+         return optimalValue * linkedParameter.Parameter.Value;
+      }
+
+      public void CaptureLinkedParameterValues()
+      {
+         // the initial value is only needed if the identification parameter is used as a factor
+         if (!UseAsFactor)
+            return;
+
+         _allLinkedParameters.Each(x => x.InitialValue = x.Parameter.Value);
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentification.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentification.cs
@@ -246,5 +246,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
          base.AcceptVisitor(visitor);
          _allIdentificationParameters.ToList().Each(x => x.AcceptVisitor(visitor));
       }
+
+      public void CaptureIdentificationParameterInitialValues() => AllIdentificationParameters.Each(x => x.CaptureLinkedParameterValues());
    }
 }

--- a/src/OSPSuite.Core/Domain/ParameterSelection.cs
+++ b/src/OSPSuite.Core/Domain/ParameterSelection.cs
@@ -18,10 +18,15 @@ namespace OSPSuite.Core.Domain
       }
 
       public virtual IParameter Parameter => Quantity as IParameter;
-      
+
       public new ParameterSelection Clone()
       {
-         return new ParameterSelection(Simulation, QuantitySelection.Clone());
+         return new ParameterSelection(Simulation, QuantitySelection.Clone())
+         {
+            InitialValue = InitialValue
+         };
       }
+
+      public double? InitialValue { get; set; }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationEngine.cs
@@ -46,6 +46,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          _eventPublisher.PublishEvent(new ParameterIdentificationStartedEvent(parameterIdentification));
 
          var results = new ConcurrentBag<ParameterIdentificationRunResult>();
+         _parameterIdentification.CaptureIdentificationParameterInitialValues();
          try
          {
             _parameterIdentificationRuns.AddRange(await createParameterIdentificationRuns(token));

--- a/src/OSPSuite.Core/Serialization/Xml/SimulationQuantitySelectionXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/SimulationQuantitySelectionXmlSerializer.cs
@@ -18,6 +18,10 @@ namespace OSPSuite.Core.Serialization.Xml
 
    public class ParameterSelectionXmlSerializer : SimulationQuantitySelectionXmlSerializer<ParameterSelection>
    {
-      
+      public override void PerformMapping()
+      {
+         base.PerformMapping();
+         Map(x => x.InitialValue);
+      }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/IdentificationParameterSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/IdentificationParameterSpecs.cs
@@ -407,10 +407,13 @@ namespace OSPSuite.Core.Domain
       }
 
       [Observation]
-      public void should_return_the_optimized_parameter_value_multiply_by_the_parameter_value_otherwise()
+      public void should_return_the_optimized_parameter_value_multiplied_by_the_captured_parameter_value()
       {
          sut.UseAsFactor = true;
          _parameterSelection.Parameter.Value = 50;
+         sut.AddLinkedParameter(_parameterSelection);
+         sut.CaptureLinkedParameterValues();
+         _parameterSelection.Parameter.Value = 0;
          sut.OptimizedParameterValueFor(new OptimizedParameterValue("P" ,10, 120, 10, 200, Scalings.Linear), _parameterSelection)
             .ShouldBeEqualTo(500);
       }

--- a/tests/OSPSuite.Core.Tests/Domain/TransferOptimizedParametersToSimulationsTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/TransferOptimizedParametersToSimulationsTaskSpecs.cs
@@ -84,6 +84,8 @@ namespace OSPSuite.Core.Domain
             _allValueOriginCommands.Add(command);
             return command;
          });
+
+         _parameterIdentification.CaptureIdentificationParameterInitialValues();
       }
    }
 


### PR DESCRIPTION
Fixes #2754

# Description
When using use-as-factor we are going to capture the value of linked parameters when the PI is started and then use the captured value and factor rather than continuing to apply the factor to the current parameter value.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):