### PR TITLE
Fixes #2868 Require at least one successful PK parameter sensitivity for HasResults

### DIFF
--- a/src/OSPSuite.Core/Domain/SensitivityAnalyses/SensitivityAnalysis.cs
+++ b/src/OSPSuite.Core/Domain/SensitivityAnalyses/SensitivityAnalysis.cs
@@ -37,7 +37,7 @@ namespace OSPSuite.Core.Domain.SensitivityAnalyses
 
       public IEnumerable<ISimulationAnalysis> Analyses => _allSimulationAnalyses;
 
-      public virtual bool HasResults => Results != null && Results.AllPKParameterSensitivities.Any();
+      public virtual bool HasResults => Results != null && Results.AllPKParameterSensitivities.Any(x => x.State.Equals(PKParameterSensitivityState.Success));
 
       public virtual bool HasUpToDateResults => Simulation != null && Simulation.HasUpToDateResults;
 

--- a/tests/OSPSuite.Core.Tests/Domain/SensitivityAnalysisSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/SensitivityAnalysisSpecs.cs
@@ -46,4 +46,68 @@ namespace OSPSuite.Core.Domain
       {
          sut.AllSensitivityParameters.All(parameter => Equals(parameter.ParameterSelection.Simulation, _newSimulation)).ShouldBeTrue();
       }
-   } }
+   }
+
+   public class When_checking_if_a_sensitivity_analysis_has_results_and_no_results_are_set : concern_for_SensitivityAnalysis
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Results = null;
+      }
+
+      [Observation]
+      public void should_return_false()
+      {
+         sut.HasResults.ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_if_a_sensitivity_analysis_has_results_and_results_contain_no_pk_parameter_sensitivities : concern_for_SensitivityAnalysis
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Results = new SensitivityAnalysisRunResult();
+      }
+
+      [Observation]
+      public void should_return_false()
+      {
+         sut.HasResults.ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_if_a_sensitivity_analysis_has_results_and_results_contain_only_failed_pk_parameter_sensitivities : concern_for_SensitivityAnalysis
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Results = new SensitivityAnalysisRunResult();
+         sut.Results.AddPKParameterSensitivity(new PKParameterSensitivity {State = PKParameterSensitivityState.FailedToCalculateDefaultPKValue});
+      }
+
+      [Observation]
+      public void should_return_false()
+      {
+         sut.HasResults.ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_if_a_sensitivity_analysis_has_results_and_at_least_one_pk_parameter_sensitivity_succeeded : concern_for_SensitivityAnalysis
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Results = new SensitivityAnalysisRunResult();
+         sut.Results.AddPKParameterSensitivity(new PKParameterSensitivity {State = PKParameterSensitivityState.FailedToCalculateDefaultPKValue});
+         sut.Results.AddPKParameterSensitivity(new PKParameterSensitivity {State = PKParameterSensitivityState.Success});
+      }
+
+      [Observation]
+      public void should_return_true()
+      {
+         sut.HasResults.ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- `SensitivityAnalysis.HasResults` now requires at least one `PKParameterSensitivity` with `State == Success`. Previously any sensitivity entry (including ones recorded as `FailedToCalculateDefaultPKValue`) was enough to make `HasResults` true, which hid the underlying simulation errors that caused the PK calculations to fail.
- Added BDD specs covering the four cases: null results, no sensitivities, only failed sensitivities, and at least one successful sensitivity.

Fixes #2868

## Test plan
- [x] `dotnet test tests/OSPSuite.Core.Tests --filter "FullyQualifiedName~When_checking_if_a_sensitivity_analysis_has_results"` — 4/4 pass.
- [ ] Manually verify in PK-Sim/MoBi that a simulation failure (e.g. missing administration) now surfaces the underlying simulation errors alongside the PK-calculation-failed dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sensitivity analysis results detection to accurately identify when successful results are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite.Core/pull/2869)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->