### PR TITLE
Fixes #2839 Work around GoDiagram TypeLoadException on .NET 8

### DIFF
--- a/src/OSPSuite.UI/Views/Diagram/BaseDiagramOverview.cs
+++ b/src/OSPSuite.UI/Views/Diagram/BaseDiagramOverview.cs
@@ -15,30 +15,11 @@ namespace OSPSuite.UI.Views.Diagram
 
       public override bool DoContextClick(GoInputEventArgs evt)
       {
-         var obj = PickObject(true, false, evt.DocPoint, false);
-         if (obj == null)
-         {
-            RaiseBackgroundContextClicked(evt);
-            return false;
-         }
-
-         RaiseObjectContextClicked(obj, evt);
-         while (obj != null)
-         {
-            var strip = obj.GetContextMenuStrip(this);
-            if (strip != null)
-            {
-               strip.Show(this, evt.ViewPoint);
-               return true;
-            }
-
-            if (obj.OnContextClick(evt, this))
-               return true;
-
-            obj = obj.Parent;
-         }
-
-         return false;
+         return DiagramContextClick.Handle(
+            this,
+            evt,
+            RaiseObjectContextClicked,
+            RaiseBackgroundContextClicked);
       }
    }
 }

--- a/src/OSPSuite.UI/Views/Diagram/BaseDiagramOverview.cs
+++ b/src/OSPSuite.UI/Views/Diagram/BaseDiagramOverview.cs
@@ -1,0 +1,44 @@
+using Northwoods.Go;
+
+namespace OSPSuite.UI.Views.Diagram
+{
+   // .NET 8 workaround: GoOverview inherits the broken GoView.DoContextClick and
+   // the default GoToolContext in its mouse tools. Apply the same overrides so
+   // right-clicks inside an overview don't trigger TypeLoadException.
+   public class BaseDiagramOverview : GoOverview
+   {
+      public BaseDiagramOverview()
+      {
+         var contextTool = new SafeGoToolContext(this) { SingleSelection = false };
+         ReplaceMouseTool(typeof(GoToolContext), contextTool);
+      }
+
+      public override bool DoContextClick(GoInputEventArgs evt)
+      {
+         var obj = PickObject(true, false, evt.DocPoint, false);
+         if (obj == null)
+         {
+            RaiseBackgroundContextClicked(evt);
+            return false;
+         }
+
+         RaiseObjectContextClicked(obj, evt);
+         while (obj != null)
+         {
+            var strip = obj.GetContextMenuStrip(this);
+            if (strip != null)
+            {
+               strip.Show(this, evt.ViewPoint);
+               return true;
+            }
+
+            if (obj.OnContextClick(evt, this))
+               return true;
+
+            obj = obj.Parent;
+         }
+
+         return false;
+      }
+   }
+}

--- a/src/OSPSuite.UI/Views/Diagram/DiagramBaseView.cs
+++ b/src/OSPSuite.UI/Views/Diagram/DiagramBaseView.cs
@@ -55,36 +55,13 @@ namespace OSPSuite.UI.Views.Diagram
          return s;
       }
 
-      // .NET 8 workaround: GoView.DoContextClick references the removed
-      // System.Windows.Forms.ContextMenu type, so JITing it throws TypeLoadException.
-      // Replicate the base logic while omitting the legacy ContextMenu branch
-      // (nothing in OSPSuite/MoBi/PK-Sim uses GoObject.GetContextMenu — only ContextMenuStrip).
       public override bool DoContextClick(GoInputEventArgs evt)
       {
-         var obj = PickObject(true, false, evt.DocPoint, false);
-         if (obj == null)
-         {
-            RaiseBackgroundContextClicked(evt);
-            return false;
-         }
-
-         RaiseObjectContextClicked(obj, evt);
-         while (obj != null)
-         {
-            var strip = obj.GetContextMenuStrip(this);
-            if (strip != null)
-            {
-               strip.Show(this, evt.ViewPoint);
-               return true;
-            }
-
-            if (obj.OnContextClick(evt, this))
-               return true;
-
-            obj = obj.Parent;
-         }
-
-         return false;
+         return DiagramContextClick.Handle(
+            this,
+            evt,
+            RaiseObjectContextClicked,
+            RaiseBackgroundContextClicked);
       }
    }
 
