### PR TITLE
Fixes #2864 Move ApplicationIcon rendering extensions to OSPSuite.Presentation

### DIFF
--- a/src/OSPSuite.Presentation/Extensions/ApplicationIconExtensions.cs
+++ b/src/OSPSuite.Presentation/Extensions/ApplicationIconExtensions.cs
@@ -5,7 +5,7 @@ using DevExpress.Utils;
 using DevExpress.Utils.Svg;
 using OSPSuite.Assets;
 
-namespace OSPSuite.UI.Extensions
+namespace OSPSuite.Presentation.Extensions
 {
    public static class ApplicationIconExtensions
    {

--- a/src/OSPSuite.Presentation/OSPSuite.Presentation.csproj
+++ b/src/OSPSuite.Presentation/OSPSuite.Presentation.csproj
@@ -40,6 +40,17 @@
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <!-- DevExpress.Data brings IDXDataErrorInfo / ErrorInfo used by DxValidatableDTO. -->
     <PackageReference Include="DevExpress.Data" Version="25.2.7" />
+    <!-- DevExpress.Utils brings SvgImage / DefaultBoolean used by Extensions/ApplicationIconExtensions. -->
+    <PackageReference Include="DevExpress.Utils" Version="25.2.7" />
+    <!--
+      Pin System.Drawing.Common to the 10.x branch so the assembly OSPSuite.Presentation compiles
+      against matches what its consumers (OSPSuite.Presentation.Tests, OSPSuite.Core.IntegrationTests,
+      downstream PKSim.Presentation / MoBi.Presentation) see at compile time. Without this pin,
+      DevExpress.* packages bring System.Drawing.Common 8.0.15 transitively while the WindowsDesktop
+      framework reference pulls 10.0 implicitly into Presentation itself, producing CS1705 version
+      mismatches in consumers.
+    -->
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OSPSuite.UI/Binders/ValueOriginBinder.cs
+++ b/src/OSPSuite.UI/Binders/ValueOriginBinder.cs
@@ -19,6 +19,7 @@ using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.UI.Controls;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Extensions;

--- a/src/OSPSuite.UI/Controls/UxGridView.cs
+++ b/src/OSPSuite.UI/Controls/UxGridView.cs
@@ -21,7 +21,7 @@ using DevExpress.XtraGrid.Views.Grid;
 using DevExpress.XtraGrid.Views.Grid.ViewInfo;
 using OSPSuite.Assets;
 using OSPSuite.Core.Extensions;
-using OSPSuite.UI.Extensions;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Mappers;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Extensions;
@@ -444,14 +444,14 @@ namespace OSPSuite.UI.Controls
 
       private void addCopyMenuItemsForRowSelect(GridViewMenu gridViewMenu)
       {
-         var copyRowMenu = new DXMenuItem(Captions.CopySelectedRows, (o, args) => copyRowSelectionToClipboard()) { Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection.ToSvgImage()};
+         var copyRowMenu = new DXMenuItem(Captions.CopySelectedRows, (o, args) => copyRowSelectionToClipboard()) { Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection.ToSvgImage() };
          gridViewMenu.Items.Insert(0, copyRowMenu);
       }
 
       private void addCopyMenuItemsForCellSelect(GridViewMenu gridViewMenu)
       {
-         var copyRowMenu = new DXMenuItem(Captions.CopySelectedRows, (o, args) => copyRowSelectionToClipboard()) { SvgImage = ApplicationIcons.CopySelection.ToSvgImage()};
-         var copySelectionMenu = new DXMenuItem(Captions.CopySelection, (o, args) => processSelectiveCopyToClipboard()) { Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection.ToSvgImage()};
+         var copyRowMenu = new DXMenuItem(Captions.CopySelectedRows, (o, args) => copyRowSelectionToClipboard()) { SvgImage = ApplicationIcons.CopySelection.ToSvgImage() };
+         var copySelectionMenu = new DXMenuItem(Captions.CopySelection, (o, args) => processSelectiveCopyToClipboard()) { Shortcut = Shortcut.CtrlC, SvgImage = ApplicationIcons.CopySelection.ToSvgImage() };
          gridViewMenu.Items.Insert(0, copyRowMenu);
          gridViewMenu.Items.Insert(0, copySelectionMenu);
       }

--- a/src/OSPSuite.UI/Controls/UxHintPanel.cs
+++ b/src/OSPSuite.UI/Controls/UxHintPanel.cs
@@ -1,6 +1,6 @@
 ﻿using DevExpress.XtraEditors;
 using OSPSuite.Assets;
-using OSPSuite.UI.Extensions;
+using OSPSuite.Presentation.Extensions;
 
 namespace OSPSuite.UI.Controls
 {
@@ -17,7 +17,6 @@ namespace OSPSuite.UI.Controls
          set => panelNote.Text = value;
       }
 
-      
       public ApplicationIcon Image
       {
          set => panelNote.ArrowImage = value.ToImage(IconSizes.Size32x32);

--- a/src/OSPSuite.UI/Controls/UxPivotGrid.cs
+++ b/src/OSPSuite.UI/Controls/UxPivotGrid.cs
@@ -6,7 +6,7 @@ using DevExpress.Utils;
 using DevExpress.Utils.Menu;
 using DevExpress.XtraPivotGrid;
 using OSPSuite.Assets;
-using OSPSuite.UI.Extensions;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Mappers;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Extensions;

--- a/src/OSPSuite.UI/Extensions/BarItemExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/BarItemExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using DevExpress.Utils.Svg;
 using DevExpress.XtraBars;
 using OSPSuite.Assets;
+using OSPSuite.Presentation.Extensions;
 
 namespace OSPSuite.UI.Extensions
 {

--- a/src/OSPSuite.UI/Extensions/ImageOptionsExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/ImageOptionsExtensions.cs
@@ -3,6 +3,7 @@ using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraTab;
 using DevExpress.XtraTabbedMdi;
 using OSPSuite.Assets;
+using OSPSuite.Presentation.Extensions;
 
 namespace OSPSuite.UI.Extensions
 {

--- a/src/OSPSuite.UI/Mappers/ApplicationIconsToImageCollectionMapper.cs
+++ b/src/OSPSuite.UI/Mappers/ApplicationIconsToImageCollectionMapper.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using DevExpress.Utils;
 using OSPSuite.Assets;
-using OSPSuite.UI.Extensions;
+using OSPSuite.Presentation.Extensions;
 
 namespace OSPSuite.UI.Mappers
 {
@@ -19,6 +19,7 @@ namespace OSPSuite.UI.Mappers
          {
             imageList.Add(icon.IconName, icon.ToSvgImage());
          }
+
          return imageList;
       }
    }

--- a/src/OSPSuite.UI/Views/Charts/CurveSettingsView.cs
+++ b/src/OSPSuite.UI/Views/Charts/CurveSettingsView.cs
@@ -13,6 +13,7 @@ using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraGrid.Views.Grid;
 using DevExpress.XtraGrid.Views.Grid.ViewInfo;
 using OSPSuite.Assets;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.DataBinding;

--- a/src/OSPSuite.UI/Views/Charts/DataBrowserPopupMenu.cs
+++ b/src/OSPSuite.UI/Views/Charts/DataBrowserPopupMenu.cs
@@ -4,6 +4,7 @@ using DevExpress.XtraGrid.Menu;
 using OSPSuite.Assets;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.Presentation.Presenters.Charts;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Extensions;
 
 namespace OSPSuite.UI.Views.Charts

--- a/src/OSPSuite.UI/Views/ExceptionView.cs
+++ b/src/OSPSuite.UI/Views/ExceptionView.cs
@@ -6,6 +6,7 @@ using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraLayout.Utils;
 using OSPSuite.Assets;
 using OSPSuite.Presentation.Views;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Extensions;
 
 namespace OSPSuite.UI.Views

--- a/src/OSPSuite.UI/Views/QuantityListView.cs
+++ b/src/OSPSuite.UI/Views/QuantityListView.cs
@@ -6,6 +6,7 @@ using DevExpress.XtraGrid.Columns;
 using DevExpress.XtraGrid.Menu;
 using DevExpress.XtraGrid.Views.Grid;
 using OSPSuite.Assets;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;

--- a/src/OSPSuite.UI/Views/SimulationOutputMappingView.cs
+++ b/src/OSPSuite.UI/Views/SimulationOutputMappingView.cs
@@ -8,6 +8,7 @@ using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraGrid.Views.Grid.ViewInfo;
 using OSPSuite.Assets;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;

--- a/tests/OSPSuite.Presentation.Tests/Presentation/Extensions/ApplicationIconExtensionsSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/Extensions/ApplicationIconExtensionsSpecs.cs
@@ -2,7 +2,7 @@ using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 
-namespace OSPSuite.UI.Extensions
+namespace OSPSuite.Presentation.Extensions
 {
    public abstract class concern_for_ApplicationIconExtensions : ContextSpecification<ApplicationIcon>
    {


### PR DESCRIPTION
## Summary

- `ApplicationIconExtensions` (the `ToSvgImage` / `ToImage` / `ToDrawingSize` methods) moves from `src/OSPSuite.UI/Extensions/` to `src/OSPSuite.Presentation/Extensions/`. Namespace `OSPSuite.UI.Extensions` → `OSPSuite.Presentation.Extensions`.
- [`OSPSuite.Presentation.csproj`](src/OSPSuite.Presentation/OSPSuite.Presentation.csproj) gains `<PackageReference Include="DevExpress.Utils" Version="25.2.7" />` (brings `SvgImage` / `DefaultBoolean`) and a pinned `<PackageReference Include="System.Drawing.Common" Version="10.0.7" />` (avoids CS1705 in consumers — DevExpress.* bring System.Drawing.Common 8.0.15 transitively while the WindowsDesktop framework reference resolves Presentation against 10.0).
- 13 OSPSuite.UI consumer files (Views, Controls, Mappers, Binders, the other Extensions files) get `using OSPSuite.Presentation.Extensions;` alongside their existing `using OSPSuite.UI.Extensions;`.
- The 4 `ApplicationIconExtensions` specs move from `tests/OSPSuite.UI.Tests/Extensions/` to `tests/OSPSuite.Presentation.Tests/Presentation/Extensions/`, namespace updated.

## Why

After #2858, the rendering lived in `OSPSuite.UI/Extensions`, which is unreachable from `Presentation` layers without inverting the layer order. PK-Sim and MoBi have DTOs that expose `Image`-typed properties bound directly into DevExpress `RepositoryItemPictureEdit` grid columns — the conversion has to happen at the DTO's `get` accessor, **below** UI. The workaround was a duplicated `IconImageRenderer` internal helper class in each of `PKSim.Presentation` and `MoBi.Presentation`, each with its own `DevExpress.Utils` PackageReference. Two implementations of the same logic with the same dependency, sitting in two places.

`OSPSuite.Presentation` is already permanently `net10.0-windows` and already references `DevExpress.Data` for `DxValidatableDTO`. Hosting the rendering here is honest, consolidates the Windows surface, and lets PK-Sim and MoBi consume `icon.ToImage()` directly from their DTOs through the package reference they already have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal extension functionality for improved code structure.

* **Dependencies**
  * Added dependency and pinned version to ensure compatibility across library consumers.


[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite.Core/pull/2865)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->