### PR TITLE
Fixes #2850 Handle null formula in ModelValidator

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2039,6 +2039,7 @@ namespace OSPSuite.Assets
       public static readonly string OutputFileNotValid = "Please specify an output file with full path information.";
       public static readonly string StartTimeLessThanOrEqualToEndTime = "Start time value should be less than end time value.";
       public static readonly string EndTimeGreaterThanOrEqualToStartTime = "End time value should be greater than start time value.";
+      public static readonly string FormulaCannotBeEmpty = "Formula cannot be empty";
 
       public static string FileDoesNotExist(string fileFullPath)
       {

--- a/src/OSPSuite.Core/Domain/Services/ModelValidator.cs
+++ b/src/OSPSuite.Core/Domain/Services/ModelValidator.cs
@@ -83,6 +83,10 @@ namespace OSPSuite.Core.Domain.Services
             case TableFormulaWithXArgument formulaWithXArgument:
                checkPathInEntity(formulaWithXArgument.FormulaUsablePathBy(formulaWithXArgument.TableObjectAlias));
                return;
+            
+            case null:
+               addNotificationType(NotificationType.Error, objectWithError, Validation.FormulaCannotBeEmpty);
+               return;
          }
 
          //in all other cases, we check the object path used in the formula

--- a/tests/OSPSuite.Core.Tests/Domain/ModelValidatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ModelValidatorSpecs.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using FakeItEasy;
+using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
@@ -310,6 +312,102 @@ namespace OSPSuite.Core.Domain
       public void should_return_an_invalid_state()
       {
          _results.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+      }
+   }
+
+   internal class When_validating_an_event_whose_formula_is_null : concern_for_ModelValidator
+   {
+      private ValidationResult _results;
+      private Event _eventWithNullFormula;
+
+      protected override void Context()
+      {
+         base.Context();
+         _eventWithNullFormula = new Event().WithName("EventWithNullFormula");
+         _eventWithNullFormula.Formula = null;
+         _validContainer.Add(_eventWithNullFormula);
+
+         sut = new ValidatorForObserversAndEvents(_objectTypeResolver, _objectPathFactory);
+      }
+
+      protected override void Because()
+      {
+         _model.Root = _validContainer;
+         _results = sut.Validate(_modelConfiguration);
+      }
+
+      [Observation]
+      public void should_return_an_invalid_state_instead_of_throwing_a_null_reference_exception()
+      {
+         _results.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+      }
+
+      [Observation]
+      public void should_report_a_validation_message_indicating_that_the_formula_cannot_be_empty()
+      {
+         _results.Messages.Any(x => x.Object == _eventWithNullFormula && x.Text == Validation.FormulaCannotBeEmpty).ShouldBeTrue();
+      }
+   }
+
+   internal class When_validating_a_quantity_whose_formula_is_null : concern_for_ModelValidator
+   {
+      private ValidationResult _results;
+      private Parameter _parameterWithNullFormula;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterWithNullFormula = new Parameter().WithName("ParameterWithNullFormula");
+         _parameterWithNullFormula.Formula = null;
+         _validContainer.Add(_parameterWithNullFormula);
+
+         sut = new ValidatorForQuantities(_objectTypeResolver, _objectPathFactory);
+      }
+
+      protected override void Because()
+      {
+         _model.Root = _validContainer;
+         _results = sut.Validate(_modelConfiguration);
+      }
+
+      [Observation]
+      public void should_return_an_invalid_state_instead_of_throwing_a_null_reference_exception()
+      {
+         _results.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+      }
+
+      [Observation]
+      public void should_report_a_validation_message_indicating_that_the_formula_cannot_be_empty()
+      {
+         _results.Messages.Any(x => x.Object == _parameterWithNullFormula && x.Text == Validation.FormulaCannotBeEmpty).ShouldBeTrue();
+      }
+   }
+
+   internal class When_checking_a_formula_validity_through_the_validator_for_formula_and_the_formula_is_null : concern_for_ModelValidator
+   {
+      private bool _isValid;
+      private Parameter _parameterWithNullFormula;
+      private ValidatorForForFormula _validatorForFormula;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterWithNullFormula = new Parameter().WithName("ParameterWithNullFormula");
+         _parameterWithNullFormula.Formula = null;
+         _validContainer.Add(_parameterWithNullFormula);
+         _validatorForFormula = new ValidatorForForFormula(_objectTypeResolver, _objectPathFactory);
+         sut = _validatorForFormula;
+      }
+
+      protected override void Because()
+      {
+         _isValid = _validatorForFormula.IsFormulaValid(_parameterWithNullFormula);
+      }
+
+      [Observation]
+      public void should_report_the_formula_as_invalid_instead_of_throwing_a_null_reference_exception()
+      {
+         _isValid.ShouldBeFalse();
       }
    }
 }


### PR DESCRIPTION
## Summary
- Add a `case null` arm in `ModelValidator.CheckFormulaIn` so an `IUsingFormula` entity with a null `Formula` surfaces a regular validation error (`Formula cannot be empty`) instead of throwing a `NullReferenceException` deep in the visitor pipeline.
- Reproduces the exact crash path from the issue: `ValidatorForObserversAndEvents.Visit(Event)` → `CheckReferences` → `CheckFormulaIn` on an event whose `Formula` is null.

## Test plan
- [x] New `When_validating_an_event_whose_formula_is_null` spec — asserts `Invalid` state and that the message text is `Validation.FormulaCannotBeEmpty` attached to the event.
- [x] New `When_validating_a_quantity_whose_formula_is_null` spec — same coverage for `ValidatorForQuantities` (parameter with null `Formula`).
- [x] New `When_checking_a_formula_validity_through_the_validator_for_formula_and_the_formula_is_null` spec — covers the `ValidatorForForFormula.IsFormulaValid` entry point.
- [x] Full ModelValidator suite green (74 tests).


Fixes #2850