### PR TITLE
Fixes #2814 Cancelled PI does not show Number of Evaluations

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
@@ -48,6 +48,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       private readonly IJacobianMatrixCalculator _jacobianMatrixCalculator;
       private readonly ConcurrentDictionary<IModelCoreSimulation, ISimModelBatch> _allSimModelBatches = new ConcurrentDictionary<IModelCoreSimulation, ISimModelBatch>();
       private readonly List<float> _totalErrorHistory = new List<float>();
+      private int _numberOfEvaluations;
 
       private readonly Cache<string, IdentificationParameterHistory> _parametersHistory =
          new Cache<string, IdentificationParameterHistory>(x => x.Name);
@@ -133,6 +134,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
       public virtual ParameterIdentificationRunResult Run(CancellationToken cancellationToken)
       {
          _cancellationToken = cancellationToken;
+         _numberOfEvaluations = 0;
          var begin = SystemTime.UtcNow();
          try
          {
@@ -149,6 +151,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          }
          catch (OperationCanceledException)
          {
+            RunResult.Properties = new OptimizationRunProperties(_numberOfEvaluations);
             RunResult.Status = RunStatus.Canceled;
             return RunResult;
          }
@@ -201,6 +204,7 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          //We clone the values here to ensure that we are not sharing the same parameter value instances as the PI algorithm
          var clonedValues = values.Select(x => x.Clone()).ToList();
 
+         _numberOfEvaluations++;
          var optimizationRunResult = updateValuesAndCalculate(clonedValues);
 
          updateRunResult(optimizationRunResult);

--- a/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
+++ b/src/OSPSuite.Core/Domain/Services/ParameterIdentifications/ParameterIdentificationRun.cs
@@ -204,8 +204,8 @@ namespace OSPSuite.Core.Domain.Services.ParameterIdentifications
          //We clone the values here to ensure that we are not sharing the same parameter value instances as the PI algorithm
          var clonedValues = values.Select(x => x.Clone()).ToList();
 
-         _numberOfEvaluations++;
          var optimizationRunResult = updateValuesAndCalculate(clonedValues);
+         _numberOfEvaluations++;
 
          updateRunResult(optimizationRunResult);
 

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterIdentificationRunSpecs.cs
@@ -464,6 +464,47 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_the_parameter_identification_run_is_canceled_after_some_evaluations : concern_for_ParameterIdentificationRun
+   {
+      private ParameterIdentificationRunResult _result;
+      private const int NUMBER_OF_EVALUATIONS_BEFORE_CANCEL = 3;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         A.CallTo(() => _algorithm.Optimize(A<OptimizedParameterConstraint[]>._,
+               A<Func<IReadOnlyList<OptimizedParameterValue>, OptimizationRunResult>>._))
+            .Invokes(x =>
+            {
+               var objectiveFunction = x.GetArgument<Func<IReadOnlyList<OptimizedParameterValue>, OptimizationRunResult>>(1);
+               var parameterValue = new OptimizedParameterValue(_identificationParameter.Name, 15d, 15d, 10, 20, Scalings.Linear);
+               for (int i = 0; i < NUMBER_OF_EVALUATIONS_BEFORE_CANCEL; i++)
+                  objectiveFunction(new[] { parameterValue });
+
+               _cancellationTokenSource.Cancel();
+               throw new OperationCanceledException();
+            });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.Run(_cancellationToken);
+      }
+
+      [Observation]
+      public void should_set_the_run_status_of_the_underlying_run_result_to_canceled()
+      {
+         _result.Status.ShouldBeEqualTo(RunStatus.Canceled);
+      }
+
+      [Observation]
+      public void should_report_the_number_of_evaluations_completed_before_cancellation()
+      {
+         _result.NumberOfEvaluations.ShouldBeEqualTo(NUMBER_OF_EVALUATIONS_BEFORE_CANCEL);
+      }
+   }
+
    public class When_the_parameter_identification_run_is_running_a_run_that_throws_an_exception : concern_for_ParameterIdentificationRun
    {
       private ParameterIdentificationRunResult _result;


### PR DESCRIPTION
Fixes #2814 Cancelled PI does not show Number of Evaluations

# Description
We just need to keep track of the number of runs and put that in the RunResult Properties on cancel.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parameter identification runs now track and report the number of optimization evaluations completed; canceled runs include this count in their results.

* **Tests**
  * Added test coverage verifying cancellation behavior and that the reported number of evaluations matches those completed before cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->