### PR TITLE
Fixes #2787 Add OutputPath meta data to observed data imports

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -237,6 +237,7 @@ namespace OSPSuite.Assets
       public static readonly string AutoUpdateChart = "Auto-update chart";
       public static readonly string Undefined = "Undefined";
       public static readonly string ExportHistory = "Export History";
+      public static readonly string AddOutputPath = "Add Output Path";
 
       public static string EditTableParameter(string parameter, bool editable) => $"{(editable ? "Edit" : "Show")} table parameter '{parameter}'";
 

--- a/src/OSPSuite.Core/Domain/Constants.cs
+++ b/src/OSPSuite.Core/Domain/Constants.cs
@@ -109,6 +109,7 @@ namespace OSPSuite.Core.Domain
       public const string AUXILIARY_TYPE = "AuxiliaryType";
       public const string FILE = "Source";
       public const string SHEET = "Sheet";
+      public const string OUTPUT_PATH = "OutputPath";
       public const string DEFAULT_WATERMARK_TEXT = "DRAFT";
 
       public const int MB_TO_BYTES = 1024 * 1024; //1 MB = 1024 * 1024 bytes

--- a/src/OSPSuite.Core/Services/OutputMappingMatchingTask.cs
+++ b/src/OSPSuite.Core/Services/OutputMappingMatchingTask.cs
@@ -48,6 +48,7 @@ namespace OSPSuite.Core.Services
          simulation.OutputMappings.Add(newOutputMapping);
          _eventPublisher.PublishEvent(new SimulationOutputMappingsChangedEvent(simulation));
       }