@@ -101,8 +78,13 @@ namespace OSPSuite.UI.Views.Diagram
 
       public override void Start()
       {
+         // Mirror the base Start() semantics minus the legacy ContextMenu branch:
+         // only latch CurrentObject when the View has a ContextMenuStrip set.
+         // OSPSuite never sets one, so in practice this is a no-op — which
+         // matches the base method's observable behaviour and means right-clicks
+         // do not alter selection state implicitly.
          var view = View;
-         if (view == null)
+         if (view?.ContextMenuStrip == null)
             return;
 
          CurrentObject = view.PickObject(true, false, LastInput.DocPoint, false);

--- a/src/OSPSuite.UI/Views/Diagram/DiagramBaseView.cs
+++ b/src/OSPSuite.UI/Views/Diagram/DiagramBaseView.cs
@@ -18,8 +18,11 @@ namespace OSPSuite.UI.Views.Diagram
          NewLinkPrototype = new NewLink();
          PortGravity = Assets.Diagram.Base.PortGravity; // controls the distance within a port to be linked is snapped
 
-         GoToolContext tool = FindMouseTool(typeof(GoToolContext)) as GoToolContext;
-         tool.SingleSelection = false;
+         // .NET 8 workaround: replace the default GoToolContext with a subclass
+         // whose Start() doesn't JIT a local of the removed
+         // System.Windows.Forms.ContextMenu type.
+         var contextTool = new SafeGoToolContext(this) { SingleSelection = false };
+         ReplaceMouseTool(typeof(GoToolContext), contextTool);
 
          MouseMoveTools.Insert(0, new CustomZooming(this));
          MouseMoveTools.Insert(0, new CustomRubberBanding(this));
@@ -43,14 +46,76 @@ namespace OSPSuite.UI.Views.Diagram
 
       public override float LimitDocScale(float s)
       {
-         if (s < Assets.Diagram.Base.MinLimitDocScale) 
+         if (s < Assets.Diagram.Base.MinLimitDocScale)
             return Assets.Diagram.Base.MinLimitDocScale;
 
-         if (s > Assets.Diagram.Base.MaxLimitDocScale) 
+         if (s > Assets.Diagram.Base.MaxLimitDocScale)
             return Assets.Diagram.Base.MaxLimitDocScale;
 
          return s;
       }
 
+      // .NET 8 workaround: GoView.DoContextClick references the removed
+      // System.Windows.Forms.ContextMenu type, so JITing it throws TypeLoadException.
+      // Replicate the base logic while omitting the legacy ContextMenu branch
+      // (nothing in OSPSuite/MoBi/PK-Sim uses GoObject.GetContextMenu — only ContextMenuStrip).
+      public override bool DoContextClick(GoInputEventArgs evt)
+      {
+         var obj = PickObject(true, false, evt.DocPoint, false);
+         if (obj == null)
+         {
+            RaiseBackgroundContextClicked(evt);
+            return false;
+         }
+
+         RaiseObjectContextClicked(obj, evt);
+         while (obj != null)
+         {
+            var strip = obj.GetContextMenuStrip(this);
+            if (strip != null)
+            {
+               strip.Show(this, evt.ViewPoint);
+               return true;
+            }
+
+            if (obj.OnContextClick(evt, this))
+               return true;
+
+            obj = obj.Parent;
+         }
+
+         return false;
+      }
+   }
+
+   // .NET 8 workaround: GoToolContext.Start() declares a local of the removed
+   // System.Windows.Forms.ContextMenu type, so JITing it throws TypeLoadException.
+   // Override it to replicate the essential behaviour (CurrentObject pickup) while
+   // skipping the legacy native-menu suppression path (OSPSuite never assigns
+   // Control.ContextMenu or ContextMenuStrip on the GoView anyway).
+   internal class SafeGoToolContext : GoToolContext
+   {
+      public SafeGoToolContext(GoView view) : base(view)
+      {
+      }
+
+      public override void Start()
+      {
+         var view = View;
+         if (view == null)
+            return;
+
+         CurrentObject = view.PickObject(true, false, LastInput.DocPoint, false);
+      }
+
+      public override void Stop()
+      {
+         // Base.Stop() reads the private myBackgroundContextMenu field (typed as
+         // the removed System.Windows.Forms.ContextMenu), which triggers
+         // TypeLoadException on JIT. Our Start() override never populates that
+         // field or its ContextMenuStrip sibling, so there is nothing to restore —
+         // just clear CurrentObject.
+         CurrentObject = null;
+      }
    }
 }

