### PR TITLE
Fixes #2819 Create a clone/update pattern for user settings

### DIFF
--- a/src/OSPSuite.Core/Diagram/IDiagramColors.cs
+++ b/src/OSPSuite.Core/Diagram/IDiagramColors.cs
@@ -4,6 +4,9 @@ namespace OSPSuite.Core.Diagram
 {
    public interface IDiagramColors
    {
+      IDiagramColors Clone();
+      void UpdatePropertiesFrom(IDiagramColors source);
+
       Color DiagramBackground { get; set; } 
 
       Color BorderFixed { get; set; } 

--- a/src/OSPSuite.Core/Diagram/IDiagramOptions.cs
+++ b/src/OSPSuite.Core/Diagram/IDiagramOptions.cs
@@ -2,6 +2,9 @@ namespace OSPSuite.Core.Diagram
 {
    public interface IDiagramOptions
    {
+      IDiagramOptions Clone();
+      void UpdatePropertiesFrom(IDiagramOptions source);
+
       bool SnapGridVisible { get; set; }
       bool MoleculePropertiesVisible { get; set; }
       bool ObserverLinksVisible { get; set; }

--- a/src/OSPSuite.Presentation/Diagram/Elements/DiagramColors.cs
+++ b/src/OSPSuite.Presentation/Diagram/Elements/DiagramColors.cs
@@ -82,5 +82,45 @@ namespace OSPSuite.Presentation.Diagram.Elements
       public Color RelatedItemNode { get; set; }
       public Color RelatedItemLink { get; set; }
       public Color RelatedItemPort { get { return DiagramBackground; } }
+
+      public IDiagramColors Clone()
+      {
+         var clone = new DiagramColors();
+         clone.UpdatePropertiesFrom(this);
+         return clone;
+      }
+
+      public void UpdatePropertiesFrom(IDiagramColors source)
+      {
+         DiagramBackground = source.DiagramBackground;
+         BorderFixed = source.BorderFixed;
+         BorderUnfixed = source.BorderUnfixed;
+         ContainerLogical = source.ContainerLogical;
+         ContainerPhysical = source.ContainerPhysical;
+         ContainerOpacity = source.ContainerOpacity;
+         ContainerBorder = source.ContainerBorder;
+         ContainerHandle = source.ContainerHandle;
+         NodeSizeOpacity = source.NodeSizeOpacity;
+         PortOpacity = source.PortOpacity;
+         NeighborhoodNode = source.NeighborhoodNode;
+         NeighborhoodLink = source.NeighborhoodLink;
+         NeighborhoodPort = source.NeighborhoodPort;
+         TransportLink = source.TransportLink;
+         MoleculeNode = source.MoleculeNode;
+         ObserverNode = source.ObserverNode;
+         ObserverLink = source.ObserverLink;
+         ReactionNode = source.ReactionNode;
+         ReactionPortEduct = source.ReactionPortEduct;
+         ReactionLinkEduct = source.ReactionLinkEduct;
+         ReactionPortProduct = source.ReactionPortProduct;
+         ReactionLinkProduct = source.ReactionLinkProduct;
+         ReactionPortModifier = source.ReactionPortModifier;
+         ReactionLinkModifier = source.ReactionLinkModifier;
+         JournalPageNode = source.JournalPageNode;
+         JournalPageLink = source.JournalPageLink;
+         JournalPagePort = source.JournalPagePort;
+         RelatedItemNode = source.RelatedItemNode;
+         RelatedItemLink = source.RelatedItemLink;
+      }
    }
 }

--- a/src/OSPSuite.Presentation/Diagram/Elements/DiagramOptions.cs
+++ b/src/OSPSuite.Presentation/Diagram/Elements/DiagramOptions.cs
@@ -25,5 +25,23 @@ namespace OSPSuite.Presentation.Diagram.Elements
       public NodeSize DefaultNodeSizeObserver { get; set; }
       public IDiagramColors DiagramColors { get; set; }
 
+      public IDiagramOptions Clone()
+      {
+         var clone = new DiagramOptions();
+         clone.UpdatePropertiesFrom(this);
+         return clone;
+      }
+
+      public void UpdatePropertiesFrom(IDiagramOptions source)
+      {
+         SnapGridVisible = source.SnapGridVisible;
+         MoleculePropertiesVisible = source.MoleculePropertiesVisible;
+         ObserverLinksVisible = source.ObserverLinksVisible;
+         UnusedMoleculesVisibleInModelDiagram = source.UnusedMoleculesVisibleInModelDiagram;
+         DefaultNodeSizeReaction = source.DefaultNodeSizeReaction;
+         DefaultNodeSizeMolecule = source.DefaultNodeSizeMolecule;
+         DefaultNodeSizeObserver = source.DefaultNodeSizeObserver;
+         DiagramColors.UpdatePropertiesFrom(source.DiagramColors);
+      }
    }
 }