+
       private OutputMapping mapMatchingOutput(DataRepository observedData, ISimulation simulation)
       {
          var newOutputMapping = new OutputMapping();
@@ -73,6 +74,9 @@ namespace OSPSuite.Core.Services
 
       public bool ObservedDataMatchesOutput(DataRepository observedData, string outputPath)
       {
+         if (string.Equals(outputPath, observedData.ExtendedPropertyValueFor(Constants.OUTPUT_PATH)))
+            return true;
+
          var organ = observedData.ExtendedPropertyValueFor(Constants.ObservedData.ORGAN);
          var compartment = observedData.ExtendedPropertyValueFor(Constants.ObservedData.COMPARTMENT);
          var molecule = observedData.ExtendedPropertyValueFor(Constants.ObservedData.MOLECULE);

--- a/src/OSPSuite.Core/Services/OutputMappingMatchingTask.cs
+++ b/src/OSPSuite.Core/Services/OutputMappingMatchingTask.cs
@@ -32,7 +32,7 @@ namespace OSPSuite.Core.Services
       private readonly IEntitiesInSimulationRetriever _entitiesInSimulationRetriever;
       private readonly IEventPublisher _eventPublisher;
 
-      public OutputMappingMatchingTask (IEntitiesInSimulationRetriever entitiesInSimulationRetriever, IEventPublisher eventPublisher)
+      public OutputMappingMatchingTask(IEntitiesInSimulationRetriever entitiesInSimulationRetriever, IEventPublisher eventPublisher)
       {
          _eventPublisher = eventPublisher;
          _entitiesInSimulationRetriever = entitiesInSimulationRetriever;
@@ -42,9 +42,9 @@ namespace OSPSuite.Core.Services
       {
          var newOutputMapping = mapMatchingOutput(observedData, simulation);
 
-         if (newOutputMapping.Output == null) 
+         if (newOutputMapping.Output == null)
             return;
-         
+
          simulation.OutputMappings.Add(newOutputMapping);
          _eventPublisher.PublishEvent(new SimulationOutputMappingsChangedEvent(simulation));
       }
@@ -74,8 +74,10 @@ namespace OSPSuite.Core.Services
 
       public bool ObservedDataMatchesOutput(DataRepository observedData, string outputPath)
       {
-         if (string.Equals(outputPath, observedData.ExtendedPropertyValueFor(Constants.OUTPUT_PATH)))
-            return true;
+         var observedOutputPath = observedData.ExtendedPropertyValueFor(Constants.OUTPUT_PATH);
+         // if present, use that as the matching objective rather than the organ/compartment/molecule properties
+         if (!string.IsNullOrWhiteSpace(observedOutputPath))
+            return string.Equals(outputPath, observedOutputPath, System.StringComparison.Ordinal);
 
          var organ = observedData.ExtendedPropertyValueFor(Constants.ObservedData.ORGAN);
          var compartment = observedData.ExtendedPropertyValueFor(Constants.ObservedData.COMPARTMENT);

--- a/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
@@ -188,8 +188,15 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
       public Unit GetDefaultMolWeightUnit() => 
          _dimensionFactory.TryGetDimension(Constants.Dimension.MOLECULAR_WEIGHT, out var dimension) ? dimension.DefaultUnit : null;
 
-      public void AddOutputPathMetadata() => 
+      public void AddOutputPathMetadata()
+      {
+         if (hasOutputPath())
+            return;
+
          _metaDataDTOList.Add(createDTO(name: Constants.OUTPUT_PATH, value: string.Empty, nameEditable: false));
+      }
+
+      private bool hasOutputPath() => _metaDataDTOList.Any(x => string.Equals(x.Name, Constants.OUTPUT_PATH));
 
       private double molWeightValueInCoreUnit(double valueInDisplayUnit)
       {
@@ -234,7 +241,7 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
          _metaDataDTOList = new NotifyList<MetaDataDTO>();
          _allDataRepositories.ToList().IntersectingMetaData().Each(x => _metaDataDTOList.Add(createDTO(x)));
          _view.BindToMetaData(_metaDataDTOList);
-         _view.AddOutputPathEnabled = !_metaDataDTOList.Any(x => string.Equals(x.Name, Constants.OUTPUT_PATH));
+         _view.AddOutputPathEnabled = !hasOutputPath();
 
          _view.MolWeightEditable = _observedDataConfiguration.MolWeightAlwaysEditable || !_allDataRepositories.Any(x => x.ExtendedProperties.Contains(Captions.Molecule));
 

--- a/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
@@ -2,11 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Assets;
-using OSPSuite.Utility;
-using OSPSuite.Utility.Collections;
-using OSPSuite.Utility.Events;
-using OSPSuite.Utility.Extensions;
-using OSPSuite.Utility.Validation;
 using OSPSuite.Core.Commands;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
@@ -16,6 +11,11 @@ using OSPSuite.Core.Events;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Views.ObservedData;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Events;
+using OSPSuite.Utility.Extensions;
+using OSPSuite.Utility.Validation;
 
 namespace OSPSuite.Presentation.Presenters.ObservedData
 {
@@ -65,6 +65,11 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
       ///    Returns the default molecular weight unit
       /// </summary>
       Unit GetDefaultMolWeightUnit();
+
+      /// <summary>
+      ///    Adds a metadata named "OutputPath". This is a specially named metadata.
+      /// </summary>
+      void AddOutputPathMetadata();
    }
 
    public class DataRepositoryMetaDataPresenter : AbstractSubPresenter<IDataRepositoryMetaDataView, IDataRepositoryMetaDataPresenter>,
@@ -95,15 +100,11 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
       ///    Binds the <paramref name="observedData" /> with the view
       /// </summary>
       /// <param name="observedData">The dataSheet repository that will be edited</param>
-      public void EditObservedData(DataRepository observedData)
-      {
-         editObservedData(new List<DataRepository> {observedData}, MetaDataDTO.MetaDataDTORules.All());
-      }
+      public void EditObservedData(DataRepository observedData) => 
+         editObservedData(new List<DataRepository> { observedData }, MetaDataDTO.MetaDataDTORules.All());
 
-      public void EditObservedDataMetaData(IEnumerable<DataRepository> observedData)
-      {
+      public void EditObservedDataMetaData(IEnumerable<DataRepository> observedData) => 
          editObservedData(observedData, MetaDataDTO.MetaDataDTORules.AllForMultipleEdits());
-      }
 
       private void editObservedData(IEnumerable<DataRepository> observedData, IEnumerable<IBusinessRule> rules)
       {
@@ -132,35 +133,23 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
          };
       }
 
-      public void NewMetaDataAdded()
-      {
+      public void NewMetaDataAdded() => 
          _metaDataDTOList.Add(createDTO(name: string.Empty, value: string.Empty));
-      }
 
-      public void MetaDataNameChanged(MetaDataDTO metaDataDTO, string oldName)
-      {
+      public void MetaDataNameChanged(MetaDataDTO metaDataDTO, string oldName) => 
          handleThisChange(metaDataNameChanged, metaDataDTO, oldName, oldName);
-      }
 
-      public void RemoveMetaData(MetaDataDTO metaDataDTO)
-      {
+      public void RemoveMetaData(MetaDataDTO metaDataDTO) => 
          AddCommand(_observedDataMetaDataTask.RemoveMetaData(_allDataRepositories, mapFrom(metaDataDTO)));
-      }
 
-      public IEnumerable<string> PredefinedValuesFor(MetaDataDTO metaDataDTO)
-      {
-         return _observedDataConfiguration.PredefinedValuesFor(metaDataDTO.Name);
-      }
+      public IEnumerable<string> PredefinedValuesFor(MetaDataDTO metaDataDTO) => 
+         _observedDataConfiguration.PredefinedValuesFor(metaDataDTO.Name);
 
-      private bool isPredefinedProperty(IExtendedProperty extendedProperty)
-      {
-         return _observedDataConfiguration.DefaultMetaDataCategories.Contains(extendedProperty.Name);
-      }
+      private bool isPredefinedProperty(IExtendedProperty extendedProperty) => 
+         _observedDataConfiguration.DefaultMetaDataCategories.Contains(extendedProperty.Name);
 
-      private MetaDataKeyValue mapFrom(MetaDataDTO dto)
-      {
-         return new MetaDataKeyValue {Key = dto.Name, Value = dto.Value};
-      }
+      private MetaDataKeyValue mapFrom(MetaDataDTO dto) => 
+         new MetaDataKeyValue { Key = dto.Name, Value = dto.Value };
 
       public void MetaDataValueChanged(MetaDataDTO metaDataDTO, string oldValue)
       {
@@ -178,32 +167,29 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
             metaDataAdded(metaDataDTO);
       }
 
-      private void metaDataAdded(MetaDataDTO metaDataDTO)
-      {
+      private void metaDataAdded(MetaDataDTO metaDataDTO) => 
          AddCommand(_observedDataMetaDataTask.AddMetaData(_allDataRepositories, mapFrom(metaDataDTO)));
-      }
 
       private void metaDataValueChanged(MetaDataDTO metaDataDTO, string oldValue)
       {
          AddCommand(_observedDataMetaDataTask.ChangeMetaData(_allDataRepositories,
-            new MetaDataChanged {NewName = metaDataDTO.Name, OldName = metaDataDTO.Name, OldValue = oldValue, NewValue = metaDataDTO.Value}));
+            new MetaDataChanged { NewName = metaDataDTO.Name, OldName = metaDataDTO.Name, OldValue = oldValue, NewValue = metaDataDTO.Value }));
       }
 
       private void metaDataNameChanged(MetaDataDTO metaDataDTO, string oldName)
       {
          AddCommand(_observedDataMetaDataTask.ChangeMetaData(_allDataRepositories,
-            new MetaDataChanged {NewName = metaDataDTO.Name, OldName = oldName, OldValue = metaDataDTO.Value, NewValue = metaDataDTO.Value}));
+            new MetaDataChanged { NewName = metaDataDTO.Name, OldName = oldName, OldValue = metaDataDTO.Value, NewValue = metaDataDTO.Value }));
       }
 
