### PR TITLE
Fixes #2874 Add line thickness to curve multi edit

### DIFF
--- a/src/OSPSuite.Core/Domain/Constants.cs
+++ b/src/OSPSuite.Core/Domain/Constants.cs
@@ -739,6 +739,7 @@ namespace OSPSuite.Core.Domain
       public static class MultiCurveOptions
       {
          public static readonly IReadOnlyList<bool?> AllBooleanOptions = new bool?[] {null, false, true};
+         public static readonly IReadOnlyList<int?> AllLineThicknesses = new int?[] {null, 1, 2, 3};
       }
 
       public static class ImporterConstants

--- a/src/OSPSuite.Presentation/Formatters/MultiCurveOptionsFormatter.cs
+++ b/src/OSPSuite.Presentation/Formatters/MultiCurveOptionsFormatter.cs
@@ -37,4 +37,15 @@ namespace OSPSuite.Presentation.Formatters
          return valueToFormat.Value.ToString();
       }
    }
+
+   public class LineThicknessFormatter : IFormatter<int?>
+   {
+      public string Format(int? valueToFormat)
+      {
+         if (valueToFormat == null)
+            return Captions.Chart.MultiCurveOptions.CurrentValue;
+
+         return valueToFormat.Value.ToString();
+      }
+   }
 }

--- a/src/OSPSuite.Presentation/Presenters/Charts/CurveMultiItemEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/CurveMultiItemEditorPresenter.cs
@@ -14,6 +14,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       IEnumerable<bool?> AllBooleanOptions { get; }
       IEnumerable<LineStyles?> AllLineStyles { get; }
       IEnumerable<Symbols?> AllSymbols { get; }
+      IEnumerable<int?> AllLineThicknesses { get; }
    }
 
    public class SelectedCurveValues
@@ -21,6 +22,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       public Color? Color { get; set; }
       public LineStyles? Style { get; set; }
       public Symbols? Symbol { get; set; }
+      public int? LineThickness { get; set; }
       public bool? Visible { get; set; }
       public bool? VisibleInLegend { get; set; }
    }
@@ -40,6 +42,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
       public IEnumerable<LineStyles?> AllLineStyles { get; } = new List<LineStyles?>() {null}.Union(EnumHelper.AllValuesFor<LineStyles>().Cast<LineStyles?>());
 
       public IEnumerable<Symbols?> AllSymbols { get; } = new List<Symbols?>() {null}.Union(EnumHelper.AllValuesFor<Symbols>().Cast<Symbols?>());
+
+      public IEnumerable<int?> AllLineThicknesses { get; } = Constants.MultiCurveOptions.AllLineThicknesses;
 
       public SelectedCurveValues GetSelectedValues()
       {

--- a/src/OSPSuite.Presentation/Presenters/Charts/CurveSettingsPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/CurveSettingsPresenter.cs
@@ -220,6 +220,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
                curveDTO.LineStyle = selectedValues.Style.GetValueOrDefault(curveDTO.LineStyle);
                curveDTO.Color = selectedValues.Color.GetValueOrDefault(curveDTO.Color);
                curveDTO.Symbol = selectedValues.Symbol.GetValueOrDefault(curveDTO.Symbol);
+               curveDTO.LineThickness = selectedValues.LineThickness.GetValueOrDefault(curveDTO.LineThickness);
                curveDTO.Visible = selectedValues.Visible.GetValueOrDefault(curveDTO.Visible);
                curveDTO.VisibleInLegend = selectedValues.VisibleInLegend.GetValueOrDefault(curveDTO.VisibleInLegend);
 

--- a/src/OSPSuite.UI/Views/Charts/CurveMultiItemEditorView.Designer.cs
+++ b/src/OSPSuite.UI/Views/Charts/CurveMultiItemEditorView.Designer.cs
@@ -1,4 +1,4 @@
-﻿using OSPSuite.UI.Controls;
+using OSPSuite.UI.Controls;
 
 namespace OSPSuite.UI.Views.Charts
 {
@@ -34,6 +34,7 @@ namespace OSPSuite.UI.Views.Charts
          this.colorEditLayoutControl = new DevExpress.XtraLayout.LayoutControl();
          this.inLegendComboBoxEdit = new UxComboBoxEdit();
          this.visibleComboBoxEdit = new UxComboBoxEdit();
+         this.lineThicknessComboBoxEdit = new UxComboBoxEdit();
          this.symbolComboBoxEdit = new UxComboBoxEdit();
          this.styleComboBoxEdit = new UxComboBoxEdit();
          this.colorPickEdit = new UxColorPickEditWithHistory();
@@ -42,6 +43,7 @@ namespace OSPSuite.UI.Views.Charts
          this.colorLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.styleLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.symbolLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+         this.lineThicknessLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.visibleLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.inLegendLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
@@ -49,6 +51,7 @@ namespace OSPSuite.UI.Views.Charts
          this.colorEditLayoutControl.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.inLegendComboBoxEdit.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.visibleComboBoxEdit.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.lineThicknessComboBoxEdit.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.symbolComboBoxEdit.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.styleComboBoxEdit.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorPickEdit.Properties)).BeginInit();
