### PR TITLE
Fixes #2843 Add molecule accessors to MoleculeBuildingBlock

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/MoleculeBuildingBlock.cs
+++ b/src/OSPSuite.Core/Domain/Builder/MoleculeBuildingBlock.cs
@@ -15,6 +15,22 @@ namespace OSPSuite.Core.Domain.Builder
 
       public IEnumerable<MoleculeBuilder> AllFloating() => this.Where(x => x.IsFloating);
 
+      public IEnumerable<MoleculeBuilder> AllStationary() => this.Where(x => !x.IsFloating);
+
+      public IEnumerable<MoleculeBuilder> AllXenobiotic() => this.Where(x => x.IsXenobiotic);
+
+      public IEnumerable<MoleculeBuilder> AllEndogenous() => this.Where(x => !x.IsXenobiotic);
+
+      public IEnumerable<MoleculeBuilder> AllOfType(QuantityType quantityType) => this.Where(x => x.QuantityType.Is(quantityType));
+
+      public IEnumerable<MoleculeBuilder> AllXenobioticFloating() => this.Where(x => x.IsXenobiotic && x.IsFloating);
+
+      public IEnumerable<MoleculeBuilder> AllXenobioticStationary() => this.Where(x => x.IsXenobiotic && !x.IsFloating);
+
+      public IEnumerable<MoleculeBuilder> AllEndogenousFloating() => this.Where(x => !x.IsXenobiotic && x.IsFloating);
+
+      public IEnumerable<MoleculeBuilder> AllEndogenousStationary() => this.Where(x => !x.IsXenobiotic && !x.IsFloating);
+
       public IEnumerable<MoleculeBuilder> AllPresentFor(IEnumerable<InitialConditionsBuildingBlock> initialConditions)
       {
          var moleculeNames = initialConditions.SelectMany(x => x)

--- a/tests/OSPSuite.Core.Tests/Domain/MoleculeBuildingBlockSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/MoleculeBuildingBlockSpecs.cs
@@ -75,4 +75,198 @@ namespace OSPSuite.Core.Domain
          _results.ShouldOnlyContain(_drug,_molecule);
       }
    }