-      public void SetMolWeight(double oldMolWeightValueInDisplayUnit, double molWeightValueInDisplayUnit)
-      {
+      public void SetMolWeight(double oldMolWeightValueInDisplayUnit, double molWeightValueInDisplayUnit) => 
          this.DoWithinLatch(() => { AddCommand(_observedDataMetaDataTask.UpdateMolWeight(_allDataRepositories, molWeightValueInCoreUnit(oldMolWeightValueInDisplayUnit), molWeightValueInCoreUnit(molWeightValueInDisplayUnit))); });
-      }
 
-      public Unit GetDefaultMolWeightUnit()
-      {
-         return _dimensionFactory.TryGetDimension(Constants.Dimension.MOLECULAR_WEIGHT, out var dimension) ? dimension.DefaultUnit : null;
-      }
+      public Unit GetDefaultMolWeightUnit() => 
+         _dimensionFactory.TryGetDimension(Constants.Dimension.MOLECULAR_WEIGHT, out var dimension) ? dimension.DefaultUnit : null;
+
+      public void AddOutputPathMetadata() => 
+         _metaDataDTOList.Add(createDTO(name: Constants.OUTPUT_PATH, value: string.Empty, nameEditable: false));
 
       private double molWeightValueInCoreUnit(double valueInDisplayUnit)
       {
@@ -271,10 +257,8 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
             .DistinctBy(x => x.Value);
       }
 
-      private IParameter createParameterForLLOQ(DataColumn dataColumn)
-      {
-         return _parameterFactory.CreateParameter(Captions.LLOQ, dataColumn.DataInfo.LLOQ, dataColumn.Dimension, displayUnit:dataColumn.DisplayUnit);
-      }
+      private IParameter createParameterForLLOQ(DataColumn dataColumn) => 
+         _parameterFactory.CreateParameter(Captions.LLOQ, dataColumn.DataInfo.LLOQ, dataColumn.Dimension, displayUnit: dataColumn.DisplayUnit);
 
       private IParameter retrieveUniqueMolWeightParameter()
       {
@@ -291,14 +275,10 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
          return _parameterFactory.CreateParameter(Constants.Parameters.MOL_WEIGHT, molWeightValue, _molWeightDimension);
       }
 
