### PR TITLE
Fixes #2767 Make preview option sticky in projects

### DIFF
--- a/src/OSPSuite.Core/Chart/Mappers/CurveChartToCurveChartTemplateMapper.cs
+++ b/src/OSPSuite.Core/Chart/Mappers/CurveChartToCurveChartTemplateMapper.cs
@@ -25,6 +25,7 @@ namespace OSPSuite.Core.Chart.Mappers
             return template;
 
          template.IncludeOriginData = curveChart.IncludeOriginData;
+         template.PreviewSettings = curveChart.PreviewSettings;
          template.ChartSettings.UpdatePropertiesFrom(curveChart.ChartSettings, _cloneManager);
          template.FontAndSize.UpdatePropertiesFrom(curveChart.FontAndSize, _cloneManager);
          curveChart.Curves.Each(curve => template.Curves.Add(curveFrom(curve)));

--- a/src/OSPSuite.Core/Serialization/Chart/CurveChartTemplateXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Chart/CurveChartTemplateXmlSerializer.cs
@@ -11,6 +11,7 @@ namespace OSPSuite.Core.Serialization.Chart
          Map(x => x.IncludeOriginData);
          Map(x => x.FontAndSize);
          Map(x => x.Name);
+         Map(x => x.PreviewSettings);
          MapEnumerable(x => x.Axes, x => x.AddAxis);
          MapEnumerable(x => x.Curves, x => x.Curves.Add);
          Map(x => x.IsDefault);

--- a/src/OSPSuite.Core/Serialization/Chart/CurveChartXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Chart/CurveChartXmlSerializer.cs
@@ -17,6 +17,7 @@ namespace OSPSuite.Core.Serialization.Chart
          Map(x => x.Name);
          Map(x => x.Title);
          Map(x => x.Description);
+         Map(x => x.PreviewSettings);
          MapEnumerable(x => x.Axes, x => x.AddAxis);
          MapEnumerable(x => x.Curves, x => x.AddCurveIfConsistent);
       }

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
@@ -191,6 +191,11 @@ namespace OSPSuite.Presentation.Presenters.Charts
       void AddDeviationLines();
 
       Func<IEnumerable<DataColumn>, IEnumerable<DataColumn>> PreExportHook { get; set; }
+
+      /// <summary>
+      /// Applies the watermark to the chart if the chart is in preview mode and auto update is enabled, otherwise does nothing
+      /// </summary>
+      void UpdateWatermark();
    }
 
    public class ChartDisplayPresenter : AbstractPresenter<IChartDisplayView, IChartDisplayPresenter>, IChartDisplayPresenter
@@ -221,6 +226,12 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       //by default, don't modify anything
       public Func<IEnumerable<DataColumn>, IEnumerable<DataColumn>> PreExportHook { get; set; } = x => x;
+
+      public void UpdateWatermark()
+      {
+         if (Chart.AutoUpdateEnabled)
+            _view.ShowWatermark(normalWatermark);
+      }
 
       public ChartDisplayPresenter(IChartDisplayView chartDisplayView,
          ICurveBinderFactory curveBinderFactory,
@@ -394,7 +405,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       {
          // Make sure binders for curves that were removed are pruned so that their axes are not considered when calculating diagram size
          pruneCurves();
-         
+
          var diagramSize = View.GetDiagramSize();
          using (new BatchUpdate(View))
          {

--- a/src/OSPSuite.Presentation/Services/ChartFromTemplateService.cs
+++ b/src/OSPSuite.Presentation/Services/ChartFromTemplateService.cs
@@ -77,6 +77,7 @@ namespace OSPSuite.Presentation.Services
             chart.FontAndSize.UpdatePropertiesFrom(template.FontAndSize, _cloneManager);
             template.Axes.Each(axis => chart.AddAxis(axis.Clone()));
             bestTemplateForCurves.KeyValues.Each(kv => addCurvesToChart(kv.Key, kv.Value, chart));
+            chart.PreviewSettings = template.PreviewSettings;
          }
       }
 

--- a/src/OSPSuite.UI/Views/Charts/ChartDisplayView.cs
+++ b/src/OSPSuite.UI/Views/Charts/ChartDisplayView.cs
@@ -191,6 +191,8 @@ namespace OSPSuite.UI.Views.Charts
       private void onSizeChanged()
       {
          _presenter?.RefreshAxisBinders();
+         if (_presenter?.Chart != null)
+            _presenter?.UpdateWatermark();
       }
 
       private void chartDoubleClick(MouseEventArgs mouseEventArgs)
@@ -568,7 +570,7 @@ namespace OSPSuite.UI.Views.Charts
                : null, editable: _curveEditEnabled, description: curveDescription);
       }
 