--- a/src/OSPSuite.UI/Views/Diagram/DiagramContextClick.cs
+++ b/src/OSPSuite.UI/Views/Diagram/DiagramContextClick.cs
@@ -1,0 +1,45 @@
+using System;
+using Northwoods.Go;
+
+namespace OSPSuite.UI.Views.Diagram
+{
+   // Shared body for DoContextClick overrides used by DiagramBaseView and
+   // BaseDiagramOverview. The base GoView.DoContextClick references the removed
+   // System.Windows.Forms.ContextMenu type, so JITing it throws
+   // TypeLoadException on .NET 8. This helper replicates the base logic while
+   // omitting the legacy ContextMenu branch.
+   internal static class DiagramContextClick
+   {
+      public static bool Handle(
+         GoView view,
+         GoInputEventArgs evt,
+         Action<GoObject, GoInputEventArgs> raiseObjectContextClicked,
+         Action<GoInputEventArgs> raiseBackgroundContextClicked)
+      {
+         var obj = view.PickObject(true, false, evt.DocPoint, false);
+         if (obj == null)
+         {
+            raiseBackgroundContextClicked(evt);
+            return false;
+         }
+
+         raiseObjectContextClicked(obj, evt);
+         while (obj != null)
+         {
+            var strip = obj.GetContextMenuStrip(view);
+            if (strip != null)
+            {
+               strip.Show(view, evt.ViewPoint);
+               return true;
+            }
+
+            if (obj.OnContextClick(evt, view))
+               return true;
+
+            obj = obj.Parent;
+         }
+
+         return false;
+      }
+   }
+}


### PR DESCRIPTION
Fixes https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/issues/2839 Work around GoDiagram TypeLoadException on .NET 8

This is completely reverse engineered by Claude by decompiling the GoDiagram assemblies. I verified that the context menus are back in V13 with this fix.


## Summary
- `Northwoods.GoWin 5.2.0` is compiled against .NET Framework and references `System.Windows.Forms.ContextMenu`, which was removed from WinForms in .NET Core 3+. JITing `GoView.DoContextClick`, `GoToolContext.Start`, or `GoToolContext.Stop` therefore throws `TypeLoadException` the first time any diagram view handles a mouse event on .NET 8.
- Override the three broken methods on our `DiagramBaseView` (and the new `BaseDiagramOverview : GoOverview`) so the vtable dispatches to bodies that never reference the removed type. A nested `SafeGoToolContext` replaces the default `GoToolContext` in each view's mouse tools.
- The workaround keeps the existing `Northwoods.GoWin` binary — no upgrade

## Test plan
- [x] Right-click in empty area of a Reaction Diagram in MoBi — expect the context menu, no exception.
- [x] Right-click on a reaction node.
- [x] Right-click in a Journal Diagram (background + node).
- [x] Right-click inside the overview thumbnail (Spatial Structure and Simulation views in MoBi both instantiate `BaseDiagramOverview`).
- [x] Confirm Model and Space diagrams still behave normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-menu handling in diagram views with enhanced stability and reliability
  * Enhanced hierarchical context-menu support for nested elements when right-clicking
  * Implemented safer tool context management to prevent selection-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->