-      private bool isReadOnly(IExtendedProperty extendedProperty)
-      {
-         return _observedDataConfiguration.ReadOnlyMetaDataCategories.Contains(extendedProperty.Name);
-      }
+      private bool isReadOnly(IExtendedProperty extendedProperty) => 
+         _observedDataConfiguration.ReadOnlyMetaDataCategories.Contains(extendedProperty.Name);
 
-      private bool canHandle(ObservedDataEvent eventToHandle)
-      {
-         return _allDataRepositories.Contains(eventToHandle.ObservedData);
-      }
+      private bool canHandle(ObservedDataEvent eventToHandle) => 
+         _allDataRepositories.Contains(eventToHandle.ObservedData);
    }
 }

--- a/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ObservedData/DataRepositoryMetaDataPresenter.cs
@@ -234,6 +234,7 @@ namespace OSPSuite.Presentation.Presenters.ObservedData
          _metaDataDTOList = new NotifyList<MetaDataDTO>();
          _allDataRepositories.ToList().IntersectingMetaData().Each(x => _metaDataDTOList.Add(createDTO(x)));
          _view.BindToMetaData(_metaDataDTOList);
+         _view.AddOutputPathEnabled = !_metaDataDTOList.Any(x => string.Equals(x.Name, Constants.OUTPUT_PATH));
 
          _view.MolWeightEditable = _observedDataConfiguration.MolWeightAlwaysEditable || !_allDataRepositories.Any(x => x.ExtendedProperties.Contains(Captions.Molecule));
 

--- a/src/OSPSuite.Presentation/Views/ObservedData/IDataRepositoryMetaDataView.cs
+++ b/src/OSPSuite.Presentation/Views/ObservedData/IDataRepositoryMetaDataView.cs
@@ -11,6 +11,7 @@ namespace OSPSuite.Presentation.Views.ObservedData
       void BindToMolWeight(IParameter molWeightParameter);
       bool MolWeightVisible { get;set; }
       bool MolWeightEditable { get; set; }
+      bool AddOutputPathEnabled { set; }
       void BindToLLOQ(IParameter lowerLimitsOfQuantification);
    }
 }

--- a/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.Designer.cs
+++ b/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.Designer.cs
@@ -32,18 +32,20 @@ namespace OSPSuite.UI.Views.ObservedData
       /// </summary>
       private void InitializeComponent()
       {
-         this.gridControl = new UxGridControl();
-         this.gridView = new UxGridView();
+         this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
+         this.gridView = new OSPSuite.UI.Controls.UxGridView();
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemAddRow = new DevExpress.XtraLayout.LayoutControlItem();
-         this.btnAddRow = new DevExpress.XtraEditors.DropDownButton();
-         this.layoutControl1 = new UxLayoutControl();
+         this.btnAddRow = new DevExpress.XtraEditors.SimpleButton();
+         this.layoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.btnAddOutputPath = new OSPSuite.UI.Controls.UxSimpleButton();
          this.tbLowerLimitOfQuantification = new DevExpress.XtraEditors.TextEdit();
          this.tbMolWeight = new DevExpress.XtraEditors.TextEdit();
          this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
          this.layoutItemMolWeight = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemLowerLimitOfQuantification = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemAddOutputPath = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
@@ -57,14 +59,15 @@ namespace OSPSuite.UI.Views.ObservedData
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemMolWeight)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemLowerLimitOfQuantification)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemAddOutputPath)).BeginInit();
          this.SuspendLayout();
          // 
          // gridControl
          // 
-         this.gridControl.Location = new System.Drawing.Point(2, 76);
+         this.gridControl.Location = new System.Drawing.Point(2, 102);
          this.gridControl.MainView = this.gridView;
          this.gridControl.Name = "gridControl";
-         this.gridControl.Size = new System.Drawing.Size(725, 530);
+         this.gridControl.Size = new System.Drawing.Size(725, 504);
          this.gridControl.TabIndex = 0;
          this.gridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
             this.gridView});
@@ -88,8 +91,8 @@ namespace OSPSuite.UI.Views.ObservedData
             this.layoutItemAddRow,
             this.emptySpaceItem1,
             this.layoutItemMolWeight,
