### PR TITLE
#1717 autoreducetolerance

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ISimModelBatch.cs
+++ b/src/OSPSuite.Core/Domain/Services/ISimModelBatch.cs
@@ -55,5 +55,7 @@ namespace OSPSuite.Core.Domain.Services
       bool KeepXMLNodeInSimModelSimulation { get; set; }
 
       bool CheckForNegativeValues { get; set; }
+
+      bool AutoReduceTolerances { get; set; }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/SimModelBatch.cs
+++ b/src/OSPSuite.Core/Domain/Services/SimModelBatch.cs
@@ -30,6 +30,8 @@ namespace OSPSuite.Core.Domain.Services
 
       public bool CheckForNegativeValues { get; set; }
 
+      public bool AutoReduceTolerances { get; set; }
+
       public bool TreatConstantMoleculesAsParameters { get; set; } = true;
 
       public SimModelBatch(ISimModelExporter simModelExporter, ISimModelSimulationFactory simModelSimulationFactory, IDataFactory dataFactory) : base(
@@ -64,6 +66,7 @@ namespace OSPSuite.Core.Domain.Services
          var simulation = CreateSimulation(simulationExport, x =>
          {
             x.CheckForNegativeValues = CheckForNegativeValues;
+            x.AutoReduceTolerances = AutoReduceTolerances;
             x.KeepXMLNodeAsString = KeepXMLNodeInSimModelSimulation;
          });
          setVariableParameters(simulation, variableParameterPaths);

--- a/src/OSPSuite.Core/Domain/Services/SimModelManager.cs
+++ b/src/OSPSuite.Core/Domain/Services/SimModelManager.cs
@@ -96,6 +96,7 @@ namespace OSPSuite.Core.Domain.Services
          options.ShowProgress = true;
          options.ExecutionTimeLimit = _executionTimeLimit;
          options.CheckForNegativeValues = _simulationRunOptions.CheckForNegativeValues;
+         options.AutoReduceTolerances = _simulationRunOptions.AutoReduceTolerances;
 
          try
          {

--- a/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
@@ -17,6 +17,11 @@ namespace OSPSuite.Core.Domain
       /// </summary>
       public bool CheckForNegativeValues { get; set; }
 
+      /// <summary>
+      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>false</c>
+      /// </summary>
+      public bool AutoReduceTolerances { get; set; }
+
       public SimulationRunOptions()
       {
          SimModelExportMode = SimModelExportMode.Full;

--- a/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
@@ -26,6 +26,7 @@ namespace OSPSuite.Core.Domain
       {
          SimModelExportMode = SimModelExportMode.Full;
          CheckForNegativeValues = true;
+         AutoReduceTolerances = true;
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.Core/Domain/SimulationRunOptions.cs
@@ -18,7 +18,7 @@ namespace OSPSuite.Core.Domain
       public bool CheckForNegativeValues { get; set; }
 
       /// <summary>
-      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>false</c>
+      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>true</c>
       /// </summary>
       public bool AutoReduceTolerances { get; set; }
 

--- a/src/OSPSuite.R/Domain/SimulationBatch.cs
+++ b/src/OSPSuite.R/Domain/SimulationBatch.cs
@@ -80,7 +80,7 @@ namespace OSPSuite.R.Domain
       public void Initialize(IModelCoreSimulation simulation, SimulationBatchOptions simulationBatchOptions, SimulationRunOptions simulationRunOptions)
       {
          _simModelBatch.CheckForNegativeValues = simulationRunOptions?.CheckForNegativeValues ?? true;
-         _simModelBatch.AutoReduceTolerances = simulationRunOptions?.AutoReduceTolerances ?? false;
+         _simModelBatch.AutoReduceTolerances = simulationRunOptions?.AutoReduceTolerances ?? true;
 
          //SimModel optionally caches XML used for loading a simulation as string.
          //This XML string was used e.g. by the old Matlab-/R-Toolbox when saving a simulation to XML.

--- a/src/OSPSuite.R/Domain/SimulationBatch.cs
+++ b/src/OSPSuite.R/Domain/SimulationBatch.cs
@@ -80,6 +80,7 @@ namespace OSPSuite.R.Domain
       public void Initialize(IModelCoreSimulation simulation, SimulationBatchOptions simulationBatchOptions, SimulationRunOptions simulationRunOptions)
       {
          _simModelBatch.CheckForNegativeValues = simulationRunOptions?.CheckForNegativeValues ?? true;
+         _simModelBatch.AutoReduceTolerances = simulationRunOptions?.AutoReduceTolerances ?? false;
 
          //SimModel optionally caches XML used for loading a simulation as string.
          //This XML string was used e.g. by the old Matlab-/R-Toolbox when saving a simulation to XML.

--- a/src/OSPSuite.R/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.R/Domain/SimulationRunOptions.cs
@@ -10,6 +10,11 @@ namespace OSPSuite.R.Domain
       public bool CheckForNegativeValues { get; set; } = true;
 
       /// <summary>
+      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>false</c>
+      /// </summary>
+      public bool AutoReduceTolerances { get; set; } = false;
+
+      /// <summary>
       ///    Specifies whether progress bar should be shown during simulation run. Default is <c>true</c>
       /// </summary>
       public bool ShowProgress { get; set; } = true;

--- a/src/OSPSuite.R/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.R/Domain/SimulationRunOptions.cs
@@ -12,7 +12,7 @@ namespace OSPSuite.R.Domain
       /// <summary>
       ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>false</c>
       /// </summary>
-      public bool AutoReduceTolerances { get; set; } = false;
+      public bool AutoReduceTolerances { get; set; } = true;
 
       /// <summary>
       ///    Specifies whether progress bar should be shown during simulation run. Default is <c>true</c>

--- a/src/OSPSuite.R/Domain/SimulationRunOptions.cs
+++ b/src/OSPSuite.R/Domain/SimulationRunOptions.cs
@@ -10,7 +10,7 @@ namespace OSPSuite.R.Domain
       public bool CheckForNegativeValues { get; set; } = true;
 
       /// <summary>
-      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>false</c>
+      ///    Specifies whether the solver should automatically reduce tolerances when a simulation run fails. Default is <c>true</c>
       /// </summary>
       public bool AutoReduceTolerances { get; set; } = true;
 

--- a/src/OSPSuite.R/Services/SimulationRunner.cs
+++ b/src/OSPSuite.R/Services/SimulationRunner.cs
@@ -127,6 +127,7 @@ namespace OSPSuite.R.Services
          return new Core.Domain.SimulationRunOptions
          {
             CheckForNegativeValues = options.CheckForNegativeValues,
+            AutoReduceTolerances = options.AutoReduceTolerances,
             SimModelExportMode = SimModelExportMode.Optimized
          };
       }

--- a/tests/OSPSuite.Core.IntegrationTests/SimModelBatchSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/SimModelBatchSpecs.cs
@@ -125,6 +125,36 @@ namespace OSPSuite.Core
       }
    }
 
+   public class When_initializing_the_sim_model_batch_with_auto_reduce_tolerances_enabled : concern_for_SimModelBatch
+   {
+      protected override void Because()
+      {
+         sut.AutoReduceTolerances = true;
+         sut.InitializeWith(_modelCoreSimulation, _variableParameterPaths, _variableSpeciesPath);
+      }
+
+      [Observation]
+      public void should_configure_the_simulation_with_auto_reduce_tolerances_enabled()
+      {
+         _simModelSimulation.Options.AutoReduceTolerances.ShouldBeTrue();
+      }
+   }
+
+   public class When_initializing_the_sim_model_batch_with_auto_reduce_tolerances_disabled : concern_for_SimModelBatch
+   {
+      protected override void Because()
+      {
+         sut.AutoReduceTolerances = false;
+         sut.InitializeWith(_modelCoreSimulation, _variableParameterPaths, _variableSpeciesPath);
+      }
+
+      [Observation]
+      public void should_configure_the_simulation_with_auto_reduce_tolerances_disabled()
+      {
+         _simModelSimulation.Options.AutoReduceTolerances.ShouldBeFalse();
+      }
+   }
+
    public class When_exporting_the_sim_model_simulation_to_c_plusplus_code : concern_for_SimModelBatch
    {
       private string _exportFolder;

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationRunOptionsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationRunOptionsSpecs.cs
@@ -21,9 +21,9 @@ namespace OSPSuite.Core.Tests.Domain
       }
 
       [Observation]
-      public void should_disable_auto_reduce_tolerances_by_default()
+      public void should_enable_auto_reduce_tolerances_by_default()
       {
-         sut.AutoReduceTolerances.ShouldBeFalse();
+         sut.AutoReduceTolerances.ShouldBeTrue();
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationRunOptionsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationRunOptionsSpecs.cs
@@ -1,0 +1,29 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Tests.Domain
+{
+   public abstract class concern_for_SimulationRunOptions : ContextSpecification<SimulationRunOptions>
+   {
+      protected override void Context()
+      {
+         sut = new SimulationRunOptions();
+      }
+   }
+
+   public class When_creating_simulation_run_options_with_default_values : concern_for_SimulationRunOptions
+   {
+      [Observation]
+      public void should_enable_check_for_negative_values_by_default()
+      {
+         sut.CheckForNegativeValues.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_disable_auto_reduce_tolerances_by_default()
+      {
+         sut.AutoReduceTolerances.ShouldBeFalse();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1717

# Description

Allow auto reduce tolerance

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic tolerance reduction for failed simulations: a new run option enables the solver to automatically relax tolerances when a simulation fails (enabled by default), improving robustness and success rates.

* **Tests**
  * Added tests ensuring the automatic tolerance reduction option is present by default and correctly propagates through simulation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->