### PR TITLE
Fixes #2852 Copy icon when merging molecules

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -273,6 +273,7 @@ namespace OSPSuite.Core.Domain.Builder
          target.IsFloating = incoming.IsFloating;
          target.IsXenobiotic = incoming.IsXenobiotic;
          target.QuantityType = incoming.QuantityType;
+         target.Icon = incoming.Icon;
 
          // calculation methods are replaced
          target.ClearUsedCalculationMethods();

--- a/tests/OSPSuite.Core.IntegrationTests/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/SimulationBuilderSpecs.cs
@@ -46,6 +46,7 @@ internal class When_overwriting_molecules_with_parameters_and_formula_reference 
       _molecule1.IsFloating = true;
       _molecule1.IsXenobiotic = true;
       _molecule1.QuantityType = QuantityType.Drug;
+      _molecule1.Icon = "Icon_M1";
       _molecule1.AddUsedCalculationMethod(new UsedCalculationMethod("SharedCategory", "Method_M1"));
       _molecule1.AddUsedCalculationMethod(new UsedCalculationMethod("M1OnlyCategory", "Method_M1Only"));
 
@@ -62,6 +63,7 @@ internal class When_overwriting_molecules_with_parameters_and_formula_reference 
       _molecule2.IsFloating = false;
       _molecule2.IsXenobiotic = false;
       _molecule2.QuantityType = QuantityType.Enzyme;
+      _molecule2.Icon = "Icon_M2";
       _molecule2.DisplayUnit = Constants.Dimension.NO_DIMENSION.DefaultUnit;
       _molecule2.AddUsedCalculationMethod(new UsedCalculationMethod("SharedCategory", "Method_M2"));
       _molecule2.AddUsedCalculationMethod(new UsedCalculationMethod("M2OnlyCategory", "Method_M2Only"));
@@ -148,6 +150,13 @@ internal class When_overwriting_molecules_with_parameters_and_formula_reference 
       var moleculeBuilder = sut.Molecules.Single(x => x.Name == "R1");
       moleculeBuilder.QuantityType.ShouldBeEqualTo(QuantityType.Enzyme);
    }
+
+   [Observation]
+   public void the_icon_should_be_from_module_2()
+   {
+      var moleculeBuilder = sut.Molecules.Single(x => x.Name == "R1");
+      moleculeBuilder.Icon.ShouldBeEqualTo("Icon_M2");
+   }
 }
 
 internal class When_extending_molecules_with_parameters_and_formula_reference : concern_for_SimulationBuilder
@@ -170,6 +179,7 @@ internal class When_extending_molecules_with_parameters_and_formula_reference : 
       _molecule1.IsFloating = true;
       _molecule1.IsXenobiotic = true;
       _molecule1.QuantityType = QuantityType.Drug;
+      _molecule1.Icon = "Icon_M1";
       _molecule1.AddUsedCalculationMethod(new UsedCalculationMethod("SharedCategory", "Method_M1"));
       _molecule1.AddUsedCalculationMethod(new UsedCalculationMethod("M1OnlyCategory", "Method_M1Only"));
 
@@ -186,6 +196,7 @@ internal class When_extending_molecules_with_parameters_and_formula_reference : 
       _molecule2.IsFloating = false;
       _molecule2.IsXenobiotic = false;
       _molecule2.QuantityType = QuantityType.Enzyme;
+      _molecule2.Icon = "Icon_M2";
       _molecule2.DisplayUnit = Constants.Dimension.NO_DIMENSION.DefaultUnit;
       _molecule2.AddUsedCalculationMethod(new UsedCalculationMethod("SharedCategory", "Method_M2"));
       _molecule2.AddUsedCalculationMethod(new UsedCalculationMethod("M2OnlyCategory", "Method_M2Only"));
@@ -270,6 +281,13 @@ internal class When_extending_molecules_with_parameters_and_formula_reference : 
    {
       var moleculeBuilder = sut.Molecules.Single(x => x.Name == "R1");
       moleculeBuilder.QuantityType.ShouldBeEqualTo(QuantityType.Enzyme);
+   }
+
+   [Observation]
+   public void the_icon_should_be_from_module_2()
+   {
+      var moleculeBuilder = sut.Molecules.Single(x => x.Name == "R1");
+      moleculeBuilder.Icon.ShouldBeEqualTo("Icon_M2");
    }
 }
 


### PR DESCRIPTION
Fixes #2852

## Summary
- `SimulationBuilder.mergeMolecules` now copies `Icon` from the incoming molecule, alongside the other already-copied properties (`IsFloating`, `IsXenobiotic`, `QuantityType`).
- Without this, an Extend/Overwrite module that changed the molecule's type (e.g. Drug → Transporter) would update `QuantityType` but leave the molecule rendering with the old icon.

## Test plan
- [x] New `the_icon_should_be_from_module_2` observation in both the Overwrite and Extend `SimulationBuilder` integration test classes (mirrors the existing `QuantityType` observations).
- [x] `dotnet test tests/OSPSuite.Core.IntegrationTests` — passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed molecule icon preservation during simulation merging operations.

* **Tests**
  * Enhanced test coverage for molecule icon handling in simulation building scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->