-            this.layoutItemLowerLimitOfQuantification});
-         this.layoutControlGroup1.Location = new System.Drawing.Point(0, 0);
+            this.layoutItemLowerLimitOfQuantification,
+            this.layoutItemAddOutputPath});
          this.layoutControlGroup1.Name = "layoutControlGroup1";
          this.layoutControlGroup1.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
          this.layoutControlGroup1.Size = new System.Drawing.Size(729, 608);
@@ -99,9 +102,9 @@ namespace OSPSuite.UI.Views.ObservedData
          // 
          this.layoutControlItem1.Control = this.gridControl;
          this.layoutControlItem1.CustomizationFormText = "layoutControlItem1";
-         this.layoutControlItem1.Location = new System.Drawing.Point(0, 74);
+         this.layoutControlItem1.Location = new System.Drawing.Point(0, 100);
          this.layoutControlItem1.Name = "layoutControlItem1";
-         this.layoutControlItem1.Size = new System.Drawing.Size(729, 534);
+         this.layoutControlItem1.Size = new System.Drawing.Size(729, 508);
          this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem1.TextVisible = false;
          // 
@@ -109,18 +112,18 @@ namespace OSPSuite.UI.Views.ObservedData
          // 
          this.layoutItemAddRow.Control = this.btnAddRow;
          this.layoutItemAddRow.CustomizationFormText = "layoutControlItem2";
-         this.layoutItemAddRow.Location = new System.Drawing.Point(364, 48);
+         this.layoutItemAddRow.Location = new System.Drawing.Point(401, 48);
          this.layoutItemAddRow.Name = "layoutItemAddRow";
-         this.layoutItemAddRow.Size = new System.Drawing.Size(365, 26);
+         this.layoutItemAddRow.Size = new System.Drawing.Size(328, 26);
          this.layoutItemAddRow.Text = "layoutControlItem2";
          this.layoutItemAddRow.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemAddRow.TextVisible = false;
          // 
          // btnAddRow
          // 
-         this.btnAddRow.Location = new System.Drawing.Point(366, 50);
+         this.btnAddRow.Location = new System.Drawing.Point(403, 50);
          this.btnAddRow.Name = "btnAddRow";
-         this.btnAddRow.Size = new System.Drawing.Size(361, 22);
+         this.btnAddRow.Size = new System.Drawing.Size(324, 22);
          this.btnAddRow.StyleController = this.layoutControl1;
          this.btnAddRow.TabIndex = 4;
          this.btnAddRow.Text = "btnAddRow";
@@ -128,6 +131,7 @@ namespace OSPSuite.UI.Views.ObservedData
          // layoutControl1
          // 
          this.layoutControl1.AllowCustomization = false;
+         this.layoutControl1.Controls.Add(this.btnAddOutputPath);
          this.layoutControl1.Controls.Add(this.tbLowerLimitOfQuantification);
          this.layoutControl1.Controls.Add(this.tbMolWeight);
          this.layoutControl1.Controls.Add(this.btnAddRow);
@@ -141,20 +145,31 @@ namespace OSPSuite.UI.Views.ObservedData
          this.layoutControl1.TabIndex = 1;
          this.layoutControl1.Text = "layoutControl1";
          // 
+         // btnAddOutputPath
+         // 
+         this.btnAddOutputPath.Location = new System.Drawing.Point(403, 76);
+         this.btnAddOutputPath.Manager = null;
+         this.btnAddOutputPath.Name = "btnAddOutputPath";
+         this.btnAddOutputPath.Shortcut = System.Windows.Forms.Keys.None;
+         this.btnAddOutputPath.Size = new System.Drawing.Size(324, 22);
+         this.btnAddOutputPath.StyleController = this.layoutControl1;
+         this.btnAddOutputPath.TabIndex = 8;
+         this.btnAddOutputPath.Text = "btnAddOutputPath";
+         // 
          // tbLowerLimitOfQuantification
          // 
          this.tbLowerLimitOfQuantification.Enabled = false;
-         this.tbLowerLimitOfQuantification.Location = new System.Drawing.Point(186, 26);
+         this.tbLowerLimitOfQuantification.Location = new System.Drawing.Point(195, 26);
          this.tbLowerLimitOfQuantification.Name = "tbLowerLimitOfQuantification";
-         this.tbLowerLimitOfQuantification.Size = new System.Drawing.Size(541, 20);
+         this.tbLowerLimitOfQuantification.Size = new System.Drawing.Size(532, 20);
          this.tbLowerLimitOfQuantification.StyleController = this.layoutControl1;
          this.tbLowerLimitOfQuantification.TabIndex = 6;
          // 
          // tbMolWeight
          // 
