### PR TITLE
Fixes #2838 Distributed parameter overwrite loses distribution

### DIFF
--- a/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
@@ -21,25 +21,17 @@ namespace OSPSuite.Core.Domain.Mappers
       public IParameter MapFrom(ParameterValue parameterValue)
       {
          var name = parameterValue.Name;
+         var value = parameterValue.Value;
          var dimension = parameterValue.Dimension;
          var displayUnit = parameterValue.DisplayUnit;
          var distributionType = parameterValue.DistributionType;
 
-         //if a distribution is defined we create a distributed parameter; the overwritten value (if any) is
-         //applied as a fixed value via the IDistributedParameter Value setter, which keeps the distribution
-         //formula intact and updates the percentile sub-parameter accordingly.
+         //if a distribution is defined we create a distributed parameter; the value (if any) is applied as a
+         //fixed value while the distribution formula and its sub-parameters are kept intact.
          //Otherwise, we create a plain parameter whose constant formula carries the value.
-         IParameter parameter;
-         if (parameterValue.IsDistributed())
-         {
-            parameter = _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit);
-            if (parameterValue.Value.HasValue)
-               parameter.Value = parameterValue.Value.Value;
-         }
-         else
-         {
-            parameter = _parameterFactory.CreateParameter(name, value: parameterValue.Value, dimension: dimension, displayUnit: displayUnit);
-         }
+         var parameter = parameterValue.IsDistributed()
+            ? _parameterFactory.CreateDistributedParameter(name, distributionType.Value, value: value, dimension: dimension, displayUnit: displayUnit)
+            : _parameterFactory.CreateParameter(name, value: value, dimension: dimension, displayUnit: displayUnit);
 
          parameter.ValueOrigin.UpdateAllFrom(parameterValue.ValueOrigin);
 

--- a/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
@@ -1,6 +1,7 @@
-﻿using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Utility;
+
 
 namespace OSPSuite.Core.Domain.Mappers
 {
@@ -24,11 +25,12 @@ namespace OSPSuite.Core.Domain.Mappers
          var displayUnit = parameterValue.DisplayUnit;
          var distributionType = parameterValue.DistributionType;
 
-         //if the distribution is undefined or the value is set, we create a default parameter to ensure that the value will take precedence.
-         //Otherwise, we create a distributed parameter and assume that required sub-parameters will be created as well
-         var parameter = !parameterValue.IsDistributed() || parameterValue.Value != null
-            ? _parameterFactory.CreateParameter(name, dimension: dimension, displayUnit: displayUnit)
-            : _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit);
+         //if a distribution is defined we create a distributed parameter (even if a value is also provided:
+         //the value is applied later as a fixed value while keeping the distribution intact).
+         //Otherwise, we create a plain parameter.
+         var parameter = parameterValue.IsDistributed()
+            ? _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit)
+            : _parameterFactory.CreateParameter(name, dimension: dimension, displayUnit: displayUnit);
 
          parameter.ValueOrigin.UpdateAllFrom(parameterValue.ValueOrigin);
 

--- a/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/ParameterValueToParameterMapper.cs
@@ -25,12 +25,21 @@ namespace OSPSuite.Core.Domain.Mappers
          var displayUnit = parameterValue.DisplayUnit;
          var distributionType = parameterValue.DistributionType;
 
-         //if a distribution is defined we create a distributed parameter (even if a value is also provided:
-         //the value is applied later as a fixed value while keeping the distribution intact).
-         //Otherwise, we create a plain parameter.
-         var parameter = parameterValue.IsDistributed()
-            ? _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit)
-            : _parameterFactory.CreateParameter(name, dimension: dimension, displayUnit: displayUnit);
+         //if a distribution is defined we create a distributed parameter; the overwritten value (if any) is
+         //applied as a fixed value via the IDistributedParameter Value setter, which keeps the distribution
+         //formula intact and updates the percentile sub-parameter accordingly.
+         //Otherwise, we create a plain parameter whose constant formula carries the value.
+         IParameter parameter;
+         if (parameterValue.IsDistributed())
+         {
+            parameter = _parameterFactory.CreateDistributedParameter(name, distributionType.Value, dimension: dimension, displayUnit: displayUnit);
+            if (parameterValue.Value.HasValue)
+               parameter.Value = parameterValue.Value.Value;
+         }
+         else
+         {
+            parameter = _parameterFactory.CreateParameter(name, value: parameterValue.Value, dimension: dimension, displayUnit: displayUnit);
+         }
 
          parameter.ValueOrigin.UpdateAllFrom(parameterValue.ValueOrigin);
 

