### PR TITLE
Fixes #2866 Color observed data by folder for any selection of observed data nodes

### DIFF
--- a/src/OSPSuite.Presentation/Binders/ObservedDataDragDropBinder.cs
+++ b/src/OSPSuite.Presentation/Binders/ObservedDataDragDropBinder.cs
@@ -34,15 +34,10 @@ namespace OSPSuite.Presentation.Binders
 
          var treeNodes = dataNodes.ToList();
 
-         //if we are dropping a selection of observed data sets, we should not get them grouped together
-         if (areAllObservedDataNodes(treeNodes))
-            return observedDataNodesFromNodes(treeNodes);
-         //if we are dropping a selection of folders, data sets should be grouped according to their parent folder
-         if (areAllObservedDataClassificationNodes(treeNodes) || areAllRootNodes(treeNodes))
-               return observedDataNodesGroupedByFolder(treeNodes).ToList();
+         if (!isDraggedTypeObservedDataRelated(treeNodes))
+            return new List<List<DataRepository>>();
 
-
-         return new List<List<DataRepository>>();
+         return observedDataNodesGroupedByFolder(treeNodes).ToList();
       }
 
       private DragEffect dragEffectForConditionalType(IDragEvent e)
@@ -106,26 +101,28 @@ namespace OSPSuite.Presentation.Binders
          var observedDataWithFolderAddressCache = new Cache<string, List<DataRepository>>();
          treeNodes.Each(treeNode =>
          {
-            var classificationNode = getClassificationNodeFrom(treeNode);
-            classificationNode.AllLeafNodes.OfType<ObservedDataNode>().Each(observedDataNode =>
-            {
-               if (observedDataWithFolderAddressCache.Contains(observedDataNode.ParentNode.Id))
-                  observedDataWithFolderAddressCache[observedDataNode.ParentNode.Id].Add(observedDataNode.Tag.Subject);
-               else
-                  observedDataWithFolderAddressCache.Add(observedDataNode.ParentNode.Id, new List<DataRepository> { observedDataNode.Tag.Subject });
-            });
+            if (treeNode is ObservedDataNode observedDataNode)
+               addObservedDataNodeToCache(observedDataWithFolderAddressCache, observedDataNode);
+            else
+               addClassificationNodeToCache(observedDataWithFolderAddressCache, treeNode);
          });
          return observedDataWithFolderAddressCache;
       }
 
-      //when dragging and dropping just a selection of observed data and not folders, each one should get a different color
-      private static List<List<DataRepository>> observedDataNodesFromNodes(IEnumerable<ITreeNode> treeNodes)
+      private void addClassificationNodeToCache(Cache<string, List<DataRepository>> cache, ITreeNode treeNode)
       {
-         var observedDataWithFolderAddressCache = new List<List<DataRepository>>();
-         treeNodes.OfType<ObservedDataNode>().Each(node =>
-            observedDataWithFolderAddressCache.Add(new List<DataRepository> {node.Tag.Subject})
-         );
-         return observedDataWithFolderAddressCache;
+         var classificationNode = getClassificationNodeFrom(treeNode);
+         classificationNode.AllLeafNodes.OfType<ObservedDataNode>().Each(node =>
+            addObservedDataNodeToCache(cache, node));
+      }
+
+      private static void addObservedDataNodeToCache(Cache<string, List<DataRepository>> cache, ObservedDataNode observedDataNode)
+      {
+         var parentNodeId = observedDataNode.ParentNode.Id;
+         if (cache.Contains(parentNodeId))
+            cache[parentNodeId].Add(observedDataNode.Tag.Subject);
+         else
+            cache.Add(parentNodeId, [observedDataNode.Tag.Subject]);
       }
 
       private static IReadOnlyList<ObservedDataNode> observedDataNodesFromObservedDataNodes(IEnumerable<ITreeNode> treeNodes)

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ObservedDataDragDropBinderSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ObservedDataDragDropBinderSpecs.cs
@@ -36,12 +36,11 @@ namespace OSPSuite.Presentation.Presentation
          _data = new DragDropInfo(
             new List<ITreeNode>
             {
-               new ObservedDataNode(new ClassifiableObservedData {Subject = new DataRepository()})
+               new ObservedDataNode(new ClassifiableObservedData { Subject = new DataRepository() })
             });
          base.Context();
       }
 