-      private SeriesPoint findPointInSeries(ChartHitInfo hitInfo, Series series) => 
+      private SeriesPoint findPointInSeries(ChartHitInfo hitInfo, Series series) =>
          hitInfo.SeriesPoint ?? findNextClosestSeriesPoint(hitInfo, series);
 
       private SeriesPoint findNextClosestSeriesPoint(ChartHitInfo hitInfo, Series series)
@@ -586,10 +588,10 @@ namespace OSPSuite.UI.Views.Charts
          return nextPoint;
       }
 
-      private void onObjectSelected(HotTrackEventArgs e) => 
+      private void onObjectSelected(HotTrackEventArgs e) =>
          e.Cancel = true;
 
-      public void SetFontAndSizeSettings(ChartFontAndSizeSettings fontAndSizeSettings) => 
+      public void SetFontAndSizeSettings(ChartFontAndSizeSettings fontAndSizeSettings) =>
          _chartControl.SetFontAndSizeSettings(fontAndSizeSettings, _chartControl.Size);
 
       public void CopyToClipboard(string watermark) => _chartControl.CopyToClipboard(_presenter.Chart, watermark);

--- a/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
@@ -45,6 +45,7 @@ namespace OSPSuite.Core.Mappers
          _curveChart.AddAxis(new Axis(AxisTypes.X));
          _curveChart.AddAxis(new Axis(AxisTypes.Y));
          _curveChart.AddAxis(new Axis(AxisTypes.Y2));
+         _curveChart.PreviewSettings = true;
          var curve = new Curve();
          curve.SetxData(_xData, _dimensionFactory);
          curve.SetyData(_yData, _dimensionFactory);
@@ -82,6 +83,12 @@ namespace OSPSuite.Core.Mappers
       public void should_have_updated_the_font_and_size()
       {
          _curveChartTemplate.FontAndSize.ChartHeight.ShouldBeEqualTo(500);
+      }
+
+      [Observation]
+      public void should_have_the_preview_settings_set()
+      {
+         _curveChart.PreviewSettings.ShouldBeEqualTo(_curveChart.PreviewSettings);
       }
    }
 

--- a/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
@@ -88,7 +88,7 @@ namespace OSPSuite.Core.Mappers
       [Observation]
       public void should_have_the_preview_settings_set()
       {
-         _curveChart.PreviewSettings.ShouldBeEqualTo(_curveChart.PreviewSettings);
+         _curveChart.PreviewSettings.ShouldBeEqualTo(_curveChartTemplate.PreviewSettings);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartFromTemplateServiceSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartFromTemplateServiceSpecs.cs
@@ -103,6 +103,9 @@ namespace OSPSuite.Presentation.Presentation
             xData = {QuantityType = QuantityType.BaseGrid},
             yData = {QuantityType = _drugColumn.QuantityInfo.Type, Path = _drugTemplatePathArray.ToPathString()}
          });
+
+         _template.PreviewSettings = true;
+
          _propagateChartChangedEvent = false;
       }
 
@@ -111,6 +114,11 @@ namespace OSPSuite.Presentation.Presentation
          sut.InitializeChartFromTemplate(_chart, _dataColumns, _template, propogateChartChangeEvent:_propagateChartChangedEvent);
       }
 
+      [Observation]
+      public void should_update_the_export_preview_settings_from_the_template()
+      {
+         _chart.PreviewSettings.ShouldBeEqualTo(_template.PreviewSettings);
+      }
 
       [Observation]
       public void should_return_a_chart_with_the_curves_for_the_exact_data()


### PR DESCRIPTION
Fixes #2767 Make preview option sticky in projects

# Description
Allows the export preview option to be retained by project save, and also added to templates, and used from templates.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watermark refresh now updates dynamically when chart size changes and can be triggered externally.
  * Chart preview settings are preserved, serialized, and propagated when creating or applying templates.

* **Tests**
  * Added tests to verify preview settings transfer and watermark refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->