--- a/src/OSPSuite.Core/Domain/ParameterFactory.cs
+++ b/src/OSPSuite.Core/Domain/ParameterFactory.cs
@@ -125,6 +125,11 @@ namespace OSPSuite.Core.Domain
          //The Percentile sub-parameter is required by the IDistributedParameter contract itself.
          addDistributionSubParametersTo((IDistributedParameter) distributedParameter, dimensionToUse);
 
+         //if a value is provided, apply it as a fixed value: the IDistributedParameter Value setter keeps the
+         //distribution formula intact, sets IsFixedValue=true and updates the percentile sub-parameter.
+         if (value.HasValue)
+            distributedParameter.Value = value.Value;
+
          return distributedParameter;
       }
 

--- a/src/OSPSuite.Core/Domain/ParameterFactory.cs
+++ b/src/OSPSuite.Core/Domain/ParameterFactory.cs
@@ -1,7 +1,9 @@
-﻿using OSPSuite.Core.Domain.Formulas;
+﻿using System.Linq;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Core.Domain
 {
@@ -111,12 +113,33 @@ namespace OSPSuite.Core.Domain
          var dimensionToUse = dimension ?? _dimensionFactory.NoDimension;
          var displayUnitToUse = displayUnit ?? _displayUnitRetriever.PreferredUnitFor(dimensionToUse);
 
-         return _objectBaseFactory.Create<IDistributedParameter>()
+         var distributedParameter = _objectBaseFactory.Create<IDistributedParameter>()
             .WithName(name)
             .WithDimension(dimensionToUse)
             .WithFormula(_distributionFormulaFactory.CreateFor(distributionType, dimensionToUse))
             .WithDisplayUnit(displayUnitToUse)
             .WithGroup(groupName ?? Constants.Groups.MOBI);
+
+         //the distribution formula references its sub-parameters by name (e.g. Mean, Deviation).
+         //Pre-create them so the formula references resolve and the parameter is operational.
+         //The Percentile sub-parameter is required by the IDistributedParameter contract itself.
+         addDistributionSubParametersTo((IDistributedParameter) distributedParameter, dimensionToUse);
+
+         return distributedParameter;
+      }
+
+      private void addDistributionSubParametersTo(IDistributedParameter distributedParameter, IDimension dimension)
+      {
+         if (distributedParameter.Formula is DistributionFormula distributionFormula)
+         {
+            distributionFormula.ObjectPaths
+               .Select(path => path.Last())
+               .Where(subName => distributedParameter.GetSingleChildByName(subName) == null)
+               .Each(subName => distributedParameter.Add(CreateParameter(subName, dimension: dimension)));
+         }
+
+         if (distributedParameter.PercentileParameter == null)
+            distributedParameter.Add(CreateParameter(Constants.Distribution.PERCENTILE));
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -94,11 +94,30 @@ namespace OSPSuite.Core.Domain.Services
 
       private void updateParameterFromIndividualValues(ValueUpdaterParams valueUpdater)
       {
+         var individual = valueUpdater.ModelConfiguration.SimulationConfiguration.Individual;
+         if (individual == null)
+            return;
+
          var addOrUpdateParameter = addOrUpdateParameterFromParameterValue(valueUpdater);
          //Order by distribution to ensure that distributed parameter are loaded BEFORE their sub parameters.
          //note: use descending otherwise parameter without distribution are returned fist
-         valueUpdater.ModelConfiguration.SimulationConfiguration.Individual?.OrderByDescending(x => x.DistributionType)
-            .Each(addOrUpdateParameter);
+         individual.OrderByDescending(x => x.DistributionType).Each(addOrUpdateParameter);
+
+         //A distributed parameter's value (and percentile) is applied before its sub-parameters
+         //(Mean/Deviation/...) are set above. Refresh the percentile of any distributed parameter that
+         //came from the individual so it reflects the now-correct sub-parameter values.
+         refreshPercentilesOf(valueUpdater, individual);
+      }
+
+      private void refreshPercentilesOf(ValueUpdaterParams valueUpdater, IndividualBuildingBlock individual)
+      {
+         var modelConfiguration = valueUpdater.ModelConfiguration;
+         foreach (var individualParameter in individual.Where(x => x.IsDistributed()))
+         {
+            var pathInModel = _keywordReplacerTask.CreateModelPathFor(individualParameter.Path, modelConfiguration.ReplacementContext);
+            if (pathInModel.Resolve<IDistributedParameter>(modelConfiguration.Model.Root) is IDistributedParameter distributedParameter && distributedParameter.IsFixedValue)
+               distributedParameter.RefreshPercentile();
+         }
       }
 
       private void updateParameterValueFromParameterValues(ValueUpdaterParams valueUpdater)

--- a/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
@@ -501,6 +501,111 @@ namespace OSPSuite.Core
       }
    }
 