-      
       protected override void Because()
       {
          sut.PrepareDrag(_dragEventArgs);
@@ -60,7 +59,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          _data = new DragDropInfo(new List<ITreeNode>
          {
-            new ClassificationNode(new Classification {ClassificationType = ClassificationType.ObservedData})
+            new ClassificationNode(new Classification { ClassificationType = ClassificationType.ObservedData })
          });
 
          base.Context();
@@ -110,8 +109,7 @@ namespace OSPSuite.Presentation.Presentation
          _data = new DragDropInfo(
             new List<ITreeNode>
             {
-               new RootNode(new RootNodeType("ObservedDataFolder", ApplicationIcons.ObservedDataFolder,ClassificationType.ObservedData))
-            
+               new RootNode(new RootNodeType("ObservedDataFolder", ApplicationIcons.ObservedDataFolder, ClassificationType.ObservedData))
             });
          base.Context();
       }
@@ -179,6 +177,7 @@ namespace OSPSuite.Presentation.Presentation
    public class When_retrieving_the_dropped_observed_data_for_an_observed_data_node : concern_for_ObservedDataDragDropBinder
    {
       private DataRepository _repository;
+      private IReadOnlyList<DataRepository> _result;
 
       protected override void Context()
       {
@@ -191,10 +190,15 @@ namespace OSPSuite.Presentation.Presentation
          base.Context();
       }
 
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataFrom(_dragEventArgs);
+      }
+
       [Observation]
       public void should_return_the_underlying_observed_data()
       {
-         sut.DroppedObservedDataFrom(_dragEventArgs).ShouldOnlyContainInOrder(_repository);
+         _result.ShouldOnlyContainInOrder(_repository);
       }
    }
 
@@ -202,11 +206,12 @@ namespace OSPSuite.Presentation.Presentation
    {
       private DataRepository _repository1;
       private DataRepository _repository2;
+      private IReadOnlyList<DataRepository> _result;
 
       protected override void Context()
       {
          _repository1 = new DataRepository();
-         _repository2 =  new DataRepository();
+         _repository2 = new DataRepository();
          var classificationNode = new ClassificationNode(new Classification { ClassificationType = ClassificationType.ObservedData });
          classificationNode.AddChild(new ObservedDataNode(new ClassifiableObservedData { Subject = _repository1 }));
          classificationNode.AddChild(new ObservedDataNode(new ClassifiableObservedData { Subject = _repository2 }));
@@ -219,10 +224,15 @@ namespace OSPSuite.Presentation.Presentation
          base.Context();
       }
 
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataFrom(_dragEventArgs);
+      }
+
       [Observation]
       public void should_return_all_underlying_observed_data()
       {
-         sut.DroppedObservedDataFrom(_dragEventArgs).ShouldOnlyContainInOrder(_repository1, _repository2);
+         _result.ShouldOnlyContainInOrder(_repository1, _repository2);
       }
    }
 
@@ -230,6 +240,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       private DataRepository _repository1;
       private DataRepository _repository2;
+      private IReadOnlyList<DataRepository> _result;
 
       protected override void Context()
       {
@@ -248,34 +259,48 @@ namespace OSPSuite.Presentation.Presentation
          base.Context();
       }
 
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataFrom(_dragEventArgs);
+      }
+
       [Observation]
       public void should_return_all_underlying_observed_data()
       {
-         sut.DroppedObservedDataFrom(_dragEventArgs).ShouldOnlyContainInOrder(_repository1, _repository2);
+         _result.ShouldOnlyContainInOrder(_repository1, _repository2);
       }
    }
 