@@ -57,14 +60,16 @@ namespace OSPSuite.UI.Views.Charts
          ((System.ComponentModel.ISupportInitialize)(this.colorLayoutControlItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.styleLayoutControlItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.symbolLayoutControlItem)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.lineThicknessLayoutControlItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.visibleLayoutControlItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.inLegendLayoutControlItem)).BeginInit();
          this.SuspendLayout();
-         // 
+         //
          // colorEditLayoutControl
-         // 
+         //
          this.colorEditLayoutControl.Controls.Add(this.inLegendComboBoxEdit);
          this.colorEditLayoutControl.Controls.Add(this.visibleComboBoxEdit);
+         this.colorEditLayoutControl.Controls.Add(this.lineThicknessComboBoxEdit);
          this.colorEditLayoutControl.Controls.Add(this.symbolComboBoxEdit);
          this.colorEditLayoutControl.Controls.Add(this.styleComboBoxEdit);
          this.colorEditLayoutControl.Controls.Add(this.colorPickEdit);
@@ -72,67 +77,78 @@ namespace OSPSuite.UI.Views.Charts
          this.colorEditLayoutControl.Location = new System.Drawing.Point(0, 0);
          this.colorEditLayoutControl.Name = "colorEditLayoutControl";
          this.colorEditLayoutControl.Root = this.Root;
-         this.colorEditLayoutControl.Size = new System.Drawing.Size(1035, 431);
+         this.colorEditLayoutControl.Size = new System.Drawing.Size(414, 218);
          this.colorEditLayoutControl.TabIndex = 38;
-         // 
+         //
          // inLegendComboBoxEdit
-         // 
-         this.inLegendComboBoxEdit.Location = new System.Drawing.Point(134, 220);
+         //
+         this.inLegendComboBoxEdit.Location = new System.Drawing.Point(147, 132);
          this.inLegendComboBoxEdit.Name = "inLegendComboBoxEdit";
          this.inLegendComboBoxEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
          this.inLegendComboBoxEdit.Properties.TextEditStyle = DevExpress.XtraEditors.Controls.TextEditStyles.DisableTextEditor;
-         this.inLegendComboBoxEdit.Size = new System.Drawing.Size(889, 48);
+         this.inLegendComboBoxEdit.Size = new System.Drawing.Size(255, 20);
          this.inLegendComboBoxEdit.StyleController = this.colorEditLayoutControl;
-         this.inLegendComboBoxEdit.TabIndex = 9;
-         // 
+         this.inLegendComboBoxEdit.TabIndex = 10;
+         //
          // visibleComboBoxEdit
