### PR TITLE
Fixes #2826 Query for used calculation method used given a molecule and category in R

### DIFF
--- a/src/OSPSuite.R/Domain/Simulation.cs
+++ b/src/OSPSuite.R/Domain/Simulation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using OSPSuite.CLI.Core.MinimalImplementations;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Commands;
@@ -136,6 +137,19 @@ namespace OSPSuite.R.Domain
       public double? MolWeightFor(IQuantity quantity) => CoreSimulation.MolWeightFor(quantity);
 
       public double? MolWeightFor(string quantityPath) => CoreSimulation.MolWeightFor(quantityPath);
+
+      /// <summary>
+      ///    Returns the name of the calculation method used for the given <paramref name="moleculeName" /> and
+      ///    <paramref name="category" />. Returns <c>null</c> if no override is defined for the combination.
+      /// </summary>
+      public string CalculationMethodFor(string moleculeName, string category)
+      {
+         return Configuration.CalculationMethodOverridesFor(moleculeName)
+            .UsedCalculationMethods
+            .FirstOrDefault(x => x.Category == category)
+            ?.CalculationMethod;
+      }
+
       public bool HasChanged { get; set; }
    }
 }

--- a/tests/OSPSuite.R.Tests/Domain/SimulationSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Domain/SimulationSpecs.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace OSPSuite.R.Domain
+{
+   public abstract class concern_for_Simulation : ContextSpecification<Simulation>
+   {
+      protected IModelCoreSimulation _coreSimulation;
+      protected SimulationConfiguration _configuration;
+
+      protected override void Context()
+      {
+         _coreSimulation = A.Fake<IModelCoreSimulation>();
+         _configuration = new SimulationConfiguration();
+         A.CallTo(() => _coreSimulation.Configuration).Returns(_configuration);
+         sut = new Simulation(_coreSimulation);
+      }
+   }
+
+   public class When_getting_calculation_method_for_molecule_and_category : concern_for_Simulation
+   {
+      private string _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _configuration.AddCalculationMethodsOverridesFor("Caffeine", new List<UsedCalculationMethod>
+         {
+            new("PartitionCoefficient", "PK-Sim Standard"),
+            new("CellularPermeabilities", "PK-Sim Standard")
+         });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CalculationMethodFor("Caffeine", "PartitionCoefficient");
+      }
+
+      [Observation]
+      public void should_return_the_calculation_method_name()
+      {
+         _result.ShouldBeEqualTo("PK-Sim Standard");
+      }
+   }
+
+   public class When_getting_calculation_method_for_molecule_with_non_existing_category : concern_for_Simulation
+   {
+      private string _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _configuration.AddCalculationMethodsOverridesFor("Caffeine", new List<UsedCalculationMethod>
+         {
+            new("PartitionCoefficient", "PK-Sim Standard")
+         });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CalculationMethodFor("Caffeine", "NonExistingCategory");
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _result.ShouldBeNull();
+      }
+   }
+
+   public class When_getting_calculation_method_for_non_existing_molecule : concern_for_Simulation
+   {
+      private string _result;
+
+      protected override void Because()
+      {
+         _result = sut.CalculationMethodFor("NonExistingMolecule", "SomeCategory");
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _result.ShouldBeNull();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2826 Query for used calculation method used given a molecule and category in R

# Description
Add a way for R to query the used calculation methods from a simulation given the molecule and category

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):