+   internal class When_an_existing_normal_distributed_parameter_value_is_overwritten_via_an_individual_parameter : concern_for_ModelConstructor
+   {
+      private const double _overwrittenValue = 5;
+
+      protected override void Context()
+      {
+         base.Context();
+         //add an IndividualParameter that overwrites the existing distributed Organism|NormalDistributed parameter
+         _simulationConfiguration.Individual.Add(new IndividualParameter
+         {
+            Path = new ObjectPath(ORGANISM, "NormalDistributed"),
+            Value = _overwrittenValue,
+            DistributionType = DistributionType.Normal,
+         });
+      }
+
+      [Observation]
+      public void should_keep_the_parameter_distributed()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, "NormalDistributed");
+         distributed.IsDistributed().ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_keep_a_distribution_formula_on_the_parameter()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, "NormalDistributed");
+         distributed.Formula.ShouldBeAnInstanceOf<DistributionFormula>();
+      }
+
+      [Observation]
+      public void should_apply_the_overwritten_value()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, "NormalDistributed");
+         distributed.Value.ShouldBeEqualTo(_overwrittenValue);
+      }
+
+      [Observation]
+      public void should_mark_the_parameter_as_fixed_value()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, "NormalDistributed");
+         distributed.IsFixedValue.ShouldBeTrue();
+      }
+   }
+
+   //This reproduces the PK-Sim issue Open-Systems-Pharmacology/PK-Sim#3511: a distributed parameter that
+   //is NOT defined in the spatial structure (species-specific in PK-Sim) but is exported via the individual
+   //building block with both DistributionType and an overwritten Value must end up in the model as a
+   //distributed parameter with the overwritten value, not as a plain constant parameter.
+   internal class When_a_distributed_parameter_value_is_overwritten_via_an_individual_parameter_and_the_parameter_is_not_in_the_spatial_structure : concern_for_ModelConstructor
+   {
+      private const double _overwrittenValue = 5;
+      private const string _paramName = "OVERWRITTEN_DISTRIBUTED";
+
+      protected override void Context()
+      {
+         base.Context();
+         //the parameter does not exist in the spatial structure, only the individual building block
+         //provides it (with DistributionType set and an overwritten value plus its sub-parameters)
+         _simulationConfiguration.Individual.Add(new IndividualParameter
+         {
+            Path = new ObjectPath(ORGANISM, ArterialBlood, _paramName),
+            DistributionType = DistributionType.Normal,
+            Value = _overwrittenValue,
+         });
+         _simulationConfiguration.Individual.Add(new IndividualParameter
+         {
+            Path = new ObjectPath(ORGANISM, ArterialBlood, _paramName, OSPSuite.Core.Domain.Constants.Distribution.MEAN),
+            Value = 4,
+         });
+         _simulationConfiguration.Individual.Add(new IndividualParameter
+         {
+            Path = new ObjectPath(ORGANISM, ArterialBlood, _paramName, OSPSuite.Core.Domain.Constants.Distribution.DEVIATION),
+            Value = 1,
+         });
+         _simulationConfiguration.Individual.Add(new IndividualParameter
+         {
+            Path = new ObjectPath(ORGANISM, ArterialBlood, _paramName, OSPSuite.Core.Domain.Constants.Distribution.PERCENTILE),
+            Value = 0.84,
+         });
+      }
+
+      [Observation]
+      public void should_create_the_parameter_as_distributed_in_the_model()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, ArterialBlood, _paramName);
+         distributed.IsDistributed().ShouldBeTrue();
+         distributed.Formula.ShouldBeAnInstanceOf<DistributionFormula>();
+      }
+
+      [Observation]
+      public void should_apply_the_overwritten_value()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, ArterialBlood, _paramName);
+         distributed.Value.ShouldBeEqualTo(_overwrittenValue);
+      }
+
+      [Observation]
+      public void should_mark_the_parameter_as_fixed_value()
+      {
+         var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, ArterialBlood, _paramName);
+         distributed.IsFixedValue.ShouldBeTrue();
+      }
+   }
+
    internal class When_a_parameter_value_is_defined_with_formula_and_nan_value : concern_for_ModelConstructor
    {
       private ParameterValue _parameterValue;

--- a/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
@@ -604,6 +604,14 @@ namespace OSPSuite.Core
          var distributed = _model.Root.EntityAt<IParameter>(ORGANISM, ArterialBlood, _paramName);
          distributed.IsFixedValue.ShouldBeTrue();
       }
