### PR TITLE
Fixes #2845 Add CompoundCondition for mixed AND/OR descriptor criteria

### DIFF
--- a/src/OSPSuite.Core/Domain/Descriptors/CompoundCondition.cs
+++ b/src/OSPSuite.Core/Domain/Descriptors/CompoundCondition.cs
@@ -1,0 +1,27 @@
+using OSPSuite.Utility.Extensions;
+
+namespace OSPSuite.Core.Domain.Descriptors;
+
+public class CompoundCondition : DescriptorCriteria, ITagCondition
+{
+   //compound conditions have no tag of their own; expose empty so RemoveByTag never matches
+   public string Tag => string.Empty;
+
+   public string Condition => $"({base.ToString()})";
+
+   public ITagCondition CloneCondition()
+   {
+      return cloneCondition();
+   }
+
+   private CompoundCondition cloneCondition()
+   {
+      var clone = new CompoundCondition { Operator = Operator };
+      this.Each(c => clone.Add(c.CloneCondition()));
+      return clone;
+   }
+
+   public override DescriptorCriteria Clone() => cloneCondition();
+
+   public override string ToString() => Condition;
+}

--- a/src/OSPSuite.Core/Domain/Descriptors/DescriptorCriteria.cs
+++ b/src/OSPSuite.Core/Domain/Descriptors/DescriptorCriteria.cs
@@ -63,6 +63,15 @@ namespace OSPSuite.Core.Domain.Descriptors
       }
 
       /// <summary>
+      ///    Replaces every occurrence of <paramref name="keyword" /> with <paramref name="replacement" /> across all
+      ///    conditions, recursing into compound conditions.
+      /// </summary>
+      public void Replace(string keyword, string replacement)
+      {
+         this.Each(x => x.Replace(keyword, replacement));
+      }
+
+      /// <summary>
       ///    Removes all tag conditions for the given <paramref name="tag" />
       /// </summary>
       /// <typeparam name="T">
@@ -82,7 +91,7 @@ namespace OSPSuite.Core.Domain.Descriptors
          conditionsToRemove.Each(condition => Remove(condition));
       }
 
-      public DescriptorCriteria Clone()
+      public virtual DescriptorCriteria Clone()
       {
          var clone = new DescriptorCriteria();
          this.Each(x => clone.Add(x.CloneCondition()));

--- a/src/OSPSuite.Core/Domain/Descriptors/DescriptorCriteriaExpressions.cs
+++ b/src/OSPSuite.Core/Domain/Descriptors/DescriptorCriteriaExpressions.cs
@@ -65,6 +65,18 @@ namespace OSPSuite.Core.Domain.Descriptors
          return this;
       }
 
+      public DescriptorCriteriaBuilder Compound(Action<DescriptorCriteriaBuilder> innerAction)
+      {
+         var innerBuilder = new DescriptorCriteriaBuilder();
+         innerAction(innerBuilder);
+         var innerCriteria = innerBuilder.Build();
+         var compound = new CompoundCondition { Operator = innerCriteria.Operator };
+         foreach (var condition in innerCriteria)
+            compound.Add(condition);
+         _criteria.Add(compound);
+         return this;
+      }
+
       public DescriptorCriteria Build()
       {
          return _criteria;

--- a/src/OSPSuite.Core/Serialization/Xml/DescriptorCriteriaXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/DescriptorCriteriaXmlSerializer.cs
@@ -4,13 +4,17 @@ using OSPSuite.Serializer;
 
 namespace OSPSuite.Core.Serialization.Xml
 {
-   public class DescriptorCriteriaXmlSerializer : OSPSuiteXmlSerializer<DescriptorCriteria>
+   public abstract class DescriptorCriteriaXmlSerializerBase<T> : OSPSuiteXmlSerializer<T> where T : DescriptorCriteria
    {
       public override void PerformMapping()
       {
          Map(x => x.Operator);
          MapEnumerable(x => x, x => x.Add).WithMappingName(Constants.Serialization.DESCRIPTOR_CONDITIONS);
       }
+   }
+
+   public class DescriptorCriteriaXmlSerializer : DescriptorCriteriaXmlSerializerBase<DescriptorCriteria>
+   {
    }
 
    public abstract class TagConditionXmlSerializer<T> : OSPSuiteXmlSerializer<T> where T : ITagCondition
@@ -58,6 +62,10 @@ namespace OSPSuite.Core.Serialization.Xml
    }
 
    public class NotInContainerConditionXmlSerializer : TagConditionXmlSerializer<NotInContainerCondition>
+   {
+   }
+
+   public class CompoundConditionXmlSerializer : DescriptorCriteriaXmlSerializerBase<CompoundCondition>
    {
    }
 

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/ProcessBuilderXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/ProcessBuilderXmlSerializerSpecs.cs
@@ -109,4 +109,50 @@ namespace OSPSuite.Core.Serializers
          AssertForSpecs.AreEqualReactionBuilder(x1, x2);
       }
    }
