### PR TITLE
Fixes  #2834 Separator Selector is styled differently and pops-under pk-sim

### DIFF
--- a/src/OSPSuite.Infrastructure.Import/Core/DataSourceFile.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSourceFile.cs
@@ -12,7 +12,7 @@ namespace OSPSuite.Infrastructure.Import.Core
    /// </summary>
    public interface IDataSourceFile
    {
-      string Path { get; set; }
+      string Path { get; }
       IDataFormat Format { get; set; }
 
       IList<IDataFormat> AvailableFormats { get; set; }
@@ -22,6 +22,11 @@ namespace OSPSuite.Infrastructure.Import.Core
       //as active when initialized
       string FormatCalculatedFrom { get; set; }
       DataSheetCollection DataSheets { get; }
+
+      /// <summary>
+      ///    Loads the file at <paramref name="path" /> into the data source.
+      /// </summary>
+      void LoadFromFile(string path);
    }
 
    public abstract class DataSourceFile : IDataSourceFile
@@ -52,29 +57,25 @@ namespace OSPSuite.Infrastructure.Import.Core
          _heavyWorkManager = heavyWorkManager;
       }
 
-      private string _path;
+      public string Path { get; private set; }
 
-      public string Path
+      protected abstract void DoLoadWork(string path, CancellationToken cancellationToken = default);
+
+      public virtual void LoadFromFile(string path)
       {
-         get => _path;
-         set
+         Path = path;
+         var cts = new CancellationTokenSource();
+         _heavyWorkManager.Start(() =>
          {
-            _path = value;
-            var cts = new CancellationTokenSource();
-            _heavyWorkManager.Start(() =>
+            try
             {
-               try
-               {
-                  LoadFromFile(_path, cts.Token);
-               }
-               catch (OperationCanceledException)
-               {
-                  //Nothing to do, just not throw exception.
-               }
-            }, "Importing data...", cts);
-         }
+               DoLoadWork(path, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+               //Nothing to do, just not throw exception.
+            }
+         }, "Importing data...", cts);
       }
-
-      protected abstract void LoadFromFile(string path, CancellationToken cancellationToken = default);
    }
 }