+
+   public abstract class concern_for_MoleculeBuildingBlock_filters : concern_for_MoleculeBuildingBlock
+   {
+      protected MoleculeBuilder _xenobioticFloatingDrug;
+      protected MoleculeBuilder _xenobioticStationaryDrug;
+      protected MoleculeBuilder _endogenousFloatingEnzyme;
+      protected MoleculeBuilder _endogenousStationaryEnzyme;
+      protected MoleculeBuilder _endogenousStationaryTransporter;
+      protected MoleculeBuilder _endogenousStationaryOtherProtein;
+
+      protected override void Context()
+      {
+         base.Context();
+         _xenobioticFloatingDrug = addMolecule("XenoFloatingDrug", isFloating: true, QuantityType.Drug, isXenobiotic: true);
+         _xenobioticStationaryDrug = addMolecule("XenoStationaryDrug", isFloating: false, QuantityType.Drug, isXenobiotic: true);
+         _endogenousFloatingEnzyme = addMolecule("EndoFloatingEnzyme", isFloating: true, QuantityType.Enzyme, isXenobiotic: false);
+         _endogenousStationaryEnzyme = addMolecule("EndoStationaryEnzyme", isFloating: false, QuantityType.Enzyme, isXenobiotic: false);
+         _endogenousStationaryTransporter = addMolecule("EndoStationaryTransporter", isFloating: false, QuantityType.Transporter, isXenobiotic: false);
+         _endogenousStationaryOtherProtein = addMolecule("EndoStationaryOtherProtein", isFloating: false, QuantityType.OtherProtein, isXenobiotic: false);
+      }
+
+      private MoleculeBuilder addMolecule(string name, bool isFloating, QuantityType quantityType, bool isXenobiotic)
+      {
+         var molecule = new MoleculeBuilder
+         {
+            Name = name,
+            IsFloating = isFloating,
+            QuantityType = quantityType,
+            IsXenobiotic = isXenobiotic
+         };
+         sut.Add(molecule);
+         return molecule;
+      }
+   }
+
+   public class When_retrieving_all_floating_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllFloating();
+      }
+
+      [Observation]
+      public void should_return_only_floating_molecules()
+      {
+         _results.ShouldOnlyContain(_xenobioticFloatingDrug, _endogenousFloatingEnzyme);
+      }
+   }
+
+   public class When_retrieving_all_stationary_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllStationary();
+      }
+
+      [Observation]
+      public void should_return_only_stationary_molecules()
+      {
+         _results.ShouldOnlyContain(_xenobioticStationaryDrug, _endogenousStationaryEnzyme, _endogenousStationaryTransporter, _endogenousStationaryOtherProtein);
+      }
+   }
+
+   public class When_retrieving_all_xenobiotic_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllXenobiotic();
+      }
+
+      [Observation]
+      public void should_return_only_xenobiotic_molecules()
+      {
+         _results.ShouldOnlyContain(_xenobioticFloatingDrug, _xenobioticStationaryDrug);
+      }
+   }
+
+   public class When_retrieving_all_endogenous_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllEndogenous();
+      }
+
+      [Observation]
+      public void should_return_only_endogenous_molecules()
+      {
+         _results.ShouldOnlyContain(_endogenousFloatingEnzyme, _endogenousStationaryEnzyme, _endogenousStationaryTransporter, _endogenousStationaryOtherProtein);
+      }
+   }
+
+   public class When_retrieving_all_molecules_of_a_specific_quantity_type : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllOfType(QuantityType.Drug);
+      }
+
+      [Observation]
+      public void should_return_only_molecules_with_that_type()
+      {
+         _results.ShouldOnlyContain(_xenobioticFloatingDrug, _xenobioticStationaryDrug);
+      }
+   }
+
+   public class When_retrieving_all_molecules_of_a_composite_quantity_type : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllOfType(QuantityType.Protein);
+      }
+
+      [Observation]
+      public void should_return_molecules_whose_type_is_a_subset_of_the_composite_type()
+      {
+         _results.ShouldOnlyContain(_endogenousFloatingEnzyme, _endogenousStationaryEnzyme, _endogenousStationaryTransporter, _endogenousStationaryOtherProtein);
+      }
+   }
+
+   public class When_retrieving_all_xenobiotic_floating_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllXenobioticFloating();
+      }
+
+      [Observation]
+      public void should_return_only_xenobiotic_floating_molecules()
+      {
+         _results.ShouldOnlyContain(_xenobioticFloatingDrug);
+      }
+   }
+
+   public class When_retrieving_all_xenobiotic_stationary_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllXenobioticStationary();
+      }
+
+      [Observation]
+      public void should_return_only_xenobiotic_stationary_molecules()
+      {
+         _results.ShouldOnlyContain(_xenobioticStationaryDrug);
+      }
+   }
+
+   public class When_retrieving_all_endogenous_floating_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllEndogenousFloating();
+      }
+
+      [Observation]
+      public void should_return_only_endogenous_floating_molecules()
+      {
+         _results.ShouldOnlyContain(_endogenousFloatingEnzyme);
+      }
+   }
+
+   public class When_retrieving_all_endogenous_stationary_molecules : concern_for_MoleculeBuildingBlock_filters
+   {
+      private IEnumerable<MoleculeBuilder> _results;
+
+      protected override void Because()
+      {
+         _results = sut.AllEndogenousStationary();
+      }
+
+      [Observation]
+      public void should_return_only_endogenous_stationary_molecules()
+      {
+         _results.ShouldOnlyContain(_endogenousStationaryEnzyme, _endogenousStationaryTransporter, _endogenousStationaryOtherProtein);
+      }
+   }
 }


### PR DESCRIPTION
## Summary
- Add filter accessors on `MoleculeBuildingBlock`: `AllStationary`, `AllXenobiotic`, `AllEndogenous`, `AllOfType(QuantityType)`, `AllXenobioticFloating`, `AllXenobioticStationary`, `AllEndogenousFloating`, `AllEndogenousStationary`.
- `AllOfType` uses `QuantityType.Is`, so composite flags (e.g. `QuantityType.Protein`) match all members (`Enzyme`, `Transporter`, `OtherProtein`).
- Lets consumers like MoBi ([MoBi#2366](https://github.com/Open-Systems-Pharmacology/MoBi/pull/2366)) delegate filtering instead of reimplementing it.

## Test plan
- [x] New `MoleculeBuildingBlockSpecs` observations — 10 new tests passing, all 1252 `OSPSuite.Core.Domain` tests green.
- [x] Verified downstream MoBi build (`MoBi.R.Tests`) after packing local NuGet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced filtering options to retrieve molecules by their properties: floating or stationary status, xenobiotic or endogenous classification, and quantity type.

* **Tests**
  * Added comprehensive test coverage for new filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->