+
+   public class ReactionBuilderWithCompoundCriteriaXmlSerializerSpecs : ModelingXmlSerializerBaseSpecs
+   {
+      [Test]
+      public void TestSerialization()
+      {
+         var reactionBuilder = CreateObject<ReactionBuilder>().WithName("CompoundCriteria.Builder");
+         reactionBuilder.Formula = CreateObject<ConstantFormula>().WithDimension(DimensionLength).WithValue(23.4);
+         //(VenousBlood AND Plasma) OR (Muscle AND Interstitial)
+         reactionBuilder.ContainerCriteria = Create.Criteria(c => c
+            .Compound(g => g.With("VenousBlood").And.With("Plasma"))
+            .With(CriteriaOperator.Or)
+            .Compound(g => g.With("Muscle").And.With("Interstitial")));
+
+         reactionBuilder.AddEduct(new ReactionPartnerBuilder("H2", 2.0));
+         reactionBuilder.AddProduct(new ReactionPartnerBuilder("H2O", 2.0));
+
+         var deserializedReactionBuilder = SerializeAndDeserialize(reactionBuilder);
+
+         AssertForSpecs.AreEqualReactionBuilder(reactionBuilder, deserializedReactionBuilder);
+      }
+   }
+
+   public class PassiveTransportBuilderWithCompoundCriteriaXmlSerializerSpecs : ModelingXmlSerializerBaseSpecs
+   {
+      [Test]
+      public void TestSerialization()
+      {
+         var transportBuilder = CreateObject<TransportBuilder>().WithName("CompoundCriteria.Transport");
+         transportBuilder.Formula = CreateObject<ConstantFormula>().WithDimension(DimensionLength).WithValue(23.4);
+
+         transportBuilder.SourceCriteria = Create.Criteria(c => c
+            .Compound(g => g.With("VenousBlood").And.With("Plasma"))
+            .With(CriteriaOperator.Or)
+            .Compound(g => g.With("Muscle").And.With("Interstitial")));
+         transportBuilder.TargetCriteria = new DescriptorCriteria { new NotMatchTagCondition("Venous") };
+
+         transportBuilder.TransportType = TransportType.Diffusion;
+         transportBuilder.MoleculeList.ForAll = !transportBuilder.MoleculeList.ForAll;
+         transportBuilder.AddMoleculeName("A");
+
+         var deserializedTransportBuilder = SerializeAndDeserialize(transportBuilder);
+
+         AssertForSpecs.AreEqualTransportBuilder(transportBuilder, deserializedTransportBuilder);
+      }
+   }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/CompoundConditionSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/CompoundConditionSpecs.cs
@@ -1,0 +1,251 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Descriptors;
+using OSPSuite.Utility.Extensions;
+
+namespace OSPSuite.Core.Domain
+{
+   public abstract class concern_for_CompoundCondition : ContextSpecification<CompoundCondition>
+   {
+      protected EntityDescriptor _entityDescriptor;
+
+      protected override void Context()
+      {
+         _entityDescriptor = new EntityDescriptor(new Parameter());
+         sut = new CompoundCondition();
+      }
+   }
+
+   public class When_evaluating_an_empty_compound_condition : concern_for_CompoundCondition
+   {
+      [Observation]
+      public void should_not_be_satisfied()
+      {
+         //empty compound has no conditions; mirrors DescriptorCriteria's empty-criteria behaviour
+         sut.IsSatisfiedBy(_entityDescriptor).ShouldBeFalse();
+      }
+   }
+
+   public class When_evaluating_an_AND_compound_with_all_inner_satisfied : concern_for_CompoundCondition
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         var firstInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => firstInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(true);
+         var secondInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => secondInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(true);
+         sut.Add(firstInnerCondition);
+         sut.Add(secondInnerCondition);
+      }
+
+      [Observation]
+      public void should_be_satisfied()
+      {
+         sut.IsSatisfiedBy(_entityDescriptor).ShouldBeTrue();
+      }
+   }
+
+   public class When_evaluating_an_AND_compound_with_one_inner_unsatisfied : concern_for_CompoundCondition
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         var firstInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => firstInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(true);
+         var secondInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => secondInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(false);
+         sut.Add(firstInnerCondition);
+         sut.Add(secondInnerCondition);
+      }
+
+      [Observation]
+      public void should_not_be_satisfied()
+      {
+         sut.IsSatisfiedBy(_entityDescriptor).ShouldBeFalse();
+      }
+   }
+
+   public class When_evaluating_an_OR_compound_with_one_inner_satisfied : concern_for_CompoundCondition
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.Or;
+         var firstInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => firstInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(false);
+         var secondInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => secondInnerCondition.IsSatisfiedBy(_entityDescriptor)).Returns(true);
+         sut.Add(firstInnerCondition);
+         sut.Add(secondInnerCondition);
+      }
+
+      [Observation]
+      public void should_be_satisfied()
+      {
+         sut.IsSatisfiedBy(_entityDescriptor).ShouldBeTrue();
+      }
+   }
+
+   public class When_cloning_a_compound_condition : concern_for_CompoundCondition
+   {
+      private CompoundCondition _clonedCompound;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.Or;
+         sut.Add(new MatchTagCondition("VenousBlood"));
+         sut.Add(new MatchTagCondition("Plasma"));
+      }
+
+      protected override void Because()
+      {
+         _clonedCompound = sut.CloneCondition().DowncastTo<CompoundCondition>();
+      }
+
+      [Observation]
+      public void should_clone_the_operator()
+      {
+         _clonedCompound.Operator.ShouldBeEqualTo(CriteriaOperator.Or);
+      }
+
+      [Observation]
+      public void should_deep_clone_the_inner_conditions()
+      {
+         _clonedCompound.Count.ShouldBeEqualTo(2);
+         _clonedCompound[0].ShouldBeAnInstanceOf<MatchTagCondition>();
+         _clonedCompound[0].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("VenousBlood");
+      }
+
+      [Observation]
+      public void clone_should_not_share_inner_list_with_original()
+      {
+         _clonedCompound.Add(new MatchTagCondition("Other"));
+         sut.Count.ShouldBeEqualTo(2);
+      }
+   }
+
+   public class When_replacing_a_keyword_in_a_compound_condition : concern_for_CompoundCondition
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Add(new MatchTagCondition("VenousBlood"));
+         sut.Add(new MatchTagCondition("Plasma"));
+      }
+
+      protected override void Because()
+      {
+         sut.Replace("VenousBlood", "ArterialBlood");
+      }
+
+      [Observation]
+      public void should_replace_the_keyword_in_inner_conditions()
+      {
+         sut[0].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("ArterialBlood");
+         sut[1].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("Plasma");
+      }
+   }
+
+   public class When_rendering_a_compound_to_string : concern_for_CompoundCondition
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         sut.Add(new MatchTagCondition("VenousBlood"));
+         sut.Add(new MatchTagCondition("Plasma"));
+      }
+
+      [Observation]
+      public void should_render_with_parentheses_around_the_inner_expression()
+      {
+         sut.Condition.ShouldBeEqualTo("(VenousBlood AND Plasma)");
+      }
+   }
+
+   public class When_comparing_two_equivalent_compound_conditions : concern_for_CompoundCondition
+   {
+      private CompoundCondition _equivalentCompound;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.Or;
+         sut.Add(new MatchTagCondition("A"));
+         sut.Add(new MatchTagCondition("B"));
+
+         _equivalentCompound = new CompoundCondition { Operator = CriteriaOperator.Or };
+         _equivalentCompound.Add(new MatchTagCondition("A"));
+         _equivalentCompound.Add(new MatchTagCondition("B"));
+      }
+
+      [Observation]
+      public void should_be_equal()
+      {
+         sut.Equals(_equivalentCompound).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_have_the_same_hash_code()
+      {
+         sut.GetHashCode().ShouldBeEqualTo(_equivalentCompound.GetHashCode());
+      }
+   }
+
+   public class When_comparing_two_compound_conditions_with_different_operator : concern_for_CompoundCondition
+   {
+      private CompoundCondition _compoundWithDifferentOperator;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         sut.Add(new MatchTagCondition("A"));
+
+         _compoundWithDifferentOperator = new CompoundCondition { Operator = CriteriaOperator.Or };
+         _compoundWithDifferentOperator.Add(new MatchTagCondition("A"));
+      }
+
+      [Observation]
+      public void should_not_be_equal()
+      {
+         sut.Equals(_compoundWithDifferentOperator).ShouldBeFalse();
+      }
+   }
+
+   public class When_comparing_a_compound_condition_to_a_plain_descriptor_criteria_with_same_contents : concern_for_CompoundCondition
+   {
+      private DescriptorCriteria _plainCriteriaWithSameContents;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         sut.Add(new MatchTagCondition("A"));
+
+         _plainCriteriaWithSameContents = new DescriptorCriteria { Operator = CriteriaOperator.And };
+         _plainCriteriaWithSameContents.Add(new MatchTagCondition("A"));
+      }
+
+      [Observation]
+      public void should_be_equal_because_they_match_the_same_criteria()
+      {
+         sut.Equals(_plainCriteriaWithSameContents).ShouldBeTrue();
+         _plainCriteriaWithSameContents.Equals(sut).ShouldBeTrue();
+      }
+   }
+
+   public class When_inspecting_the_tag_of_a_compound_condition : concern_for_CompoundCondition
+   {
+      [Observation]
+      public void should_return_empty_string()
+      {
+         sut.Tag.ShouldBeEqualTo(string.Empty);
+      }
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Domain/DescriptorCriteriaExpressionsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/DescriptorCriteriaExpressionsSpecs.cs
@@ -1,0 +1,68 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Descriptors;
+using OSPSuite.Utility.Extensions;
+
+namespace OSPSuite.Core.Domain
+{
+   public class When_building_a_descriptor_criteria_with_a_compound : StaticContextSpecification
+   {
+      private DescriptorCriteria _criteria;
+
+      protected override void Because()
+      {
+         _criteria = Create.Criteria(c => c
+            .Compound(g => g.With("VenousBlood").And.With("Plasma"))
+            .With(CriteriaOperator.Or)
+            .Compound(g => g.With("Muscle").And.With("Interstitial")));
+      }
+
+      [Observation]
+      public void should_set_the_outer_operator_to_or()
+      {
+         _criteria.Operator.ShouldBeEqualTo(CriteriaOperator.Or);
+      }
+
+      [Observation]
+      public void should_contain_two_compound_conditions()
+      {
+         _criteria.Count.ShouldBeEqualTo(2);
+         _criteria[0].ShouldBeAnInstanceOf<CompoundCondition>();
+         _criteria[1].ShouldBeAnInstanceOf<CompoundCondition>();
+      }
+
+      [Observation]
+      public void each_compound_should_default_to_AND_for_its_inner_operator()
+      {
+         _criteria[0].DowncastTo<CompoundCondition>().Operator.ShouldBeEqualTo(CriteriaOperator.And);
+         _criteria[1].DowncastTo<CompoundCondition>().Operator.ShouldBeEqualTo(CriteriaOperator.And);
+      }
+
+      [Observation]
+      public void should_populate_inner_conditions()
+      {
+         var firstCompoundInner = _criteria[0].DowncastTo<CompoundCondition>();
+         firstCompoundInner.Count.ShouldBeEqualTo(2);
+         firstCompoundInner[0].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("VenousBlood");
+         firstCompoundInner[1].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("Plasma");
+      }
+   }
+
+   public class When_building_a_compound_with_an_explicit_inner_operator : StaticContextSpecification
+   {
+      private DescriptorCriteria _criteria;
+
+      protected override void Because()
+      {
+         _criteria = Create.Criteria(c => c
+            .Compound(g => g.With("A").With(CriteriaOperator.Or).With("B")));
+      }
+
+      [Observation]
+      public void should_set_the_inner_operator()
+      {
+         _criteria[0].DowncastTo<CompoundCondition>().Operator.ShouldBeEqualTo(CriteriaOperator.Or);
+      }
+   }
+
+}

--- a/tests/OSPSuite.Core.Tests/Domain/DescriptorCriteriaSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/DescriptorCriteriaSpecs.cs
@@ -324,4 +324,255 @@ namespace OSPSuite.Core.Domain
          sut.ShouldContain(_inContainerCondition);
       }
    }