+
+      [Observation]
+      public void should_have_recomputed_the_percentile_against_the_individual_supplied_sub_parameter_values()
+      {
+         //value=5, mean=4, deviation=1 → percentile is normal CDF((5-4)/1) ≈ 0.8413
+         var distributed = (IDistributedParameter) _model.Root.EntityAt<IParameter>(ORGANISM, ArterialBlood, _paramName);
+         distributed.Percentile.ShouldBeEqualTo(0.8413, 1e-3);
+      }
    }
 
    internal class When_a_parameter_value_is_defined_with_formula_and_nan_value : concern_for_ModelConstructor

--- a/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
@@ -60,39 +60,6 @@ namespace OSPSuite.Core.Mappers
       }
    }
 
-   public class When_mapping_a_distributed_parameter_value_with_an_overwritten_value_to_parameter_value : concern_for_ParameterValueToParameterMapper
-   {
-      private IndividualParameter _individualParameter;
-
-      protected override void Context()
-      {
-         base.Context();
-         _individualParameter = new IndividualParameter
-         {
-            Name = "name",
-            DistributionType = DistributionType.LogNormal,
-            Value = 1.5
-         };
-      }
-
-      protected override void Because()
-      {
-         sut.MapFrom(_individualParameter);
-      }
-
-      [Observation]
-      public void should_create_a_distributed_parameter()
-      {
-         A.CallTo(() => _parameterFactory.CreateDistributedParameter(A<string>._, A<DistributionType>._, A<double?>._, A<IDimension>._, A<string>._, A<Unit>._)).MustHaveHappened();
-      }
-
-      [Observation]
-      public void should_not_create_a_non_distributed_parameter()
-      {
-         A.CallTo(() => _parameterFactory.CreateParameter(A<string>._, A<double?>._, A<IDimension>._, A<string>._, A<Formula>._, A<Unit>._)).MustNotHaveHappened();
-      }
-   }
-
    public class When_mapping_an_parameter_value_with_constant_formula_to_a_parameter_value : concern_for_ParameterValueToParameterMapper
    {
       private IndividualParameter _individualParameter;

--- a/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/ParameterValueToParameterMapperSpecs.cs
@@ -60,6 +60,39 @@ namespace OSPSuite.Core.Mappers
       }
    }
 