-         // 
-         this.visibleComboBoxEdit.Location = new System.Drawing.Point(134, 168);
+         //
+         this.visibleComboBoxEdit.Location = new System.Drawing.Point(147, 108);
          this.visibleComboBoxEdit.Name = "visibleComboBoxEdit";
          this.visibleComboBoxEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
          this.visibleComboBoxEdit.Properties.TextEditStyle = DevExpress.XtraEditors.Controls.TextEditStyles.DisableTextEditor;
-         this.visibleComboBoxEdit.Size = new System.Drawing.Size(889, 48);
+         this.visibleComboBoxEdit.Size = new System.Drawing.Size(255, 20);
          this.visibleComboBoxEdit.StyleController = this.colorEditLayoutControl;
-         this.visibleComboBoxEdit.TabIndex = 8;
-         // 
+         this.visibleComboBoxEdit.TabIndex = 9;
+         //
+         // lineThicknessComboBoxEdit
+         //
+         this.lineThicknessComboBoxEdit.Location = new System.Drawing.Point(147, 84);
+         this.lineThicknessComboBoxEdit.Name = "lineThicknessComboBoxEdit";
+         this.lineThicknessComboBoxEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.lineThicknessComboBoxEdit.Properties.TextEditStyle = DevExpress.XtraEditors.Controls.TextEditStyles.DisableTextEditor;
+         this.lineThicknessComboBoxEdit.Size = new System.Drawing.Size(255, 20);
+         this.lineThicknessComboBoxEdit.StyleController = this.colorEditLayoutControl;
+         this.lineThicknessComboBoxEdit.TabIndex = 8;
+         //
          // symbolComboBoxEdit
-         // 
-         this.symbolComboBoxEdit.Location = new System.Drawing.Point(134, 116);
+         //
+         this.symbolComboBoxEdit.Location = new System.Drawing.Point(147, 60);
          this.symbolComboBoxEdit.Name = "symbolComboBoxEdit";
          this.symbolComboBoxEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
          this.symbolComboBoxEdit.Properties.TextEditStyle = DevExpress.XtraEditors.Controls.TextEditStyles.DisableTextEditor;
-         this.symbolComboBoxEdit.Size = new System.Drawing.Size(889, 48);
+         this.symbolComboBoxEdit.Size = new System.Drawing.Size(255, 20);
          this.symbolComboBoxEdit.StyleController = this.colorEditLayoutControl;
          this.symbolComboBoxEdit.TabIndex = 7;
-         // 
+         //
          // styleComboBoxEdit
-         // 
-         this.styleComboBoxEdit.Location = new System.Drawing.Point(134, 64);
+         //
+         this.styleComboBoxEdit.Location = new System.Drawing.Point(147, 36);
          this.styleComboBoxEdit.Name = "styleComboBoxEdit";
          this.styleComboBoxEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
          this.styleComboBoxEdit.Properties.TextEditStyle = DevExpress.XtraEditors.Controls.TextEditStyles.DisableTextEditor;
-         this.styleComboBoxEdit.Size = new System.Drawing.Size(889, 48);
+         this.styleComboBoxEdit.Size = new System.Drawing.Size(255, 20);
          this.styleComboBoxEdit.StyleController = this.colorEditLayoutControl;
          this.styleComboBoxEdit.TabIndex = 6;
-         // 
-         // colorPickEdit1
-         // 
+         //
+         // colorPickEdit
+         //
          this.colorPickEdit.EditValue = System.Drawing.Color.Empty;
-         this.colorPickEdit.Location = new System.Drawing.Point(134, 12);
+         this.colorPickEdit.Location = new System.Drawing.Point(147, 12);
          this.colorPickEdit.Name = "colorPickEdit";
          this.colorPickEdit.Properties.AutomaticColor = System.Drawing.Color.Black;
          this.colorPickEdit.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.colorPickEdit.Size = new System.Drawing.Size(889, 48);
+         this.colorPickEdit.Size = new System.Drawing.Size(255, 20);
          this.colorPickEdit.StyleController = this.colorEditLayoutControl;
          this.colorPickEdit.TabIndex = 5;
