### PR TITLE
Fixes #2752 Closing and opening a simulation causes curves to change color

### DIFF
--- a/src/OSPSuite.Presentation/Extensions/CurveChartExtensions.cs
+++ b/src/OSPSuite.Presentation/Extensions/CurveChartExtensions.cs
@@ -29,19 +29,9 @@ namespace OSPSuite.Presentation.Extensions
          return colors[newIndex];
       }
 
-      public static void UpdateCurveColorAndStyle(this CurveChart chart, Curve curve, DataColumn dataColumn, IReadOnlyCollection<DataColumn> dataColumns, bool isLinkedDataToSimulation = false)
+      public static void UpdateCurveColorAndStyle(this CurveChart chart, Curve curve, DataColumn dataColumn, IReadOnlyCollection<DataColumn> dataColumns)
       {
-         // Finds color from a related column
-         if (isLinkedDataToSimulation)
-         {
-            var matchedColor = tryGetMatchingCurveColor(chart, curve);
-            if (matchedColor.HasValue)
-            {
-               curve.Color = matchedColor.Value;
-            }
-         }
-
-         else if (dataColumnContainsRelatedColumns(dataColumn))
+         if (dataColumnContainsRelatedColumns(dataColumn))
             curve.Color = getColorFromRelatedColumn(chart, dataColumn);
 
          // Finds color from a column which dataColumn is related
@@ -55,18 +45,7 @@ namespace OSPSuite.Presentation.Extensions
          curve.UpdateStyleForObservedData();
       }
 
-      private static Color? tryGetMatchingCurveColor(CurveChart chart, Curve newCurve)
-      {
-         var compartment = newCurve.yData.BottomCompartment;
 
-         if (string.IsNullOrEmpty(compartment))
-            return null;
-
-         var match = chart.Curves
-            .FirstOrDefault(c => c.yData.BottomCompartment?.Equals(compartment, StringComparison.CurrentCultureIgnoreCase) == true);
-
-         return match?.Color;
-      }
 
       private static bool otherColumnsContainColumnAsRelated(IReadOnlyCollection<DataColumn> dataColumns)
       {

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -718,7 +718,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
             return null;
 
          var match = chart.Curves.Where(c => c.yData.IsCalculation())
-            .FirstOrDefault(c => c.yData.BottomCompartment?.Equals(compartment, StringComparison.CurrentCultureIgnoreCase) == true);
+            .FirstOrDefault(c => c.yData.BottomCompartment?.Equals(compartment, StringComparison.OrdinalIgnoreCase) == true);
 
          return match?.Color;
       }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
@@ -523,12 +523,48 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
-   public class When_the_chart_editor_presenter_is_notified_that_the_data_is_linked_to_simulation : concern_for_ChartEditorPresenter
+   public class When_the_chart_editor_presenter_is_updating_curves_that_are_linked_to_simulation : concern_for_ChartEditorPresenter
    {
       protected override void Context()
       {
          base.Context();
-         sut.AddCurveForColumn(_standardColumn, isLinkedDataToSimulation: false);
+         var calculationColumn = new DataColumn("Standard", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            BottomCompartment = _bottomCompartment
+         };
+
+         sut.AddCurveForColumn(calculationColumn, isLinkedDataToSimulation: false);
+         sut.AddCurveForColumn(_standardColumn2, isLinkedDataToSimulation: false);
+      }
+
+      protected override void Because()
+      {
+         sut.AddCurveForColumn(_standardColumn2, isLinkedDataToSimulation: true);
+      }
+
+      [Observation]
+      public void should_update_the_curve_with_same_color()
+      {
+         sut.Chart.Curves.Count.ShouldBeEqualTo(2);
+         sut.Chart.Curves.All(x => x.Color == sut.Chart.Curves.First().Color).ShouldBeTrue();
+      }
+   }
+
+   public class When_adding_curves_that_are_linked_to_simulation_curves : concern_for_ChartEditorPresenter
+   {
+      private DataColumn _calculationColumn;
+
+      protected override void Context()
+      {
+         base.Context();
+         _calculationColumn = new DataColumn("Standard", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            BottomCompartment = _bottomCompartment
+         };
+
+         sut.AddCurveForColumn(_calculationColumn, isLinkedDataToSimulation: false);
       }
 
       protected override void Because()
@@ -539,8 +575,8 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_add_curve_with_same_color()
       {
-         sut.Chart.Curves.Count().ShouldBeEqualTo(2);
-         sut.Chart.Curves.First().Color.ShouldBeEqualTo(sut.Chart.Curves.ToList()[1].Color);
+         sut.Chart.Curves.Count.ShouldBeEqualTo(2);
+         sut.Chart.Curves.All(x => x.Color == sut.Chart.Curves.First().Color).ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
Fixes #2752 Closing and opening a simulation causes curves to change color

# Description
We have to apply linked-data color changes separately from other types of curve updates because an existing curve may still need a color change to link with simulation data, but nothing else on the curve should change.

And other types of curve updates should not be applied to existing curves.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved curve color synchronization for curves linked to simulation data. Curves now consistently inherit colors based on their linked simulation relationships, ensuring better visual coherence on charts.

* **Improvements**
  * Simplified curve color selection logic to provide a more predictable color assignment hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->