-   public class When_retrieving_the_dropped_observed_data_color_grouped_for_an_observed_data_node : concern_for_ObservedDataDragDropBinder
+   public class When_retrieving_the_dropped_observed_data_color_grouped_for_an_observed_data_node_directly_under_the_root : concern_for_ObservedDataDragDropBinder
    {
       private DataRepository _repository;
+      private List<List<DataRepository>> _result;
 
       protected override void Context()
       {
          _repository = A.Fake<DataRepository>();
+         var rootNode = new RootNode(new RootNodeType("ObservedDataFolder", ApplicationIcons.ObservedDataFolder, ClassificationType.ObservedData));
+         var observedDataNode = new ObservedDataNode(new ClassifiableObservedData { Subject = _repository });
+         rootNode.AddChild(observedDataNode);
+
          _data = new DragDropInfo(
             new List<ITreeNode>
             {
-               new ObservedDataNode(new ClassifiableObservedData { Subject = _repository })
+               observedDataNode
             });
          base.Context();
+      }
+
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
       }
 
       [Observation]
       public void should_return_the_underlying_observed_data_with_its_ID_as_key()
       {
-         var result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
-         result.Count.ShouldBeEqualTo(1);
-         result[0].ShouldOnlyContain(_repository);
+         _result.Count.ShouldBeEqualTo(1);
+         _result[0].ShouldOnlyContain(_repository);
       }
    }
 
@@ -283,6 +308,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       private DataRepository _repository1;
       private DataRepository _repository2;
+      private List<List<DataRepository>> _result;
 
       protected override void Context()
       {
@@ -300,12 +326,16 @@ namespace OSPSuite.Presentation.Presentation
          base.Context();
       }
 
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
+      }
+
       [Observation]
       public void should_return_all_underlying_observed_data()
       {
-         var result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
-         result.Count.ShouldBeEqualTo(1);
-         result[0].ShouldOnlyContain(_repository1, _repository2);
+         _result.Count.ShouldBeEqualTo(1);
+         _result[0].ShouldOnlyContain(_repository1, _repository2);
       }
    }
 
@@ -313,6 +343,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       private DataRepository _repository1;
       private DataRepository _repository2;