-         // 
+         //
          // Root
-         // 
+         //
          this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
          this.Root.GroupBordersVisible = false;
          this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
@@ -140,79 +156,91 @@ namespace OSPSuite.UI.Views.Charts
             this.colorLayoutControlItem,
             this.styleLayoutControlItem,
             this.symbolLayoutControlItem,
+            this.lineThicknessLayoutControlItem,
             this.visibleLayoutControlItem,
             this.inLegendLayoutControlItem});
          this.Root.Name = "Root";
-         this.Root.Size = new System.Drawing.Size(1035, 431);
+         this.Root.Size = new System.Drawing.Size(414, 218);
          this.Root.TextVisible = false;
-         // 
+         //
          // emptySpaceItem1
-         // 
+         //
          this.emptySpaceItem1.AllowHotTrack = false;
-         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 260);
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 144);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
-         this.emptySpaceItem1.Size = new System.Drawing.Size(1015, 151);
+         this.emptySpaceItem1.Size = new System.Drawing.Size(394, 54);
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
-         // 
+         //
          // colorLayoutControlItem
-         // 
+         //
          this.colorLayoutControlItem.Control = this.colorPickEdit;
          this.colorLayoutControlItem.Location = new System.Drawing.Point(0, 0);
          this.colorLayoutControlItem.Name = "colorLayoutControlItem";
-         this.colorLayoutControlItem.Size = new System.Drawing.Size(1015, 52);
+         this.colorLayoutControlItem.Size = new System.Drawing.Size(394, 24);
          this.colorLayoutControlItem.Text = "Color";
-         this.colorLayoutControlItem.TextSize = new System.Drawing.Size(119, 33);
-         // 
+         this.colorLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
          // styleLayoutControlItem
-         // 
+         //
          this.styleLayoutControlItem.Control = this.styleComboBoxEdit;
-         this.styleLayoutControlItem.Location = new System.Drawing.Point(0, 52);
+         this.styleLayoutControlItem.Location = new System.Drawing.Point(0, 24);
          this.styleLayoutControlItem.Name = "styleLayoutControlItem";
-         this.styleLayoutControlItem.Size = new System.Drawing.Size(1015, 52);
+         this.styleLayoutControlItem.Size = new System.Drawing.Size(394, 24);
          this.styleLayoutControlItem.Text = "Style";
-         this.styleLayoutControlItem.TextSize = new System.Drawing.Size(119, 33);
-         // 
+         this.styleLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
          // symbolLayoutControlItem
-         // 
+         //
          this.symbolLayoutControlItem.Control = this.symbolComboBoxEdit;
-         this.symbolLayoutControlItem.Location = new System.Drawing.Point(0, 104);
+         this.symbolLayoutControlItem.Location = new System.Drawing.Point(0, 48);
          this.symbolLayoutControlItem.Name = "symbolLayoutControlItem";
-         this.symbolLayoutControlItem.Size = new System.Drawing.Size(1015, 52);
+         this.symbolLayoutControlItem.Size = new System.Drawing.Size(394, 24);
          this.symbolLayoutControlItem.Text = "Symbol";
-         this.symbolLayoutControlItem.TextSize = new System.Drawing.Size(119, 33);
-         // 
+         this.symbolLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
+         // lineThicknessLayoutControlItem
+         //
+         this.lineThicknessLayoutControlItem.Control = this.lineThicknessComboBoxEdit;
+         this.lineThicknessLayoutControlItem.Location = new System.Drawing.Point(0, 72);
+         this.lineThicknessLayoutControlItem.Name = "lineThicknessLayoutControlItem";
+         this.lineThicknessLayoutControlItem.Size = new System.Drawing.Size(394, 24);
+         this.lineThicknessLayoutControlItem.Text = "Line Thickness";
+         this.lineThicknessLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
          // visibleLayoutControlItem
-         // 
+         //
          this.visibleLayoutControlItem.Control = this.visibleComboBoxEdit;