+
+   public abstract class concern_for_DescriptorCriteria_with_compound : ContextSpecification<DescriptorCriteria>
+   {
+      protected override void Context()
+      {
+         //sut models: (VenousBlood AND Plasma) OR (Muscle AND Interstitial)
+         sut = new DescriptorCriteria { Operator = CriteriaOperator.Or };
+         sut.Add(buildCompound(CriteriaOperator.And, new MatchTagCondition("VenousBlood"), new MatchTagCondition("Plasma")));
+         sut.Add(buildCompound(CriteriaOperator.And, new MatchTagCondition("Muscle"), new MatchTagCondition("Interstitial")));
+      }
+
+      protected static CompoundCondition buildCompound(CriteriaOperator innerOperator, params ITagCondition[] innerConditions)
+      {
+         var compound = new CompoundCondition { Operator = innerOperator };
+         foreach (var condition in innerConditions)
+            compound.Add(condition);
+         return compound;
+      }
+
+      protected IEntity entityWithTags(params string[] tags)
+      {
+         var entity = new Parameter().WithName("para");
+         foreach (var tag in tags)
+            entity.AddTag(tag);
+         return entity;
+      }
+   }
+
+   public class When_outer_OR_of_two_AND_compounds_matches_the_first_branch : concern_for_DescriptorCriteria_with_compound
+   {
+      [Observation]
+      public void should_satisfy_for_an_entity_tagged_VenousBlood_and_Plasma()
+      {
+         sut.IsSatisfiedBy(entityWithTags("VenousBlood", "Plasma")).ShouldBeTrue();
+      }
+   }
+
+   public class When_outer_OR_of_two_AND_compounds_matches_the_second_branch : concern_for_DescriptorCriteria_with_compound
+   {
+      [Observation]
+      public void should_satisfy_for_an_entity_tagged_Muscle_and_Interstitial()
+      {
+         sut.IsSatisfiedBy(entityWithTags("Muscle", "Interstitial")).ShouldBeTrue();
+      }
+   }
+
+   public class When_outer_OR_of_two_AND_compounds_matches_neither_branch : concern_for_DescriptorCriteria_with_compound
+   {
+      [Observation]
+      public void should_not_satisfy_for_an_entity_with_one_tag_from_each_branch()
+      {
+         //hybrid: matches one tag from each branch, neither branch fully
+         sut.IsSatisfiedBy(entityWithTags("VenousBlood", "Interstitial")).ShouldBeFalse();
+      }
+   }
+
+   public class When_outer_AND_with_a_compound_OR_branch_satisfied : concern_for_DescriptorCriteria
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         sut.Add(A.Fake<ITagCondition>());
+         A.CallTo(() => sut[0].IsSatisfiedBy(_entityCriteria)).Returns(true);
+
+         var compound = new CompoundCondition { Operator = CriteriaOperator.Or };
+         var firstInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => firstInnerCondition.IsSatisfiedBy(_entityCriteria)).Returns(false);
+         var secondInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => secondInnerCondition.IsSatisfiedBy(_entityCriteria)).Returns(true);
+         compound.Add(firstInnerCondition);
+         compound.Add(secondInnerCondition);
+         sut.Add(compound);
+      }
+
+      [Observation]
+      public void should_be_satisfied()
+      {
+         sut.IsSatisfiedBy(_entityCriteria).ShouldBeTrue();
+      }
+   }
+
+   public class When_outer_AND_with_a_compound_OR_branch_all_unsatisfied : concern_for_DescriptorCriteria
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.And;
+         sut.Add(A.Fake<ITagCondition>());
+         A.CallTo(() => sut[0].IsSatisfiedBy(_entityCriteria)).Returns(true);
+
+         var compound = new CompoundCondition { Operator = CriteriaOperator.Or };
+         var firstInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => firstInnerCondition.IsSatisfiedBy(_entityCriteria)).Returns(false);
+         var secondInnerCondition = A.Fake<ITagCondition>();
+         A.CallTo(() => secondInnerCondition.IsSatisfiedBy(_entityCriteria)).Returns(false);
+         compound.Add(firstInnerCondition);
+         compound.Add(secondInnerCondition);
+         sut.Add(compound);
+      }
+
+      [Observation]
+      public void should_not_be_satisfied()
+      {
+         sut.IsSatisfiedBy(_entityCriteria).ShouldBeFalse();
+      }
+   }
+
+   public class When_cloning_a_descriptor_criteria_containing_a_compound : concern_for_DescriptorCriteria
+   {
+      private DescriptorCriteria _clonedCriteria;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.Or;
+         var compound = new CompoundCondition();
+         compound.Add(new MatchTagCondition("VenousBlood"));
+         compound.Add(new MatchTagCondition("Plasma"));
+         sut.Add(compound);
+      }
+
+      protected override void Because()
+      {
+         _clonedCriteria = sut.Clone();
+      }
+
+      [Observation]
+      public void should_deep_clone_the_compound()
+      {
+         _clonedCriteria.Count.ShouldBeEqualTo(1);
+         _clonedCriteria[0].ShouldBeAnInstanceOf<CompoundCondition>();
+         var clonedCompound = _clonedCriteria[0].DowncastTo<CompoundCondition>();
+         clonedCompound.Operator.ShouldBeEqualTo(CriteriaOperator.And);
+         clonedCompound.Count.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void clone_should_not_share_inner_list()
+      {
+         _clonedCriteria[0].DowncastTo<CompoundCondition>().Add(new MatchTagCondition("Other"));
+         sut[0].DowncastTo<CompoundCondition>().Count.ShouldBeEqualTo(2);
+      }
+   }
+
+   public class When_replacing_a_keyword_in_a_descriptor_criteria_containing_a_compound : concern_for_DescriptorCriteria
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var compound = new CompoundCondition();
+         compound.Add(new MatchTagCondition("VenousBlood"));
+         compound.Add(new MatchTagCondition("Plasma"));
+         sut.Add(compound);
+         sut.Add(new MatchTagCondition("VenousBlood"));
+      }
+
+      protected override void Because()
+      {
+         sut.Replace("VenousBlood", "ArterialBlood");
+      }
+
+      [Observation]
+      public void should_replace_inside_the_compound()
+      {
+         var compound = sut[0].DowncastTo<CompoundCondition>();
+         compound[0].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("ArterialBlood");
+      }
+
+      [Observation]
+      public void should_replace_at_the_outer_level()
+      {
+         sut[1].DowncastTo<MatchTagCondition>().Tag.ShouldBeEqualTo("ArterialBlood");
+      }
+   }
+
+   public class When_rendering_a_descriptor_criteria_with_compound_to_string : concern_for_DescriptorCriteria
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Operator = CriteriaOperator.Or;
+
+         var venousPlasma = new CompoundCondition();
+         venousPlasma.Add(new MatchTagCondition("VenousBlood"));
+         venousPlasma.Add(new MatchTagCondition("Plasma"));
+
+         var muscleInterstitial = new CompoundCondition();
+         muscleInterstitial.Add(new MatchTagCondition("Muscle"));
+         muscleInterstitial.Add(new MatchTagCondition("Interstitial"));
+
+         sut.Add(venousPlasma);
+         sut.Add(muscleInterstitial);
+      }
+
+      [Observation]
+      public void should_render_outer_OR_of_parenthesised_compound_groups()
+      {
+         sut.ToString().ShouldBeEqualTo("(VenousBlood AND Plasma) OR (Muscle AND Interstitial)");
+      }
+   }
+
+   public class When_comparing_two_descriptor_criteria_with_equivalent_compounds : concern_for_DescriptorCriteria
+   {
+      private DescriptorCriteria _equivalentCriteria;
+
+      protected override void Context()
+      {
+         base.Context();
+         var firstCompound = new CompoundCondition();
+         firstCompound.Add(new MatchTagCondition("A"));
+         firstCompound.Add(new MatchTagCondition("B"));
+         sut.Add(firstCompound);
+
+         var secondCompound = new CompoundCondition();
+         secondCompound.Add(new MatchTagCondition("A"));
+         secondCompound.Add(new MatchTagCondition("B"));
+         _equivalentCriteria = new DescriptorCriteria();
+         _equivalentCriteria.Add(secondCompound);
+      }
+
+      [Observation]
+      public void should_be_equal()
+      {
+         sut.Equals(_equivalentCriteria).ShouldBeTrue();
+      }
+   }
+
+   public class When_comparing_two_descriptor_criteria_with_compounds_differing_by_inner_operator : concern_for_DescriptorCriteria
+   {
+      private DescriptorCriteria _criteriaWithDifferentInnerOperator;
+
+      protected override void Context()
+      {
+         base.Context();
+         var compoundWithAnd = new CompoundCondition();
+         compoundWithAnd.Add(new MatchTagCondition("A"));
+         sut.Add(compoundWithAnd);
+
+         var compoundWithOr = new CompoundCondition { Operator = CriteriaOperator.Or };
+         compoundWithOr.Add(new MatchTagCondition("A"));
+         _criteriaWithDifferentInnerOperator = new DescriptorCriteria();
+         _criteriaWithDifferentInnerOperator.Add(compoundWithOr);
+      }
+
+      [Observation]
+      public void should_not_be_equal()
+      {
+         sut.Equals(_criteriaWithDifferentInnerOperator).ShouldBeFalse();
+      }
+   }
 }


