### PR TITLE
Fixes #2836 Run (and some other actions) are not disabled in the context menu after a PI was started

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/ParameterIdentificationContextMenuItems.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
@@ -12,11 +14,12 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
 {
    public static class ParameterIdentificationContextMenuItems
    {
-      public static IMenuBarItem DeleteParameterIdentification(ParameterIdentification parameterIdentification, IContainer container)
+      public static IMenuBarItem DeleteParameterIdentification(ParameterIdentification parameterIdentification, IContainer container, bool isRunning)
       {
          return CreateMenuButton.WithCaption(MenuNames.Delete)
             .WithIcon(ApplicationIcons.Delete)
-            .WithCommandFor<DeleteParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container);
+            .WithCommandFor<DeleteParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container)
+            .AsDisabledIf(isRunning);
       }
 
       public static IMenuBarItem CreateParameterIdentification(IContainer container)
@@ -41,11 +44,12 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
             .WithCommandFor<EditParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container);
       }
 
-      public static IMenuBarItem RenameParameterIdentification(ParameterIdentification simulation, IContainer container)
+      public static IMenuBarItem RenameParameterIdentification(ParameterIdentification simulation, IContainer container, bool isRunning)
       {
          return CreateMenuButton.WithCaption(MenuNames.Rename)
             .WithCommandFor<RenameParameterIdentificationUICommand, ParameterIdentification>(simulation, container)
-            .WithIcon(ApplicationIcons.Rename);
+            .WithIcon(ApplicationIcons.Rename)
+            .AsDisabledIf(isRunning);
       }
 
       public static IMenuBarButton ExportParameterIdentificationToR(ParameterIdentification parameterIdentification, IContainer container)
@@ -76,22 +80,24 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
             .WithIcon(ApplicationIcons.AddToJournal);
       }
 
-      public static IMenuBarItem RunParameterIdentification(ParameterIdentification parameterIdentification, IContainer container)
+      public static IMenuBarItem RunParameterIdentification(ParameterIdentification parameterIdentification, IContainer container, bool isRunning)
       {
          return CreateMenuButton.WithCaption(MenuNames.RunParameterIdentification)
             .WithIcon(ApplicationIcons.Run)
-            .WithCommandFor<RunParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container);
+            .WithCommandFor<RunParameterIdentificationUICommand, ParameterIdentification>(parameterIdentification, container)
+            .AsDisabledIf(isRunning);
       }
 
       public static IEnumerable<IMenuBarItem> ContextMenuItemsFor(ParameterIdentification parameterIdentification, IContainer container)
       {
+         var isRunning = container.Resolve<IParameterIdentificationRunner>().RunningParameterIdentifications.Contains(parameterIdentification);
+
          yield return EditParameterIdentification(parameterIdentification, container);
-            
 
-         yield return RunParameterIdentification(parameterIdentification, container)
-            .AsGroupStarter(); 
+         yield return RunParameterIdentification(parameterIdentification, container, isRunning)
+            .AsGroupStarter();
 
-         yield return RenameParameterIdentification(parameterIdentification, container);
+         yield return RenameParameterIdentification(parameterIdentification, container, isRunning);
 
          yield return CloneParameterIdentification(parameterIdentification, container)
             .AsGroupStarter();
@@ -101,7 +107,7 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
          yield return ExportParameterIdentificationToMatlab(parameterIdentification, container)
             .ForDeveloper();
 
-         yield return DeleteParameterIdentification(parameterIdentification, container)
+         yield return DeleteParameterIdentification(parameterIdentification, container, isRunning)
             .AsGroupStarter();
       }
    }


### PR DESCRIPTION
Fixes #2836 Run (and some other actions) are not disabled in the context menu after a PI was started

# Description
It was not checked for running during context menu construction

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Context menu actions (Delete, Rename, Run) are now disabled while a parameter identification is running, preventing accidental interference with ongoing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->