-         this.visibleLayoutControlItem.Location = new System.Drawing.Point(0, 156);
+         this.visibleLayoutControlItem.Location = new System.Drawing.Point(0, 96);
          this.visibleLayoutControlItem.Name = "visibleLayoutControlItem";
-         this.visibleLayoutControlItem.Size = new System.Drawing.Size(1015, 52);
+         this.visibleLayoutControlItem.Size = new System.Drawing.Size(394, 24);
          this.visibleLayoutControlItem.Text = "Visible";
-         this.visibleLayoutControlItem.TextSize = new System.Drawing.Size(119, 33);
-         // 
+         this.visibleLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
          // inLegendLayoutControlItem
-         // 
+         //
          this.inLegendLayoutControlItem.Control = this.inLegendComboBoxEdit;
-         this.inLegendLayoutControlItem.Location = new System.Drawing.Point(0, 208);
+         this.inLegendLayoutControlItem.Location = new System.Drawing.Point(0, 120);
          this.inLegendLayoutControlItem.Name = "inLegendLayoutControlItem";
-         this.inLegendLayoutControlItem.Size = new System.Drawing.Size(1015, 52);
+         this.inLegendLayoutControlItem.Size = new System.Drawing.Size(394, 24);
          this.inLegendLayoutControlItem.Text = "In Legend";
-         this.inLegendLayoutControlItem.TextSize = new System.Drawing.Size(119, 33);
-         // 
+         this.inLegendLayoutControlItem.TextSize = new System.Drawing.Size(131, 13);
+         //
          // CurveMultiItemEditorView
-         // 
-         this.AutoScaleDimensions = new System.Drawing.SizeF(15F, 33F);
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Caption = "Edit Options";
-         this.ClientSize = new System.Drawing.Size(1035, 548);
+         this.ClientSize = new System.Drawing.Size(414, 261);
          this.Controls.Add(this.colorEditLayoutControl);
          this.Name = "CurveMultiItemEditorView";
          this.Text = "Edit Options";
+         this.Controls.SetChildIndex(this.colorEditLayoutControl, 0);
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorEditLayoutControl)).EndInit();
          this.colorEditLayoutControl.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.inLegendComboBoxEdit.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.visibleComboBoxEdit.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.lineThicknessComboBoxEdit.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.symbolComboBoxEdit.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.styleComboBoxEdit.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorPickEdit.Properties)).EndInit();
@@ -221,6 +249,7 @@ namespace OSPSuite.UI.Views.Charts
          ((System.ComponentModel.ISupportInitialize)(this.colorLayoutControlItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.styleLayoutControlItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.symbolLayoutControlItem)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.lineThicknessLayoutControlItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.visibleLayoutControlItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.inLegendLayoutControlItem)).EndInit();
          this.ResumeLayout(false);
@@ -239,6 +268,8 @@ namespace OSPSuite.UI.Views.Charts
       private OSPSuite.UI.Controls.UxComboBoxEdit styleComboBoxEdit;
       private DevExpress.XtraLayout.LayoutControlItem styleLayoutControlItem;
       private DevExpress.XtraLayout.LayoutControlItem symbolLayoutControlItem;
+      private OSPSuite.UI.Controls.UxComboBoxEdit lineThicknessComboBoxEdit;
+      private DevExpress.XtraLayout.LayoutControlItem lineThicknessLayoutControlItem;
       private OSPSuite.UI.Controls.UxComboBoxEdit inLegendComboBoxEdit;
       private OSPSuite.UI.Controls.UxComboBoxEdit visibleComboBoxEdit;
       private DevExpress.XtraLayout.LayoutControlItem visibleLayoutControlItem;