+   public class When_mapping_a_distributed_parameter_value_with_an_overwritten_value_to_parameter_value : concern_for_ParameterValueToParameterMapper
+   {
+      private IndividualParameter _individualParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualParameter = new IndividualParameter
+         {
+            Name = "name",
+            DistributionType = DistributionType.LogNormal,
+            Value = 1.5
+         };
+      }
+
+      protected override void Because()
+      {
+         sut.MapFrom(_individualParameter);
+      }
+
+      [Observation]
+      public void should_create_a_distributed_parameter()
+      {
+         A.CallTo(() => _parameterFactory.CreateDistributedParameter(A<string>._, A<DistributionType>._, A<double?>._, A<IDimension>._, A<string>._, A<Unit>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_create_a_non_distributed_parameter()
+      {
+         A.CallTo(() => _parameterFactory.CreateParameter(A<string>._, A<double?>._, A<IDimension>._, A<string>._, A<Formula>._, A<Unit>._)).MustNotHaveHappened();
+      }
+   }
+
    public class When_mapping_an_parameter_value_with_constant_formula_to_a_parameter_value : concern_for_ParameterValueToParameterMapper
    {
       private IndividualParameter _individualParameter;

--- a/tests/OSPSuite.HelpersForTests/ModelHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/ModelHelperForSpecs.cs
@@ -899,6 +899,18 @@ namespace OSPSuite.Helpers
             new DistributionFormulaFactory(_objectPathFactory, _objectBaseFactory).CreateDiscreteDistributionFormulaFor(
                distributedParameter, mean);
 
+         var normalDistributedParameter = _objectBaseFactory.Create<IDistributedParameter>().WithName("NormalDistributed");
+         organism.Add(normalDistributedParameter);
+         var nMean = NewConstantParameter(Constants.Distribution.MEAN, 2);
+         var nDeviation = NewConstantParameter(Constants.Distribution.DEVIATION, 0.5);
+         var nPercentile = NewConstantParameter(Constants.Distribution.PERCENTILE, 0.5);
+         normalDistributedParameter.Add(nMean);
+         normalDistributedParameter.Add(nDeviation);
+         normalDistributedParameter.Add(nPercentile);
+         normalDistributedParameter.Formula =
+            new DistributionFormulaFactory(_objectPathFactory, _objectBaseFactory).CreateNormalDistributionFormulaFor(
+               normalDistributedParameter, nMean, nDeviation);
+
          //ART
          var art = CreateContainerWithName(ArterialBlood)
             .WithMode(ContainerMode.Logical);


### PR DESCRIPTION
## Summary
- Keep a parameter distributed when an individual parameter provides both `DistributionType` and `Value` (the value is then applied as a fixed value while the distribution formula and sub-parameters remain intact).
- `ParameterFactory.CreateDistributedParameter` now pre-creates the sub-parameters referenced by the distribution formula (`Mean`, `Deviation`, `Percentile`, ...) so a distributed parameter created from an individual building block is fully operational even when not present in the spatial structure.
- Adds integration tests covering both cases (overwrite of an existing distributed parameter, and a distributed parameter only defined in the individual building block — reproduces Open-Systems-Pharmacology/PK-Sim#3511).

## Test plan
- [ ] `OSPSuite.Core.Tests` pass
- [ ] `OSPSuite.Core.IntegrationTests` pass (new `ModelConstructorIntegrationTests` cases)
- [ ] Verify in PK-Sim that the originally reported scenario (PK-Sim#3511) is resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when individual values overwrite distributed parameters so distribution status, fixed flags, and overwritten values are preserved.
  * Ensure required distribution sub-parameters (including percentile) are created and percentiles are refreshed when distributions become fixed.

* **Tests**
  * Added integration tests covering distributed-parameter overwrite scenarios, including cases created outside the existing spatial structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->