### PR TITLE
Fixes #2848 Apply extending module's formula when merging observers

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -261,6 +261,7 @@ namespace OSPSuite.Core.Domain.Builder
       private void mergeObservers(ObserverBuilder target, BuilderSource<ObserverBuilder> source)
       {
          mergeMoleculeLists(target, source.Builder);
+         target.Formula = source.Builder.Formula;
       }
 
       private void mergeMolecules(MoleculeBuilder target, BuilderSource<MoleculeBuilder> source)

--- a/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SimulationBuilderSpecs.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
@@ -90,6 +91,116 @@ namespace OSPSuite.Core.Domain
          var observedBuilder = sut.Observers.ElementAt(0);
          sut.MoleculeListFor(observedBuilder).MoleculeNames.ShouldContain("molecule1");
          sut.MoleculeListFor(observedBuilder).MoleculeNames.ShouldContain("molecule2");
+      }
+   }
+
+   internal class When_extending_an_observer_builder_with_a_different_formula : concern_for_SimulationBuilder
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private ModuleConfiguration _moduleConfiguration1;
+      private ModuleConfiguration _moduleConfiguration2;
+      private ICloneManagerForModel _cloneManagerForModel;
+      private IContainerMergeTask _containerMergeTask;
+      private IFormula _formulaFromModule1;
+      private IFormula _formulaFromModule2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moduleConfiguration1 = CreateModuleConfiguration();
+         _moduleConfiguration2 = CreateModuleConfiguration();
+
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration1);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration2);
+
+         _moduleConfiguration2.Module.MergeBehavior = MergeBehavior.Extend;
+
+         var observer1 = _moduleConfiguration1.Module.Observers.AmountObserverBuilders.ElementAt(0);
+         var observer2 = _moduleConfiguration2.Module.Observers.AmountObserverBuilders.ElementAt(0);
+
+         _formulaFromModule1 = A.Fake<IFormula>();
+         _formulaFromModule2 = A.Fake<IFormula>();
+         observer1.Formula = _formulaFromModule1;
+         observer2.Formula = _formulaFromModule2;
+
+         _cloneManagerForModel = A.Fake<ICloneManagerForModel>();
+         _containerMergeTask = A.Fake<IContainerMergeTask>();
+
+         //only testing the formula extend behavior. No need to really clone
+         A.CallTo(() => _cloneManagerForModel.CloneAndKeepId<ObserverBuilder>(observer1)).Returns(observer1);
+         A.CallTo(() => _cloneManagerForModel.CloneAndKeepId<ObserverBuilder>(observer2)).Returns(observer2);
+
+         sut = new SimulationBuilder(_cloneManagerForModel, _containerMergeTask);
+      }
+
+      protected override void Because()
+      {
+         sut.PerformMerge(_simulationConfiguration);
+      }
+
+      [Observation]
+      public void the_formula_should_be_taken_from_the_extending_module()
+      {
+         var observerBuilder = sut.Observers.ElementAt(0);
+         observerBuilder.Formula.ShouldBeEqualTo(_formulaFromModule2);
+      }
+   }
+
+   internal class When_extending_an_observer_builder_across_three_modules_with_different_formulas : concern_for_SimulationBuilder
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private ModuleConfiguration _moduleConfiguration1;
+      private ModuleConfiguration _moduleConfiguration2;
+      private ModuleConfiguration _moduleConfiguration3;
+      private ICloneManagerForModel _cloneManagerForModel;
+      private IContainerMergeTask _containerMergeTask;
+      private IFormula _formulaFromModule3;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moduleConfiguration1 = CreateModuleConfiguration();
+         _moduleConfiguration2 = CreateModuleConfiguration();
+         _moduleConfiguration3 = CreateModuleConfiguration();
+
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration1);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration2);
+         _simulationConfiguration.AddModuleConfiguration(_moduleConfiguration3);
+
+         _moduleConfiguration2.Module.MergeBehavior = MergeBehavior.Extend;
+         _moduleConfiguration3.Module.MergeBehavior = MergeBehavior.Extend;
+
+         var observer1 = _moduleConfiguration1.Module.Observers.AmountObserverBuilders.ElementAt(0);
+         var observer2 = _moduleConfiguration2.Module.Observers.AmountObserverBuilders.ElementAt(0);
+         var observer3 = _moduleConfiguration3.Module.Observers.AmountObserverBuilders.ElementAt(0);
+
+         observer1.Formula = A.Fake<IFormula>();
+         observer2.Formula = A.Fake<IFormula>();
+         _formulaFromModule3 = A.Fake<IFormula>();
+         observer3.Formula = _formulaFromModule3;
+
+         _cloneManagerForModel = A.Fake<ICloneManagerForModel>();
+         _containerMergeTask = A.Fake<IContainerMergeTask>();
+
+         A.CallTo(() => _cloneManagerForModel.CloneAndKeepId<ObserverBuilder>(observer1)).Returns(observer1);
+         A.CallTo(() => _cloneManagerForModel.CloneAndKeepId<ObserverBuilder>(observer2)).Returns(observer2);
+         A.CallTo(() => _cloneManagerForModel.CloneAndKeepId<ObserverBuilder>(observer3)).Returns(observer3);
+
+         sut = new SimulationBuilder(_cloneManagerForModel, _containerMergeTask);
+      }
+
+      protected override void Because()
+      {
+         sut.PerformMerge(_simulationConfiguration);
+      }
+
+      [Observation]
+      public void the_formula_should_be_taken_from_the_last_extending_module()
+      {
+         var observerBuilder = sut.Observers.ElementAt(0);
+         observerBuilder.Formula.ShouldBeEqualTo(_formulaFromModule3);
       }
    }
 }


### PR DESCRIPTION
## Summary

- When two modules define an observer with the same name and the second module extends the first, `mergeObservers` was merging the molecule list but leaving the base observer's formula in place. Result: the simulation used the formula from the first module instead of the extending one.
- Fix is one line in `SimulationBuilder.mergeObservers`: assign the extending source's `Formula` onto the target, matching how `mergeReactions` and `mergeTransports` already handle their formulas.

## Test plan

- [x] New unit spec `When_extending_an_observer_builder_with_a_different_formula` — two modules, second extends, asserts merged observer's formula comes from the extending module.
- [x] New unit spec `When_extending_an_observer_builder_across_three_modules_with_different_formulas` — three modules in an extend chain, asserts the last module's formula wins (covers the repeated `mergeObservers` invocation path).
- [x] `dotnet test tests/OSPSuite.Core.Tests --filter "FullyQualifiedName~observer_builder"` — 8 pass (6 pre-existing + 2 new).

Fixes #2848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formula values are now correctly copied and retained when merging observer configurations during simulation module setup.

* **Tests**
  * Added tests to verify formula handling during multi-module merge operations, ensuring formulas from extending modules are properly propagated through sequential merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->