--- a/src/OSPSuite.UI/Views/Charts/CurveMultiItemEditorView.cs
+++ b/src/OSPSuite.UI/Views/Charts/CurveMultiItemEditorView.cs
@@ -16,6 +16,7 @@ namespace OSPSuite.UI.Views.Charts
       private readonly IFormatter<bool?> _boolFormatter = new BooleanYesNoFormatter();
       private readonly IFormatter<LineStyles?> _lineStylesFormatter = new LineStylesFormatter();
       private readonly IFormatter<Symbols?> _symbolsFormatter = new SymbolsFormatter();
+      private readonly IFormatter<int?> _lineThicknessFormatter = new LineThicknessFormatter();
       private readonly ScreenBinder<SelectedCurveValues> _screenBinder = new ScreenBinder<SelectedCurveValues> { BindingMode = BindingMode.TwoWay };
 
       public CurveMultiItemEditorView()
@@ -30,6 +31,7 @@ namespace OSPSuite.UI.Views.Charts
          colorLayoutControlItem.Text = Captions.Chart.CurveOptions.Color.FormatForLabel();
          styleLayoutControlItem.Text = Captions.Chart.CurveOptions.LineStyle.FormatForLabel();
          symbolLayoutControlItem.Text = Captions.Chart.CurveOptions.Symbol.FormatForLabel();
+         lineThicknessLayoutControlItem.Text = Captions.LineThickness.FormatForLabel();
          visibleLayoutControlItem.Text = Captions.Chart.CurveOptions.Visible.FormatForLabel();
          inLegendLayoutControlItem.Text = Captions.Chart.CurveOptions.VisibleInLegend.FormatForLabel();
       }
@@ -51,6 +53,11 @@ namespace OSPSuite.UI.Views.Charts
             .To(symbolComboBoxEdit)
             .WithValues(_presenter.AllSymbols)
             .WithFormat(_symbolsFormatter);
+
+         _screenBinder.Bind(x => x.LineThickness)
+            .To(lineThicknessComboBoxEdit)
+            .WithValues(_presenter.AllLineThicknesses)
+            .WithFormat(_lineThicknessFormatter);
 
          _screenBinder.Bind(x => x.Visible)
             .To(visibleComboBoxEdit)

--- a/tests/OSPSuite.Presentation.Tests/Presentation/CurveSettingsPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/CurveSettingsPresenterSpecs.cs
@@ -8,7 +8,6 @@ using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Core.Extensions;
 using OSPSuite.Helpers;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.DTO.Charts;
@@ -26,7 +25,7 @@ namespace OSPSuite.Presentation.Presentation
       protected Curve _curve2;
       private DataColumn _datColumn1;
       private DataColumn _datColumn2;
-      private IApplicationController _applicationController;
+      protected IApplicationController _applicationController;
       protected List<CurveDTO> _allCurveDTOs;
       protected CurveDTO _curveDTO1;
 
@@ -34,7 +33,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          _view = A.Fake<ICurveSettingsView>();
          _dimensionFactory = A.Fake<IDimensionFactory>();
-         _applicationController = A.Fake<IApplicationController>(); 
+         _applicationController = A.Fake<IApplicationController>();
          _chart = new CurveChart();
          A.CallTo(() => _dimensionFactory.MergedDimensionFor(A<IWithDimension>._)).ReturnsLazily(x => x.GetArgument<IWithDimension>(0).Dimension);
 
@@ -255,7 +254,7 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
-   public class When_the_curve_settings_presenter_is_refreshing_and_is_in_latch: concern_for_CurveSettingsPresenter
+   public class When_the_curve_settings_presenter_is_refreshing_and_is_in_latch : concern_for_CurveSettingsPresenter
    {
       protected override void Context()
       {
@@ -274,7 +273,6 @@ namespace OSPSuite.Presentation.Presentation
          //once becasue of initial context
          A.CallTo(() => _view.BindTo(A<IEnumerable<CurveDTO>>._)).MustHaveHappenedOnceExactly();
       }
-
    }
 
    public class When_the_curve_settings_presenter_is_moving_a_curve_legend_position_after_another_curve : concern_for_CurveSettingsPresenter