-         this.tbMolWeight.Location = new System.Drawing.Point(186, 2);
+         this.tbMolWeight.Location = new System.Drawing.Point(195, 2);
          this.tbMolWeight.Name = "tbMolWeight";
-         this.tbMolWeight.Size = new System.Drawing.Size(541, 20);
+         this.tbMolWeight.Size = new System.Drawing.Size(532, 20);
          this.tbMolWeight.StyleController = this.layoutControl1;
          this.tbMolWeight.TabIndex = 5;
          // 
@@ -164,7 +179,7 @@ namespace OSPSuite.UI.Views.ObservedData
          this.emptySpaceItem1.CustomizationFormText = "emptySpaceItem1";
          this.emptySpaceItem1.Location = new System.Drawing.Point(0, 48);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
-         this.emptySpaceItem1.Size = new System.Drawing.Size(364, 26);
+         this.emptySpaceItem1.Size = new System.Drawing.Size(401, 52);
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
          // 
          // layoutItemMolWeight
@@ -183,6 +198,15 @@ namespace OSPSuite.UI.Views.ObservedData
          this.layoutItemLowerLimitOfQuantification.Size = new System.Drawing.Size(729, 24);
          this.layoutItemLowerLimitOfQuantification.TextSize = new System.Drawing.Size(181, 13);
          this.layoutItemLowerLimitOfQuantification.Visibility = DevExpress.XtraLayout.Utils.LayoutVisibility.Never;
+         // 
+         // layoutItemAddOutputPath
+         // 
+         this.layoutItemAddOutputPath.Control = this.btnAddOutputPath;
+         this.layoutItemAddOutputPath.Location = new System.Drawing.Point(401, 74);
+         this.layoutItemAddOutputPath.Name = "layoutItemAddOutputPath";
+         this.layoutItemAddOutputPath.Size = new System.Drawing.Size(328, 26);
+         this.layoutItemAddOutputPath.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemAddOutputPath.TextVisible = false;
          // 
          // DataRepositoryMetaDataView
          // 
@@ -204,6 +228,7 @@ namespace OSPSuite.UI.Views.ObservedData
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemMolWeight)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemLowerLimitOfQuantification)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemAddOutputPath)).EndInit();
          this.ResumeLayout(false);
 
       }
@@ -216,11 +241,13 @@ namespace OSPSuite.UI.Views.ObservedData
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
       private UxLayoutControl layoutControl1;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemAddRow;
-      private DevExpress.XtraEditors.DropDownButton btnAddRow;
+      private DevExpress.XtraEditors.SimpleButton btnAddRow;
       private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
       private DevExpress.XtraEditors.TextEdit tbMolWeight;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemMolWeight;
       private DevExpress.XtraEditors.TextEdit tbLowerLimitOfQuantification;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemLowerLimitOfQuantification;
+      private UxSimpleButton btnAddOutputPath;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemAddOutputPath;
    }
 }

--- a/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.Designer.cs
+++ b/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.Designer.cs
@@ -37,7 +37,7 @@ namespace OSPSuite.UI.Views.ObservedData
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemAddRow = new DevExpress.XtraLayout.LayoutControlItem();
-         this.btnAddRow = new DevExpress.XtraEditors.SimpleButton();
+         this.btnAddRow = new DevExpress.XtraEditors.DropDownButton();
          this.layoutControl1 = new UxLayoutControl();
          this.tbLowerLimitOfQuantification = new DevExpress.XtraEditors.TextEdit();
          this.tbMolWeight = new DevExpress.XtraEditors.TextEdit();
@@ -216,7 +216,7 @@ namespace OSPSuite.UI.Views.ObservedData
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
       private UxLayoutControl layoutControl1;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemAddRow;
-      private DevExpress.XtraEditors.SimpleButton btnAddRow;
+      private DevExpress.XtraEditors.DropDownButton btnAddRow;
       private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
       private DevExpress.XtraEditors.TextEdit tbMolWeight;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemMolWeight;

--- a/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.cs
+++ b/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.cs
@@ -99,6 +99,8 @@ namespace OSPSuite.UI.Views.ObservedData
             .WithFormat(dto => new UnitFormatter(dto.DisplayUnit));
 
          btnAddRow.Click += (o, e) => OnEvent(_presenter.NewMetaDataAdded);
+         btnAddOutputPath.Click += (o, e) => OnEvent(_presenter.AddOutputPathMetadata);
+
          _removeButtonRepository.ButtonClick += (o, e) => OnEvent(_presenter.RemoveMetaData, _gridViewBinder.FocusedElement);
       }
 