--- a/src/OSPSuite.Infrastructure.Import/Core/DataSourceFile.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSourceFile.cs
@@ -63,9 +63,15 @@ namespace OSPSuite.Infrastructure.Import.Core
 
       public virtual void LoadFromFile(string path)
       {
-         Path = path;
+         
          var cts = new CancellationTokenSource();
-         _heavyWorkManager.Start(() =>
+         if(heavyWorkSucceeds(path, cts))
+            Path = path;
+      }
+
+      private bool heavyWorkSucceeds(string path, CancellationTokenSource cts)
+      {
+         return _heavyWorkManager.Start(() =>
          {
             try
             {

--- a/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileParser.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileParser.cs
@@ -28,13 +28,13 @@ namespace OSPSuite.Infrastructure.Import.Core
          var lowerCasePath = path.ToLower();
          if (_csvExtensions.Any(lowerCasePath.EndsWith))
          {
-            _csvDataSourceFile.Path = path;
+            _csvDataSourceFile.LoadFromFile(path);
             return _csvDataSourceFile;
          }
 
          if (_excelExtensions.Any(lowerCasePath.EndsWith))
          {
-            _excelDataSourceFile.Path = path;
+            _excelDataSourceFile.LoadFromFile(path);
             return _excelDataSourceFile;
          }
 

--- a/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileReaders/CsvDataSourceFile.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileReaders/CsvDataSourceFile.cs
@@ -14,27 +14,33 @@ namespace OSPSuite.Infrastructure.Import.Core.DataSourceFileReaders
    public class CsvDataSourceFile : DataSourceFile, ICsvDataSourceFile
    {
       private readonly ICsvSeparatorSelector _csvSeparatorSelector;
+      private CSVSeparators _csvSeparators;
 
       public CsvDataSourceFile(IImportLogger logger, ICsvSeparatorSelector csvSeparatorSelector, IHeavyWorkManager heavyWorkManager) : base(logger, heavyWorkManager)
       {
          _csvSeparatorSelector = csvSeparatorSelector;
       }
 
-      protected override void LoadFromFile(string path, CancellationToken c)
+      public override void LoadFromFile(string path)
       {
-         var csvSeparators = _csvSeparatorSelector.GetCsvSeparator(path);
+         _csvSeparators = _csvSeparatorSelector.GetCsvSeparator(path);
 
          //if separator selection dialog was cancelled, abort
-         if (csvSeparators == null)
+         if (_csvSeparators == null)
             return;
 
+         base.LoadFromFile(path);
+      }
+      
+      protected override void DoLoadWork(string path, CancellationToken cancellationToken = default)
+      {
          //we keep a copy of the already loaded sheets, in case the reading fails
          var alreadyLoadedDataSheets = DataSheets.Clone();
          DataSheets.Clear();
 
          try
          {
-            using (var reader = new CsvReaderFromFile(path, csvSeparators.ColumnSeparator))
+            using (var reader = new CsvReaderFromFile(path, _csvSeparators.ColumnSeparator))
             {
                var csv = reader.Csv;
                var headers = csv.GetFieldHeaders();
@@ -52,7 +58,7 @@ namespace OSPSuite.Infrastructure.Import.Core.DataSourceFileReaders
                {
                   csv.CopyCurrentRecordTo(currentRow);
                   var currentCultureDecimalSeparator = Convert.ToChar(Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-                  var rowList = currentRow.Select(x => x.Replace(csvSeparators.DecimalSeparator, currentCultureDecimalSeparator)).ToList();
+                  var rowList = currentRow.Select(x => x.Replace(_csvSeparators.DecimalSeparator, currentCultureDecimalSeparator)).ToList();
                   var levels = getMeasurementLevels(rowList);
                   dataSheet.CalculateColumnDescription(levels);
                   dataSheet.AddRow(rowList);

--- a/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileReaders/ExcelDataSourceFile.cs
+++ b/src/OSPSuite.Infrastructure.Import/Core/DataSourceFileReaders/ExcelDataSourceFile.cs
@@ -18,7 +18,7 @@ namespace OSPSuite.Infrastructure.Import.Core.DataSourceFileReaders
       {
       }
 
-      protected override void LoadFromFile(string path, CancellationToken cancellationToken = default)
+      protected override void DoLoadWork(string path, CancellationToken cancellationToken = default)
       {
          //we keep a copy of the already loaded sheets, in case the reading fails
          var alreadyLoadedDataSheets = DataSheets.Clone();

--- a/src/OSPSuite.Presentation/Presenters/Importer/ImporterDataPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Importer/ImporterDataPresenter.cs
@@ -216,7 +216,7 @@ namespace OSPSuite.Presentation.Presenters.Importer
 
       public void ReopenAllSheets()
       {
-         _dataSourceFile.Path = _dataSourceFile.Path;
+         _dataSourceFile.LoadFromFile(_dataSourceFile.Path);
          RefreshTabs();
       }
 

--- a/src/OSPSuite.UI/Views/Importer/CsvSeparatorSelectorView.cs
+++ b/src/OSPSuite.UI/Views/Importer/CsvSeparatorSelectorView.cs
@@ -3,6 +3,7 @@ using DevExpress.XtraEditors;
 using DevExpress.XtraLayout.Utils;
 using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Presenters.Importer;
+using OSPSuite.Presentation.Views;
 using OSPSuite.Presentation.Views.Importer;
 using static OSPSuite.Assets.Captions.Importer;
 
@@ -16,7 +17,7 @@ namespace OSPSuite.UI.Views.Importer
       private readonly List<char> _columnSeparatorList = new List<char> { Comma, ' ', ';', Period };
       private readonly List<char> _decimalSeparatorList = new List<char> { Period, Comma };
 
-      public CSVSeparatorSelectorView()
+      public CSVSeparatorSelectorView(IShell shell) : base(shell)
       {
          InitializeComponent();
          fillSeparatorComboBox();

--- a/src/OSPSuite.UI/Views/Importer/CsvSeparatorSelectorView.cs
+++ b/src/OSPSuite.UI/Views/Importer/CsvSeparatorSelectorView.cs
@@ -17,6 +17,11 @@ namespace OSPSuite.UI.Views.Importer
       private readonly List<char> _columnSeparatorList = new List<char> { Comma, ' ', ';', Period };
       private readonly List<char> _decimalSeparatorList = new List<char> { Period, Comma };
 
+      //only for design time
+      public CSVSeparatorSelectorView() : this(null)
+      {
+      }
+
       public CSVSeparatorSelectorView(IShell shell) : base(shell)
       {
          InitializeComponent();

--- a/tests/OSPSuite.Presentation.Tests/Importer/Core/DataSourceFileReaders/CsvDataSourceFileSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Core/DataSourceFileReaders/CsvDataSourceFileSpecs.cs
@@ -42,7 +42,7 @@ namespace OSPSuite.Presentation.Importer.Core.DataSourceFileReaders
 
       protected override void Because()
       {
-         sut.Path = _csvFilePath;
+         sut.LoadFromFile(_csvFilePath);
       }
 
       [TestCase]
@@ -123,7 +123,7 @@ namespace OSPSuite.Presentation.Importer.Core.DataSourceFileReaders
       [Observation]
       public void duplicate_header_file_throws_exception()
       {
-         Assert.Throws<InvalidObservedDataFileException>(() => sut.Path = _csvFilePath);
+         Assert.Throws<InvalidObservedDataFileException>(() => sut.LoadFromFile(_csvFilePath));
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Importer/Core/DataSourceFileReaders/ExcelDataSourceFileSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Core/DataSourceFileReaders/ExcelDataSourceFileSpecs.cs
@@ -25,10 +25,8 @@ namespace OSPSuite.Presentation.Importer.Core.DataSourceFileReaders
       {
          workManager = new HeavyWorkManagerForSpecs();
 
-         sut = new ExcelDataSourceFile(A.Fake<IImportLogger>(), workManager)
-         {
-            Path = _excelFilePath
-         };
+         sut = new ExcelDataSourceFile(A.Fake<IImportLogger>(), workManager);
+         sut.LoadFromFile(_excelFilePath);
       }
 
       public override void GlobalContext()
@@ -43,7 +41,7 @@ namespace OSPSuite.Presentation.Importer.Core.DataSourceFileReaders
       [TestCase]
       public void headers_are_adjusted_on_empty_columns()
       {
-         sut.Path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "sample2.xlsx");
+         sut.LoadFromFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "sample2.xlsx"));
          var columns = sut.DataSheets.ElementAt(0).GetHeaders();
          columns.Count().ShouldBeEqualTo(4);
          for (var i = 0; i < 4; i++)

--- a/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ImporterPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Importer/Presenters/ImporterPresenterSpecs.cs
@@ -238,7 +238,7 @@ namespace OSPSuite.Presentation.Importer.Presenters
 
          _dataSourceFile = new ExcelDataSourceFile(A.Fake<IImportLogger>(), new HeavyWorkManagerForSpecs());
          _dataSourceFile.Format = A.Fake<IDataFormat>();
-         _dataSourceFile.Path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "IntegrationSampleUnitFromColumn.xlsx");
+         _dataSourceFile.LoadFromFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "IntegrationSampleUnitFromColumn.xlsx"));
          A.CallTo(() => _importerDataPresenter.SetDataSource(A<string>.Ignored)).Returns(_dataSourceFile);
          _importerDataPresenter.OnImportSheets += Raise.With(new ImportSheetsEventArgs()
             { Filter = "", DataSourceFile = _dataSourceFile, SheetNames = _sheets.Keys.ToList() });


### PR DESCRIPTION
Fixes  #2834 Separator Selector is styled differently and pops-under pk-sim

# Description
We were opening a new dialog from within the heavyworkmanager and not setting the parent handle

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data file loading robustness and cancellation handling for CSV and Excel imports.

* **Refactor**
  * Restructured internal data source file loading mechanism for better separation of concerns.
  * Enhanced CSV separator management for more reliable file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->