@@ -316,7 +314,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          base.Context();
          _curveDTO1.Color = Color.Red;
-         sut.CurvePropertyChanged += (o,e) => _curvePropertyChanged = true;
+         sut.CurvePropertyChanged += (o, e) => _curvePropertyChanged = true;
          ;
       }
 
@@ -335,6 +333,61 @@ namespace OSPSuite.Presentation.Presentation
       public void should_notify_a_curve_property_changed_event()
       {
          _curvePropertyChanged.ShouldBeTrue();
+      }
+   }
+
+   public abstract class concern_for_CurveSettingsPresenter_editing_properties : concern_for_CurveSettingsPresenter
+   {
+      protected ICurveMultiItemEditorPresenter _multiEditorPresenter;
+      protected SelectedCurveValues _selectedValues;
+
+      protected override void Context()
+      {
+         base.Context();
+         _multiEditorPresenter = A.Fake<ICurveMultiItemEditorPresenter>();
+         A.CallTo(() => _applicationController.Start<ICurveMultiItemEditorPresenter>()).Returns(_multiEditorPresenter);
+         A.CallTo(() => _multiEditorPresenter.GetSelectedValues()).Returns(_selectedValues);
+      }
+
+      protected override void Because()
+      {
+         sut.EditProperties(_allCurveDTOs);
+      }
+   }
+
+   public class When_the_curve_settings_presenter_is_editing_properties_with_a_line_thickness : concern_for_CurveSettingsPresenter_editing_properties
+   {
+      protected override void Context()
+      {
+         _selectedValues = new SelectedCurveValues { LineThickness = 3 };
+         base.Context();
+         _curve1.LineThickness = 1;
+         _curve2.LineThickness = 1;
+      }
+
+      [Observation]
+      public void should_update_the_line_thickness_of_all_selected_curves()
+      {
+         _curve1.LineThickness.ShouldBeEqualTo(3);
+         _curve2.LineThickness.ShouldBeEqualTo(3);
+      }
+   }
+
+   public class When_the_curve_settings_presenter_is_editing_properties_without_a_line_thickness : concern_for_CurveSettingsPresenter_editing_properties
+   {
+      protected override void Context()
+      {
+         _selectedValues = new SelectedCurveValues { LineThickness = null };
+         base.Context();
+         _curve1.LineThickness = 1;
+         _curve2.LineThickness = 2;
+      }
+
+      [Observation]
+      public void should_keep_the_existing_line_thickness_of_each_selected_curve()
+      {
+         _curve1.LineThickness.ShouldBeEqualTo(1);
+         _curve2.LineThickness.ShouldBeEqualTo(2);
       }
    }
 }


### PR DESCRIPTION
## Summary
- Add line thickness selector to the multi-curve edit dialog (`{Current value, 1, 2, 3}`, matching `UxLineThicknessEdit` used by the single-curve dialog).
- Fix squashed OK/Cancel buttons in the multi-curve edit dialog by switching `AutoScaleDimensions` from the outlier `15F, 33F` to the suite-standard `6F, 13F` (other chart dialogs use the same), and resizing the form/controls to match.

## Test plan
- [x] `dotnet test tests/OSPSuite.Presentation.Tests --filter "FullyQualifiedName~settings_presenter"` — 36 passed (2 new + 34 existing).
- [x] Manual: in MoBi, select multiple curves in the chart editor → Edit Options → confirm line thickness dropdown is present, picking a value applies it to all selected curves, leaving it at "Current value" preserves each curve's existing thickness.
- [x] Manual: confirm OK/Cancel buttons render at normal size (not squashed).

<img width="462" height="312" alt="image" src="https://github.com/user-attachments/assets/502e0697-6ca5-4ace-bf46-0c88caf1382c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added line thickness editing to the multi-curve editor. Users can now select and apply line thickness values to multiple curves simultaneously with enhanced formatting options. Existing curve properties are preserved when no specific thickness is selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite.Core/pull/2875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->