### PR DESCRIPTION
## Summary

- Add `CompoundCondition` (inherits `DescriptorCriteria`, implements `ITagCondition`) so a criteria can contain compound operands and express things like `(VenousBlood AND Plasma) OR (Muscle AND Interstitial)`.
- `DescriptorCriteria.Equals` is now type-strict (a compound is not equal to a plain criteria with the same contents); `Clone` is virtual; new recursive `Replace(keyword, replacement)` walks into nested compounds.
- New `.Compound(...)` builder extension; `DescriptorCriteriaXmlSerializer` split into a generic base so `CompoundConditionXmlSerializer` round-trips compounds in XML.

Companion changes in MoBi (UI, commands, modal editor) live on the MoBi side and are tracked in [Open-Systems-Pharmacology/MoBi#2205](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2205) — those will land after this nuget ships.

## Test plan

- [x] `dotnet test tests/OSPSuite.Core.Tests` — 2014 pass
- [x] `dotnet test tests/OSPSuite.Core.IntegrationTests` — 499 pass / 1 unrelated skip
- [x] New unit specs cover compound semantics: operator/satisfied/clone/replace/string/equality, plus a guard that a compound ≠ a plain criteria with the same contents
- [x] New `DescriptorCriteriaSpecs` observations cover the issue scenario, outer-AND-with-compound-OR, clone, replace, ToString, equality
- [x] New `DescriptorCriteriaExpressionsSpecs` covers the `.Compound(...)` builder
- [x] Integration: `ProcessBuilderXmlSerializerSpecs` round-trips `ReactionBuilder` and `TransportBuilder` with compound criteria

Fixes #2845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for compound/nested descriptor criteria, enabling more complex condition grouping with AND/OR operators
  * Enhanced keyword replacement functionality to traverse nested criteria hierarchies
  * Improved serialization and deserialization support for compound criteria structures with proper formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->