+      private List<List<DataRepository>> _result;
 
       protected override void Context()
       {
@@ -331,16 +362,106 @@ namespace OSPSuite.Presentation.Presentation
          base.Context();
       }
 
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
+      }
+
       [Observation]
       public void should_return_all_underlying_observed_data()
       {
-         var result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
-         result.Count.ShouldBeEqualTo(2);
-         
-         var rootNode = (_data.Subject as List<ITreeNode>)[0] as RootNode;
-         result[1].ShouldOnlyContain(_repository1);
-         var classificationNode = rootNode.AllNodes.FirstOrDefault(node => (node as ClassificationNode) != null);
-         result[0].ShouldOnlyContain(_repository2);
+         _result.Count.ShouldBeEqualTo(2);
+         _result[1].ShouldOnlyContain(_repository1);
+         _result[0].ShouldOnlyContain(_repository2);
+      }
+   }
+
+   public class When_retrieving_the_dropped_observed_data_color_grouped_for_a_subset_of_observed_data_nodes_in_the_same_folder : concern_for_ObservedDataDragDropBinder
+   {
+      private DataRepository _repository1;
+      private DataRepository _repository2;
+      private DataRepository _ignoredRepository;
+      private List<List<DataRepository>> _result;
+
+      protected override void Context()
+      {
+         _repository1 = new DataRepository();
+         _repository2 = new DataRepository();
+         _ignoredRepository = new DataRepository();
+         var classificationNode = new ClassificationNode(new Classification { ClassificationType = ClassificationType.ObservedData });
+         var pickedNode1 = new ObservedDataNode(new ClassifiableObservedData { Subject = _repository1 });
+         var pickedNode2 = new ObservedDataNode(new ClassifiableObservedData { Subject = _repository2 });
+         classificationNode.AddChild(pickedNode1);
+         classificationNode.AddChild(pickedNode2);
+         classificationNode.AddChild(new ObservedDataNode(new ClassifiableObservedData { Subject = _ignoredRepository }));
+
+         _data = new DragDropInfo(
+            new List<ITreeNode>
+            {
+               pickedNode1,
+               pickedNode2
+            });
+         base.Context();
+      }
+
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
+      }
+
+      [Observation]
+      public void should_return_a_single_color_group_containing_only_the_selected_observed_data()
+      {
+         _result.Count.ShouldBeEqualTo(1);
+         _result[0].ShouldOnlyContain(_repository1, _repository2);
+      }
+   }
+
+   public class When_retrieving_the_dropped_observed_data_color_grouped_for_observed_data_nodes_from_different_folders : concern_for_ObservedDataDragDropBinder
+   {
+      private DataRepository _repositoryUnderRoot;
+      private DataRepository _repositoryInClassification1;
+      private DataRepository _repositoryInClassification2;
+      private List<List<DataRepository>> _result;
+
+      protected override void Context()
+      {
+         _repositoryUnderRoot = new DataRepository();
+         _repositoryInClassification1 = new DataRepository();
+         _repositoryInClassification2 = new DataRepository();
+
+         var rootNode = new RootNode(new RootNodeType("ObservedDataFolder", ApplicationIcons.ObservedDataFolder, ClassificationType.ObservedData));
+         var classificationNode = new ClassificationNode(new Classification { ClassificationType = ClassificationType.ObservedData });
+         rootNode.AddChild(classificationNode);
+
+         var nodeUnderRoot = new ObservedDataNode(new ClassifiableObservedData { Subject = _repositoryUnderRoot });
+         var nodeInClassification1 = new ObservedDataNode(new ClassifiableObservedData { Subject = _repositoryInClassification1 });
+         var nodeInClassification2 = new ObservedDataNode(new ClassifiableObservedData { Subject = _repositoryInClassification2 });
+         rootNode.AddChild(nodeUnderRoot);
+         classificationNode.AddChild(nodeInClassification1);
+         classificationNode.AddChild(nodeInClassification2);
+
+         _data = new DragDropInfo(
+            new List<ITreeNode>
+            {
+               nodeUnderRoot,
+               nodeInClassification1,
+               nodeInClassification2
+            });
+         base.Context();
+      }
+
+      protected override void Because()
+      {
+         _result = sut.DroppedObservedDataWithFolderPathFrom(_dragEventArgs);
+      }
+
+      [Observation]
+      public void should_return_one_color_group_per_parent_folder()
+      {
+         _result.Count.ShouldBeEqualTo(2);
+         _result.First(group => group.Contains(_repositoryUnderRoot)).ShouldOnlyContain(_repositoryUnderRoot);
+         _result.First(group => group.Contains(_repositoryInClassification1)).ShouldOnlyContain(_repositoryInClassification1, _repositoryInClassification2);
       }
    }
 }


### PR DESCRIPTION
## Summary
- `ObservedDataDragDropBinder.DroppedObservedDataWithFolderPathFrom` now groups dropped observed data by their parent classification regardless of whether the drag was of folders, individual observed-data nodes, or items directly under the root.
- Subset selections within one folder share a single color group; selections spanning multiple folders produce one color group per parent.
- The two existing input shapes (single ObservedDataNode, whole classification folder, whole root folder) keep their previous grouping.

## Test plan
Enable the `ColorGroupObservedDataFromSameFolder` user setting in MoBi, set up an observed-data tree with two classification folders plus one dataset directly under the root, then drag onto a chart:

**Regressions:**
- [x] Drag a whole classification folder → its datasets share one color.
- [x] Drag the root observed-data folder → datasets grouped by their direct parent.
- [x] Drag two whole classification folders → two color groups, one per folder.
- [x] Drag a single observed data item → one color group of one.

**New behavior:**
- [x] Multi-select a subset of datasets within one classification folder → all share one color.
- [x] Multi-select datasets across two classification folders → two color groups, partitioned by parent.
- [x] Multi-select where some are under a classification and some directly under the root → one color group per parent.

**Drag-effect sanity:**
- [x] Drag a non-observed-data node (e.g. simulation folder) onto an observed-data target → rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal structure of observed data drag-and-drop handling for better organization by folder path.

* **Tests**
  * Updated test suite to enhance test structure and coverage for observed data drag-and-drop scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite.Core/pull/2867)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->