### PR TITLE
Fixes #2739 PI options not visible on small screens

### DIFF
--- a/src/OSPSuite.UI/Controls/UxPivotGrid.cs
+++ b/src/OSPSuite.UI/Controls/UxPivotGrid.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Data;
 using System.Windows.Forms;
-using OSPSuite.Utility.Extensions;
 using DevExpress.Data.PivotGrid;
 using DevExpress.Utils;
 using DevExpress.Utils.Menu;
@@ -9,6 +8,7 @@ using DevExpress.XtraPivotGrid;
 using OSPSuite.Assets;
 using OSPSuite.UI.Mappers;
 using OSPSuite.UI.Services;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.UI.Controls
 {
@@ -35,7 +35,7 @@ namespace OSPSuite.UI.Controls
 
       public PivotGridField CreateDataAreaNamed(string name)
       {
-         return new PivotGridField(name, PivotArea.DataArea) {SummaryType = PivotSummaryType.Max};
+         return new PivotGridField(name, PivotArea.DataArea) { SummaryType = PivotSummaryType.Max };
       }
 
       public PivotGridField CreateRowAreaNamed(string name)
@@ -105,8 +105,8 @@ namespace OSPSuite.UI.Controls
          if (e.MenuType != PivotGridMenuType.HeaderArea)
             return;
 
-         var copySelectionMenu = new DXMenuItem(Captions.CopySelection, clickCopySelectionMenuItem) {Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection};
-         var copyAllMenu = new DXMenuItem(Captions.CopyTable, clickCopyTableMenuItem) {Shortcut = Shortcut.CtrlShiftC, SvgImage = ApplicationIcons.Copy };
+         var copySelectionMenu = new DXMenuItem(Captions.CopySelection, clickCopySelectionMenuItem) { Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection };
+         var copyAllMenu = new DXMenuItem(Captions.CopyTable, clickCopyTableMenuItem) { Shortcut = Shortcut.CtrlShiftC, SvgImage = ApplicationIcons.Copy };
 
          e.Menu.Items.Clear();
          e.Menu.Items.Insert(0, copySelectionMenu);
@@ -155,6 +155,22 @@ namespace OSPSuite.UI.Controls
       public void SetParameterDisplay(Func<string, string> parameterDisplayFunc)
       {
          _parameterDisplayFunc = parameterDisplayFunc;
+      }
+
+      public int OptimalHeight
+      {
+         get
+         {
+            EnsureViewInfoIsCalculated();
+            var viewInfo = Data.ViewInfo;
+
+            var height = viewInfo.RowAreaFields.Bounds.Height + viewInfo.FilterHeaders.Bounds.Height + viewInfo.RowHeaders.Bounds.Height +
+                         viewInfo.DataHeaders.Bounds.Height;
+
+            if (viewInfo.IsHScrollBarVisible)
+               height += viewInfo.ScrollBarSize.Height;
+            return height;
+         }
       }
    }
 }

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/CategorialParameterIdentificationRunModeView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/CategorialParameterIdentificationRunModeView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.Utility.Collections;
@@ -106,6 +107,8 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          pivotGridControl.DataSource = categorialRunModeDTO.CalculationMethodSelectionTable;
          displayCalculationMethodConfiguration(categorialRunModeDTO.ShouldShowSelection);
          _categorialRunModeScreenBinder.BindToSource(categorialRunModeDTO);
+         if(layoutItemPivotGrid.Visibility != LayoutVisibility.Never)
+            pivotGridControl.MinimumSize = new Size(pivotGridControl.MinimumSize.Width, pivotGridControl.OptimalHeight);
       }
 
       public void UpdateParameterIdentificationCount(int parameterIdentificationCount)

--- a/src/OSPSuite.UI/Views/ParameterIdentifications/CategorialParameterIdentificationRunModeView.cs
+++ b/src/OSPSuite.UI/Views/ParameterIdentifications/CategorialParameterIdentificationRunModeView.cs
@@ -107,7 +107,7 @@ namespace OSPSuite.UI.Views.ParameterIdentifications
          pivotGridControl.DataSource = categorialRunModeDTO.CalculationMethodSelectionTable;
          displayCalculationMethodConfiguration(categorialRunModeDTO.ShouldShowSelection);
          _categorialRunModeScreenBinder.BindToSource(categorialRunModeDTO);
-         if(layoutItemPivotGrid.Visibility != LayoutVisibility.Never)
+         if (layoutItemPivotGrid.Visibility != LayoutVisibility.Never)
             pivotGridControl.MinimumSize = new Size(pivotGridControl.MinimumSize.Width, pivotGridControl.OptimalHeight);
       }
 


### PR DESCRIPTION
Fixes #2739 PI options not visible on small screens

# Description
Calculate and apply a min height for the control. The scrollbar would not be displayed until this was done

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

<img width="758" height="632" alt="image" src="https://github.com/user-attachments/assets/2db692a8-a787-4da8-a666-253e567de229" />


# Questions (if appropriate):