### PR TITLE
Fixes #2841 Add optional PKSimModule property to Input

### DIFF
--- a/src/OSPSuite.Core/Qualification/Input.cs
+++ b/src/OSPSuite.Core/Qualification/Input.cs
@@ -10,6 +10,12 @@ namespace OSPSuite.Core.Qualification
 
       public string Project { get; set; }
 
+      /// <summary>
+      ///    Optional. For MoBi qualification plans, the name of the PK-Sim module inside the
+      ///    MoBi project that this input should be resolved against.
+      /// </summary>
+      public string PKSimModule { get; set; }
+
       public int? SectionId { get; set; }
 
       public string SectionReference { get; set; }


### PR DESCRIPTION
## Summary
- Add optional `PKSimModule` property on `OSPSuite.Core.Qualification.Input`
- Backwards compatible — existing plans that omit the field are unchanged

## Test plan
- [x] MoBi qualification plan with `Input.PKSimModule` set routes through to PK-Sim's per-module input export (verified end-to-end against Amikacin-Model, with companion MoBi-side remap change)
- [x] MoBi qualification plan without `Input.PKSimModule` still works (current PK-Sim-compatible behaviour)
- [x] PK-Sim qualification plan unchanged

Fixes #2841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced qualification planning with the ability to specify which PK-Sim module within a MoBi project should be referenced for resolving inputs, enabling better handling of multi-module project scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->