@@ -142,6 +144,11 @@ namespace OSPSuite.UI.Views.ObservedData
          _gridViewBinder.BindToSource(metaData);
       }
 
+      public bool AddOutputPathEnabled
+      {
+         set => btnAddOutputPath.Enabled = value;
+      }
+
       public void BindToLLOQ(IParameter lowerLimitsOfQuantification)
       {
          layoutItemLowerLimitOfQuantification.Visibility = LayoutVisibilityConvertor.FromBoolean(true);
@@ -174,10 +181,8 @@ namespace OSPSuite.UI.Views.ObservedData
          base.InitializeResources();
          Caption = Captions.MetaData;
          btnAddRow.InitWithImage(ApplicationIcons.Create, text: Captions.AddMetaData);
-         var dropDownControl = new DXPopupMenu();
-         btnAddRow.DropDownControl = dropDownControl;
-         dropDownControl.Items.Add(new DXMenuItem(Captions.AddOutputPath, (o, e) => OnEvent(() => _presenter.AddOutputPathMetadata())));
-
+         btnAddOutputPath.Text = Captions.AddOutputPath;
+         layoutItemAddOutputPath.AdjustLargeButtonSize(layoutControl1);
          layoutItemAddRow.AdjustLargeButtonSize(layoutControl1);
          layoutItemMolWeight.Text = Constants.Parameters.MOL_WEIGHT.FormatForLabel();
          layoutItemLowerLimitOfQuantification.Text = Captions.LLOQ.FormatForLabel(checkCase:false);

--- a/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.cs
+++ b/src/OSPSuite.UI/Views/ObservedData/DataRepositoryMetaDataView.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using DevExpress.Utils.Menu;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
@@ -27,7 +28,7 @@ namespace OSPSuite.UI.Views.ObservedData
       private readonly GridViewBinder<MetaDataDTO> _gridViewBinder;
       private readonly UxRepositoryItemComboBox _repositoryForPredefinedValues;
       private readonly RepositoryItemTextEdit _readOnlyRepository;
-      private readonly RepositoryItemTextEdit _stantdardEditRepository = new RepositoryItemTextEdit();
+      private readonly RepositoryItemTextEdit _standardEditRepository = new RepositoryItemTextEdit();
       private IGridViewColumn _colName;
       private IGridViewColumn _colValue;
       private readonly RepositoryItem _disabledRemoveButtonRepository = new UxRemoveButtonRepository();
@@ -116,14 +117,14 @@ namespace OSPSuite.UI.Views.ObservedData
 
       private RepositoryItem nameRepository(MetaDataDTO dto)
       {
-         return dto.NameEditable ? _stantdardEditRepository : _readOnlyRepository;
+         return dto.NameEditable ? _standardEditRepository : _readOnlyRepository;
       }
 
       private RepositoryItem valueRepository(MetaDataDTO dto)
       {
          return dto.ValueReadOnly
             ? _readOnlyRepository
-            : dto.HasListOfValues ? _repositoryForPredefinedValues : _stantdardEditRepository;
+            : dto.HasListOfValues ? _repositoryForPredefinedValues : _standardEditRepository;
       }
 
       private void onNameChanged(MetaDataDTO metaDataDTO, PropertyValueSetEventArgs<string> e)
@@ -173,6 +174,10 @@ namespace OSPSuite.UI.Views.ObservedData
          base.InitializeResources();
          Caption = Captions.MetaData;
          btnAddRow.InitWithImage(ApplicationIcons.Create, text: Captions.AddMetaData);
+         var dropDownControl = new DXPopupMenu();
+         btnAddRow.DropDownControl = dropDownControl;
+         dropDownControl.Items.Add(new DXMenuItem(Captions.AddOutputPath, (o, e) => OnEvent(() => _presenter.AddOutputPathMetadata())));
+
          layoutItemAddRow.AdjustLargeButtonSize(layoutControl1);
          layoutItemMolWeight.Text = Constants.Parameters.MOL_WEIGHT.FormatForLabel();
          layoutItemLowerLimitOfQuantification.Text = Captions.LLOQ.FormatForLabel(checkCase:false);

--- a/tests/OSPSuite.Core.Tests/Services/OutputMappingMatchingTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/OutputMappingMatchingTaskSpecs.cs
@@ -115,8 +115,6 @@ namespace OSPSuite.Core.Services
       {
          base.Context();
          _observedData.ExtendedProperties.Add(new ExtendedProperty<string> { Name = Constants.OUTPUT_PATH, Value = "TestCompartment|Brain|TestMolecule" });
-         // remove this so the default path matching is not a fallback.
-         _observedData.ExtendedProperties.Remove(Constants.ObservedData.MOLECULE);
       }
 
       protected override void Because()
@@ -130,6 +128,26 @@ namespace OSPSuite.Core.Services
          _simulation.OutputMappings.All.Count.ShouldBeEqualTo(1);
          _simulation.OutputMappings.All.First().Output.Name.ShouldBeEqualTo("TestMolecule");
          _simulation.OutputMappings.All.First().WeightedObservedData.Name.ShouldBeEqualTo("TestData");
+      }
+   }
+
+   public class When_adding_observed_data_with_output_path_metadata_not_matching_a_simulation_output : concern_for_OutputMappingMatchingTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _observedData.ExtendedProperties.Add(new ExtendedProperty<string> { Name = Constants.OUTPUT_PATH, Value = "TestCompartment|Bone|TestMolecule" });
+      }
+
+      protected override void Because()
+      {
+         sut.AddMatchingOutputMapping(_observedData, _simulation);
+      }
+
+      [Observation]
+      public void matching_simulation_output_mapping_should_not_have_been_added()
+      {
+         _simulation.OutputMappings.All.Count.ShouldBeEqualTo(0);
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Services/OutputMappingMatchingTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/OutputMappingMatchingTaskSpecs.cs
@@ -18,7 +18,6 @@ namespace OSPSuite.Core.Services
       protected PathCache<IQuantity> _pathCache;
       protected IQuantity _quantity1;
       protected IQuantity _quantity2;
-      protected IQuantity _compartment;
       protected DataRepository _observedData;
       protected ISimulation _simulation;
       protected IContainer _container;
@@ -46,7 +45,7 @@ namespace OSPSuite.Core.Services
 
          _quantity2 = new MoleculeAmount();
          _quantity2.QuantityType = QuantityType.Drug;
-         
+
          _simulation.Model.Root = _container;
 
          _pathCache = new PathCache<IQuantity>(_entityPathResolver)
@@ -73,12 +72,10 @@ namespace OSPSuite.Core.Services
       }
    }
 