--- a/src/OSPSuite.Presentation/Diagram/Elements/IForceLayoutConfiguration.cs
+++ b/src/OSPSuite.Presentation/Diagram/Elements/IForceLayoutConfiguration.cs
@@ -2,6 +2,9 @@ namespace OSPSuite.Presentation.Diagram.Elements
 {
    public interface IForceLayoutConfiguration
    {
+      IForceLayoutConfiguration Clone();
+      void UpdatePropertiesFrom(IForceLayoutConfiguration source);
+
       float BaseGravitationalMass { get; set; }
       float BaseElectricalCharge { get; set; }
       float BaseSpringLength { get; set; }

--- a/src/OSPSuite.UI/Diagram/Elements/ForceLayoutConfiguration.cs
+++ b/src/OSPSuite.UI/Diagram/Elements/ForceLayoutConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using OSPSuite.Presentation.Diagram.Elements;
 
 namespace OSPSuite.UI.Diagram.Elements
@@ -223,6 +224,39 @@ namespace OSPSuite.UI.Diagram.Elements
          {
             RelativeSpringStiffnessOf[NodeLayoutType.CONTAINER_NODE, NodeLayoutType.REMOTE_CONTAINER_BOUNDARY_NODE] = value;
             RelativeSpringStiffnessOf[NodeLayoutType.REMOTE_CONTAINER_BOUNDARY_NODE, NodeLayoutType.CONTAINER_NODE] = value;
+         }
+      }
+
+      public IForceLayoutConfiguration Clone()
+      {
+         var clone = new ForceLayoutConfiguration();
+         clone.UpdatePropertiesFrom(this);
+         return clone;
+      }
+
+      public void UpdatePropertiesFrom(IForceLayoutConfiguration source)
+      {
+         BaseGravitationalMass = source.BaseGravitationalMass;
+         BaseElectricalCharge = source.BaseElectricalCharge;
+         BaseSpringLength = source.BaseSpringLength;
+         BaseSpringStiffness = source.BaseSpringStiffness;
+         MaxIterations = source.MaxIterations;
+         Epsilon = source.Epsilon;
+         InfinityDistance = source.InfinityDistance;
+         ArrangementSpacingWidth = source.ArrangementSpacingWidth;
+         ArrangementSpacingHeight = source.ArrangementSpacingHeight;
+         LogPositions = source.LogPositions;
+
+         Array.Copy(source.RelativeGravitationalMassOf, RelativeGravitationalMassOf, NUMBER_OF_GROUPS);
+         Array.Copy(source.RelativeElectricalChargeOf, RelativeElectricalChargeOf, NUMBER_OF_GROUPS);
+
+         for (int i = 0; i < NUMBER_OF_GROUPS; i++)
+         {
+            for (int j = 0; j < NUMBER_OF_GROUPS; j++)
+            {
+               RelativeSpringLengthOf[i, j] = source.RelativeSpringLengthOf[i, j];
+               RelativeSpringStiffnessOf[i, j] = source.RelativeSpringStiffnessOf[i, j];
+            }
          }
       }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DiagramColorsSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DiagramColorsSpecs.cs
@@ -1,0 +1,86 @@
+using System.Drawing;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Presentation.Diagram.Elements;
+
+namespace OSPSuite.Presentation
+{
+   public abstract class concern_for_DiagramColors : ContextSpecification<DiagramColors>
+   {
+      protected override void Context()
+      {
+         sut = new DiagramColors();
+      }
+   }
+
+   public class When_cloning_diagram_colors : concern_for_DiagramColors
+   {
+      private IDiagramColors _clone;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.DiagramBackground = Color.Red;
+         sut.BorderFixed = Color.Blue;
+         sut.ContainerOpacity = 0.5F;
+         sut.MoleculeNode = Color.Green;
+         sut.ReactionNode = Color.Yellow;
+      }
+
+      protected override void Because()
+      {
+         _clone = sut.Clone();
+      }
+
+      [Observation]
+      public void should_create_a_new_instance()
+      {
+         _clone.ShouldNotBeNull();
+         ReferenceEquals(_clone, sut).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_copy_all_color_properties()
+      {
+         _clone.DiagramBackground.ShouldBeEqualTo(Color.Red);
+         _clone.BorderFixed.ShouldBeEqualTo(Color.Blue);
+         _clone.ContainerOpacity.ShouldBeEqualTo(0.5F);
+         _clone.MoleculeNode.ShouldBeEqualTo(Color.Green);
+         _clone.ReactionNode.ShouldBeEqualTo(Color.Yellow);
+      }
+   }
+
+   public class When_updating_diagram_colors_from_another_instance : concern_for_DiagramColors
+   {
+      private DiagramColors _source;
+
+      protected override void Context()
+      {
+         base.Context();
+         _source = new DiagramColors
+         {
+            DiagramBackground = Color.Black,
+            BorderFixed = Color.Cyan,
+            NodeSizeOpacity = 0.8F,
+            ObserverNode = Color.Magenta,
+            JournalPageNode = Color.Orange
+         };
+      }
+
+      protected override void Because()
+      {
+         sut.UpdatePropertiesFrom(_source);
+      }
+
+      [Observation]
+      public void should_update_all_properties_from_source()
+      {
+         sut.DiagramBackground.ShouldBeEqualTo(Color.Black);
+         sut.BorderFixed.ShouldBeEqualTo(Color.Cyan);
+         sut.NodeSizeOpacity.ShouldBeEqualTo(0.8F);
+         sut.ObserverNode.ShouldBeEqualTo(Color.Magenta);
+         sut.JournalPageNode.ShouldBeEqualTo(Color.Orange);
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DiagramOptionsSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DiagramOptionsSpecs.cs
@@ -1,0 +1,102 @@
+using System.Drawing;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Presentation.Diagram.Elements;
+
+namespace OSPSuite.Presentation
+{
+   public abstract class concern_for_DiagramOptions : ContextSpecification<DiagramOptions>
+   {
+      protected override void Context()
+      {
+         sut = new DiagramOptions();
+      }
+   }
+
+   public class When_cloning_diagram_options : concern_for_DiagramOptions
+   {
+      private IDiagramOptions _clone;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.SnapGridVisible = true;
+         sut.MoleculePropertiesVisible = true;
+         sut.ObserverLinksVisible = true;
+         sut.UnusedMoleculesVisibleInModelDiagram = true;
+         sut.DefaultNodeSizeReaction = NodeSize.Large;
+         sut.DefaultNodeSizeMolecule = NodeSize.Small;
+         sut.DefaultNodeSizeObserver = NodeSize.Large;
+         sut.DiagramColors.MoleculeNode = Color.Red;
+      }
+
+      protected override void Because()
+      {
+         _clone = sut.Clone();
+      }
+
+      [Observation]
+      public void should_create_a_new_instance()
+      {
+         ReferenceEquals(_clone, sut).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_copy_all_properties()
+      {
+         _clone.SnapGridVisible.ShouldBeTrue();
+         _clone.MoleculePropertiesVisible.ShouldBeTrue();
+         _clone.ObserverLinksVisible.ShouldBeTrue();
+         _clone.UnusedMoleculesVisibleInModelDiagram.ShouldBeTrue();
+         _clone.DefaultNodeSizeReaction.ShouldBeEqualTo(NodeSize.Large);
+         _clone.DefaultNodeSizeMolecule.ShouldBeEqualTo(NodeSize.Small);
+         _clone.DefaultNodeSizeObserver.ShouldBeEqualTo(NodeSize.Large);
+      }
+
+      [Observation]
+      public void should_deep_clone_diagram_colors()
+      {
+         ReferenceEquals(_clone.DiagramColors, sut.DiagramColors).ShouldBeFalse();
+         _clone.DiagramColors.MoleculeNode.ShouldBeEqualTo(Color.Red);
+      }
+   }
+
+   public class When_updating_diagram_options_from_another_instance : concern_for_DiagramOptions
+   {
+      private DiagramOptions _source;
+
+      protected override void Context()
+      {
+         base.Context();
+         _source = new DiagramOptions
+         {
+            SnapGridVisible = true,
+            MoleculePropertiesVisible = true,
+            DefaultNodeSizeReaction = NodeSize.Small,
+            DefaultNodeSizeMolecule = NodeSize.Large
+         };
+         _source.DiagramColors.MoleculeNode = Color.Blue;
+      }
+
+      protected override void Because()
+      {
+         sut.UpdatePropertiesFrom(_source);
+      }
+
+      [Observation]
+      public void should_update_all_properties()
+      {
+         sut.SnapGridVisible.ShouldBeTrue();
+         sut.MoleculePropertiesVisible.ShouldBeTrue();
+         sut.DefaultNodeSizeReaction.ShouldBeEqualTo(NodeSize.Small);
+         sut.DefaultNodeSizeMolecule.ShouldBeEqualTo(NodeSize.Large);
+      }
+
+      [Observation]
+      public void should_update_diagram_colors()
+      {
+         sut.DiagramColors.MoleculeNode.ShouldBeEqualTo(Color.Blue);
+      }
+   }
+}

--- a/tests/OSPSuite.UI.Tests/ForceLayoutConfigurationSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/ForceLayoutConfigurationSpecs.cs
@@ -1,0 +1,133 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Presentation.Diagram.Elements;
+using OSPSuite.UI.Diagram.Elements;
+
+namespace OSPSuite.UI
+{
+   public abstract class concern_for_ForceLayoutConfiguration : ContextSpecification<ForceLayoutConfiguration>
+   {
+      protected override void Context()
+      {
+         sut = new ForceLayoutConfiguration();
+      }
+   }
+
+   public class When_cloning_force_layout_configuration : concern_for_ForceLayoutConfiguration
+   {
+      private IForceLayoutConfiguration _clone;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.BaseGravitationalMass = 5F;
+         sut.BaseElectricalCharge = 100F;
+         sut.BaseSpringLength = 50F;
+         sut.BaseSpringStiffness = 0.5F;
+         sut.MaxIterations = 500;
+         sut.Epsilon = 0.05F;
+         sut.InfinityDistance = 1000F;
+         sut.ArrangementSpacingWidth = 200F;
+         sut.ArrangementSpacingHeight = 150F;
+         sut.LogPositions = true;
+         sut.RelativeElectricalChargeMolecule = 3F;
+         sut.RelativeGravitationalMassMolecule = 1.5F;
+         sut.RelativeSpringLengthContainerContainer = 4F;
+         sut.RelativeSpringStiffnessContainerContainer = 2F;
+      }
+
+      protected override void Because()
+      {
+         _clone = sut.Clone();
+      }
+
+      [Observation]
+      public void should_create_a_new_instance()
+      {
+         ReferenceEquals(_clone, sut).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_copy_base_properties()
+      {
+         _clone.BaseGravitationalMass.ShouldBeEqualTo(5F);
+         _clone.BaseElectricalCharge.ShouldBeEqualTo(100F);
+         _clone.BaseSpringLength.ShouldBeEqualTo(50F);
+         _clone.BaseSpringStiffness.ShouldBeEqualTo(0.5F);
+      }
+
+      [Observation]
+      public void should_copy_iteration_properties()
+      {
+         _clone.MaxIterations.ShouldBeEqualTo(500);
+         _clone.Epsilon.ShouldBeEqualTo(0.05F);
+         _clone.InfinityDistance.ShouldBeEqualTo(1000F);
+         _clone.ArrangementSpacingWidth.ShouldBeEqualTo(200F);
+         _clone.ArrangementSpacingHeight.ShouldBeEqualTo(150F);
+         _clone.LogPositions.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_copy_relative_charge_and_mass_arrays()
+      {
+         _clone.RelativeElectricalChargeMolecule.ShouldBeEqualTo(3F);
+         _clone.RelativeGravitationalMassMolecule.ShouldBeEqualTo(1.5F);
+      }
+
+      [Observation]
+      public void should_copy_relative_spring_matrices()
+      {
+         _clone.RelativeSpringLengthContainerContainer.ShouldBeEqualTo(4F);
+         _clone.RelativeSpringStiffnessContainerContainer.ShouldBeEqualTo(2F);
+      }
+
+      [Observation]
+      public void should_not_share_array_references_with_original()
+      {
+         ReferenceEquals(_clone.RelativeGravitationalMassOf, sut.RelativeGravitationalMassOf).ShouldBeFalse();
+         ReferenceEquals(_clone.RelativeElectricalChargeOf, sut.RelativeElectricalChargeOf).ShouldBeFalse();
+         ReferenceEquals(_clone.RelativeSpringLengthOf, sut.RelativeSpringLengthOf).ShouldBeFalse();
+         ReferenceEquals(_clone.RelativeSpringStiffnessOf, sut.RelativeSpringStiffnessOf).ShouldBeFalse();
+      }
+   }
+
+   public class When_updating_force_layout_configuration_from_another_instance : concern_for_ForceLayoutConfiguration
+   {
+      private ForceLayoutConfiguration _source;
+
+      protected override void Context()
+      {
+         base.Context();
+         _source = new ForceLayoutConfiguration
+         {
+            BaseGravitationalMass = 10F,
+            BaseElectricalCharge = 200F,
+            MaxIterations = 2000,
+            LogPositions = true,
+            RelativeElectricalChargeReaction = 5F,
+            RelativeSpringLengthReactionMolecule = 3F
+         };
+      }
+
+      protected override void Because()
+      {
+         sut.UpdatePropertiesFrom(_source);
+      }
+
+      [Observation]
+      public void should_update_base_properties()
+      {
+         sut.BaseGravitationalMass.ShouldBeEqualTo(10F);
+         sut.BaseElectricalCharge.ShouldBeEqualTo(200F);
+         sut.MaxIterations.ShouldBeEqualTo(2000);
+         sut.LogPositions.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_update_relative_properties()
+      {
+         sut.RelativeElectricalChargeReaction.ShouldBeEqualTo(5F);
+         sut.RelativeSpringLengthReactionMolecule.ShouldBeEqualTo(3F);
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2819 create a clone/update pattern for user settings

# Description
Implementing a clone/update so that we can bind and edit a clone of user settings instead of the active usersettings object.

That allows cancel to reverse any changes that were made in the dialog.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to clone and update diagram configurations and layout settings for enhanced state management.

* **Tests**
  * Added comprehensive test coverage for diagram and layout configuration cloning and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->