-   
    public class When_adding_matching_observed_data_to_a_simulation : concern_for_OutputMappingMatchingTask
    {
-      protected override void Context()
+      protected override void Because()
       {
-         base.Context();
          sut.AddMatchingOutputMapping(_observedData, _simulation);
       }
 
@@ -98,6 +95,10 @@ namespace OSPSuite.Core.Services
          base.Context();
          _observedData.ExtendedProperties.Remove(Constants.ObservedData.MOLECULE);
          _observedData.ExtendedProperties.Add(new ExtendedProperty<string> { Name = Constants.ObservedData.MOLECULE, Value = "TestMolecule_2" });
+      }
+
+      protected override void Because()
+      {
          sut.AddMatchingOutputMapping(_observedData, _simulation);
       }
 
@@ -108,4 +109,27 @@ namespace OSPSuite.Core.Services
       }
    }
 
+   public class When_adding_observed_data_with_output_path_metadata_matching_a_simulation_output : concern_for_OutputMappingMatchingTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _observedData.ExtendedProperties.Add(new ExtendedProperty<string> { Name = Constants.OUTPUT_PATH, Value = "TestCompartment|Brain|TestMolecule" });
+         // remove this so the default path matching is not a fallback.
+         _observedData.ExtendedProperties.Remove(Constants.ObservedData.MOLECULE);
+      }
+
+      protected override void Because()
+      {
+         sut.AddMatchingOutputMapping(_observedData, _simulation);
+      }
+
+      [Observation]
+      public void matching_simulation_output_mapping_should_have_been_added()
+      {
+         _simulation.OutputMappings.All.Count.ShouldBeEqualTo(1);
+         _simulation.OutputMappings.All.First().Output.Name.ShouldBeEqualTo("TestMolecule");
+         _simulation.OutputMappings.All.First().WeightedObservedData.Name.ShouldBeEqualTo("TestData");
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2787 Add OutputPath meta data to observed data imports

# Description

Adding the output path with a special 'Add' button that ensures the name is correct for the new meta data property

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

That's how you add this meta data to ensure the name is correct. It has a special meaning for the output path matching

<img width="299" height="195" alt="image" src="https://github.com/user-attachments/assets/86bea3ca-4aed-4163-9780-b19f31d10642" />

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add Output Path" button in the observed-data metadata UI to insert a non-editable OUTPUT_PATH metadata entry and toggle its availability.
  * Matching logic now supports direct output-path-based association between observed data and simulation outputs for improved matching accuracy.

* **Tests**
  * Added tests verifying matching behavior when OUTPUT_PATH metadata matches or does not match simulation outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->