### PR TITLE
Fixes #2399 Unify plot colors across analysable charts

### DIFF
--- a/src/OSPSuite.Core/Chart/AnalysisChart.cs
+++ b/src/OSPSuite.Core/Chart/AnalysisChart.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Utility.Extensions;
@@ -8,6 +10,37 @@ namespace OSPSuite.Core.Chart
    public abstract class AnalysisChart : ChartWithObservedData, ISimulationAnalysis
    {
       public IAnalysable Analysable { get; set; }
+
+      public abstract AnalysisChartTypes AnalysisChartType { get; }
+
+      /// <summary>
+      ///    Returns the color another <see cref="AnalysisChart" /> on the same <see cref="Analysable" />
+      ///    already assigned to the given output <paramref name="path" />, preferring a peer marked
+      ///    <see cref="AnalysisChartTypes.TimeProfile" /> as the canonical color source.
+      ///    Returns <c>null</c> when no peer carries a curve for that path.
+      /// </summary>
+      public virtual Color? PeerColorForPath(string path)
+      {
+         if (Analysable == null)
+            return null;
+
+         var peers = Analysable.Analyses
+            .OfType<AnalysisChart>()
+            .Where(c => !ReferenceEquals(c, this))
+            .ToList();
+
+         //prefer a Time Profile peer so the canonical color source wins
+         var fromTimeProfile = peers.Where(c => c.AnalysisChartType == AnalysisChartTypes.TimeProfile)
+            .SelectMany(c => c.Curves)
+            .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
+         if (fromTimeProfile != null)
+            return fromTimeProfile.Color;
+
+         //fall back to any peer chart that already chose a color for this path
+         var fromAnyPeer = peers.SelectMany(c => c.Curves)
+            .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
+         return fromAnyPeer?.Color;
+      }
    }
 
    public abstract class AnalysisChartWithLocalRepositories : AnalysisChart

--- a/src/OSPSuite.Core/Chart/AnalysisChartTypes.cs
+++ b/src/OSPSuite.Core/Chart/AnalysisChartTypes.cs
@@ -1,0 +1,8 @@
+namespace OSPSuite.Core.Chart;
+
+public enum AnalysisChartTypes
+{
+   TimeProfile,
+   PredictedVsObserved,
+   ResidualVsTime
+}

--- a/src/OSPSuite.Core/Chart/ParameterIdentifications/ParameterIdentificationAnalysisChart.cs
+++ b/src/OSPSuite.Core/Chart/ParameterIdentifications/ParameterIdentificationAnalysisChart.cs
@@ -2,18 +2,22 @@
 {
    public class ParameterIdentificationTimeProfileChart : AnalysisChart
    {
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
    }
 
    public class ParameterIdentificationTimeProfileConfidenceIntervalChart : AnalysisChartWithLocalRepositories
    {
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
    }
 
    public class ParameterIdentificationTimeProfilePredictionIntervalChart : AnalysisChartWithLocalRepositories
    {
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
    }
 
    public class ParameterIdentificationTimeProfileVPCIntervalChart : AnalysisChartWithLocalRepositories
    {
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
    }
 
    public class ParameterIdentificationResidualVsTimeChart : ResidualsVsTimeChart

--- a/src/OSPSuite.Core/Chart/PredictedVsObservedChart.cs
+++ b/src/OSPSuite.Core/Chart/PredictedVsObservedChart.cs
@@ -16,6 +16,8 @@ namespace OSPSuite.Core.Chart
       private readonly Cache<float, IReadOnlyList<DataRepository>> _deviationRepositoryCache = new Cache<float, IReadOnlyList<DataRepository>>(onMissingKey: x => null);
       public List<float> DeviationFoldValues { get; } = new List<float>();
 
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.PredictedVsObserved;
+
       protected PredictedVsObservedChart()
       {
          ChartSettings.LegendPosition = LegendPositions.BottomInside;

--- a/src/OSPSuite.Core/Chart/ResidualsVsTimeChart.cs
+++ b/src/OSPSuite.Core/Chart/ResidualsVsTimeChart.cs
@@ -8,6 +8,8 @@ namespace OSPSuite.Core.Chart
    {
       public const string ZERO = "Zero";
 
+      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.ResidualVsTime;
+
       public override Curve CreateCurve(DataColumn columnX, DataColumn columnY, string curveName, IDimensionFactory dimensionFactory)
       {
          var curve = base.CreateCurve(columnX, columnY, curveName, dimensionFactory);
@@ -18,6 +20,7 @@ namespace OSPSuite.Core.Chart
             curve.Symbol = Symbols.Circle;
             curve.LineStyle = LineStyles.None;
          }
+
          return curve;
       }
    }

--- a/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentification.cs
+++ b/src/OSPSuite.Core/Domain/ParameterIdentifications/ParameterIdentification.cs
@@ -25,7 +25,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
 
       public virtual void AddSimulation(ISimulation simulation)
       {
-         if (simulation == null) 
+         if (simulation == null)
             return;
 
          if (_allSimulations.Contains(simulation))
@@ -191,7 +191,7 @@ namespace OSPSuite.Core.Domain.ParameterIdentifications
          HasChanged = true;
       }
 
-      public IEnumerable<ISimulationAnalysis> Analyses => _allSimulationAnalyses;
+      public virtual IEnumerable<ISimulationAnalysis> Analyses => _allSimulationAnalyses;
       public bool HasUpToDateResults => AllSimulations.All(x => x.HasUpToDateResults);
       public bool ComesFromPKSim => AllSimulations.All(x => x.ComesFromPKSim);
 

--- a/src/OSPSuite.Presentation/Extensions/CurveChartExtensions.cs
+++ b/src/OSPSuite.Presentation/Extensions/CurveChartExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OSPSuite.Core.Chart;
@@ -37,15 +36,16 @@ namespace OSPSuite.Presentation.Extensions
          // Finds color from a column which dataColumn is related
          else if (otherColumnsContainColumnAsRelated(dataColumns))
             curve.Color = getColorFromColumnRelatedTo(chart, dataColumn, dataColumns);
-         
+
          // For a ResidualVsTimeChart, do not select a color for the Zero curve.
-         else if(!(chart is ResidualsVsTimeChart) || !string.Equals(curve.Name, ResidualsVsTimeChart.ZERO))
-            curve.Color = chart.SelectNewColor();
+         else if (!(chart is ResidualsVsTimeChart) || !string.Equals(curve.Name, ResidualsVsTimeChart.ZERO))
+         {
+            var peerColor = (chart as AnalysisChart)?.PeerColorForPath(dataColumn.PathAsString);
+            curve.Color = peerColor ?? chart.SelectNewColor();
+         }
 
          curve.UpdateStyleForObservedData();
       }
-
-
 
       private static bool otherColumnsContainColumnAsRelated(IReadOnlyCollection<DataColumn> dataColumns)
       {

--- a/src/OSPSuite.Presentation/Presenters/Charts/SimulationAnalysisChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/SimulationAnalysisChartPresenter.cs
@@ -119,8 +119,18 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       protected void SelectColorForPath(string path)
       {
-         if (!_colorCache.Contains(path))
-            _colorCache[path] = Chart.SelectNewColor();
+         // prefer colors from peer charts that already contain the path-color match
+         var peerColor = (Chart as AnalysisChart)?.PeerColorForPath(path);
+         if (peerColor.HasValue)
+         {
+            _colorCache[path] = peerColor.Value;
+            return;
+         }
+
+         if (_colorCache.Contains(path))
+            return;
+
+         _colorCache[path] = Chart.SelectNewColor();
       }
 
       protected void UpdateColorForCalculationColumn(Curve curve, DataColumn calculationColumn)

--- a/src/OSPSuite.Presentation/Presenters/SimulationVsObservedDataChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/SimulationVsObservedDataChartPresenter.cs
@@ -19,7 +19,7 @@ namespace OSPSuite.Presentation.Presenters
    {
    }
 
-   public abstract class SimulationVsObservedDataChartPresenter<TChart> : SimulationAnalysisChartPresenter<TChart, ISimulationVsObservedDataView, ISimulationVsObservedDataPresenter>, ISimulationVsObservedDataPresenter 
+   public abstract class SimulationVsObservedDataChartPresenter<TChart> : SimulationAnalysisChartPresenter<TChart, ISimulationVsObservedDataView, ISimulationVsObservedDataPresenter>, ISimulationVsObservedDataPresenter
       where TChart : ChartWithObservedData, ISimulationAnalysis
    {
       protected ISimulation _simulation;
@@ -39,8 +39,13 @@ namespace OSPSuite.Presentation.Presenters
       {
          _simulation = analysable.DowncastTo<ISimulation>();
 
-         ClearChartAndDataRepositories();
-         UpdateCacheColor();
+         if (ChartIsBeingUpdated)
+         {
+            UpdateTemplateFromChart();
+            ClearChartAndDataRepositories();
+         }
+         else
+            UpdateCacheColor();
 
          if (!_simulation.ResultsDataRepository.IsNull())
          {

--- a/tests/OSPSuite.Core.Tests/Domain/AnalysisChartSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/AnalysisChartSpecs.cs
@@ -1,0 +1,169 @@
+using System.Drawing;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Chart.ParameterIdentifications;
+using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Helpers;
+
+namespace OSPSuite.Core.Domain;
+
+public abstract class concern_for_AnalysisChart : ContextSpecification<AnalysisChart>
+{
+   protected ParameterIdentification _parameterIdentification;
+   protected ParameterIdentificationTimeProfileChart _peerTimeProfile;
+   protected DataColumn _outputColumn;
+   protected const string PATH = "Sim|Liver|Cell|Concentration";
+
+   protected override void Context()
+   {
+      _parameterIdentification = new ParameterIdentification();
+
+      //a DataColumn whose QuantityInfo path matches what the peer-lookup keys on
+      var baseGrid = new BaseGrid("BaseGrid", DomainHelperForSpecs.TimeDimensionForSpecs());
+      _outputColumn = new DataColumn("OutputCol", DomainHelperForSpecs.NoDimension(), baseGrid)
+      {
+         QuantityInfo = new QuantityInfo(new[] { "Sim", "Liver", "Cell", "Concentration" }, QuantityType.Drug)
+      };
+
+      //SUT is a non-Time-Profile chart so it has a reason to consult peers
+      sut = new ParameterIdentificationPredictedVsObservedChart();
+      _parameterIdentification.AddAnalysis(sut);
+   }
+}
+
+public class When_a_peer_time_profile_chart_carries_a_curve_for_the_path : concern_for_AnalysisChart
+{
+   private static readonly Color CANONICAL_COLOR = Color.Magenta;
+   private Color? _result;
+
+   protected override void Context()
+   {
+      base.Context();
+
+      _peerTimeProfile = new ParameterIdentificationTimeProfileChart();
+      var peerCurve = new Curve { Name = "Peer" };
+      var dimensionFactory = A.Fake<IDimensionFactory>();
+      peerCurve.SetxData(_outputColumn.BaseGrid, dimensionFactory);
+      peerCurve.SetyData(_outputColumn, dimensionFactory);
+      peerCurve.Color = CANONICAL_COLOR;
+      _peerTimeProfile.AddCurve(peerCurve, useAxisDefault: false);
+
+      _parameterIdentification.AddAnalysis(_peerTimeProfile);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.PeerColorForPath(PATH);
+   }
+
+   [Observation]
+   public void should_return_the_color_from_the_time_profile_peer()
+   {
+      _result.ShouldBeEqualTo(CANONICAL_COLOR);
+   }
+}
+
+public class When_only_non_time_profile_peers_carry_a_curve_for_the_path : concern_for_AnalysisChart
+{
+   private static readonly Color FALLBACK_COLOR = Color.Olive;
+   private ParameterIdentificationResidualVsTimeChart _peerResidual;
+   private Color? _result;
+
+   protected override void Context()
+   {
+      base.Context();
+
+      _peerResidual = new ParameterIdentificationResidualVsTimeChart();
+      var peerCurve = new Curve { Name = "Peer" };
+      var dimensionFactory = A.Fake<IDimensionFactory>();
+      peerCurve.SetxData(_outputColumn.BaseGrid, dimensionFactory);
+      peerCurve.SetyData(_outputColumn, dimensionFactory);
+      peerCurve.Color = FALLBACK_COLOR;
+      _peerResidual.AddCurve(peerCurve, useAxisDefault: false);
+
+      _parameterIdentification.AddAnalysis(_peerResidual);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.PeerColorForPath(PATH);
+   }
+
+   [Observation]
+   public void should_fall_back_to_any_peer_chart_that_has_a_curve_for_the_path()
+   {
+      _result.ShouldBeEqualTo(FALLBACK_COLOR);
+   }
+}
+
+public class When_no_peer_carries_a_curve_for_the_path : concern_for_AnalysisChart
+{
+   private Color? _result;
+
+   protected override void Because()
+   {
+      _result = sut.PeerColorForPath(PATH);
+   }
+
+   [Observation]
+   public void should_return_null_so_the_caller_can_pick_a_fresh_color()
+   {
+      _result.HasValue.ShouldBeFalse();
+   }
+}
+
+public class When_the_chart_has_no_analysable : concern_for_AnalysisChart
+{
+   private Color? _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      //detach the chart from the analysable so we exercise the early-return path
+      sut.Analysable = null;
+   }
+
+   protected override void Because()
+   {
+      _result = sut.PeerColorForPath(PATH);
+   }
+
+   [Observation]
+   public void should_return_null_without_throwing()
+   {
+      _result.HasValue.ShouldBeFalse();
+   }
+}
+
+public class When_the_only_peer_with_a_matching_path_is_the_chart_itself : concern_for_AnalysisChart
+{
+   private static readonly Color SELF_COLOR = Color.SteelBlue;
+   private Color? _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      //add a curve on the SUT so we can prove the self-filter excludes our own curves
+      var selfCurve = new Curve { Name = "Self" };
+      var dimensionFactory = A.Fake<IDimensionFactory>();
+      selfCurve.SetxData(_outputColumn.BaseGrid, dimensionFactory);
+      selfCurve.SetyData(_outputColumn, dimensionFactory);
+      selfCurve.Color = SELF_COLOR;
+      sut.AddCurve(selfCurve, useAxisDefault: false);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.PeerColorForPath(PATH);
+   }
+
+   [Observation]
+   public void should_skip_the_chart_itself_and_return_null()
+   {
+      _result.HasValue.ShouldBeFalse();
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
@@ -37,7 +38,7 @@ namespace OSPSuite.Presentation.Presentation
       protected ResidualsResult _residualResults;
       protected ResidualsVsTimeChartService _residualsVsTimeChartService;
       private IChartEditorLayoutTask _chartEditorLayoutTask;
-      private IProjectRetriever _projectRetreiver;
+      private IProjectRetriever _projectRetriever;
       private ChartPresenterContext _chartPresenterContext;
       private ICurveNamer _curveNamer;
 
@@ -54,7 +55,7 @@ namespace OSPSuite.Presentation.Presentation
          _chartTemplatingTask = A.Fake<IChartTemplatingTask>();
          _dimensionFactory = A.Fake<IDimensionFactory>();
          _chartEditorLayoutTask = A.Fake<IChartEditorLayoutTask>();
-         _projectRetreiver = A.Fake<IProjectRetriever>();
+         _projectRetriever = A.Fake<IProjectRetriever>();
 
          _chartPresenterContext = A.Fake<ChartPresenterContext>();
          A.CallTo(() => _chartPresenterContext.EditorAndDisplayPresenter).Returns(_chartEditorAndDisplayPresenter);
@@ -64,7 +65,7 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _chartPresenterContext.PresenterSettingsTask).Returns(_presentationSettingsTask);
          A.CallTo(() => _chartPresenterContext.DimensionFactory).Returns(_dimensionFactory);
          A.CallTo(() => _chartPresenterContext.EditorLayoutTask).Returns(_chartEditorLayoutTask);
-         A.CallTo(() => _chartPresenterContext.ProjectRetriever).Returns(_projectRetreiver);
+         A.CallTo(() => _chartPresenterContext.ProjectRetriever).Returns(_projectRetriever);
 
 
          sut = new ParameterIdentificationResidualVsTimeChartPresenter(_view, _chartPresenterContext, _residualsVsTimeChartService);
@@ -73,10 +74,10 @@ namespace OSPSuite.Presentation.Presentation
          _parameterIdentification = A.Fake<ParameterIdentification>();
 
          _parameterIdentificationRunResult = A.Fake<ParameterIdentificationRunResult>();
-         A.CallTo(() => _parameterIdentification.Results).Returns(new[] {_parameterIdentificationRunResult});
+         A.CallTo(() => _parameterIdentification.Results).Returns(new[] { _parameterIdentificationRunResult });
 
          _residualResults = new ResidualsResult();
-         _optimizationRunResult = new OptimizationRunResult {ResidualsResult = _residualResults};
+         _optimizationRunResult = new OptimizationRunResult { ResidualsResult = _residualResults };
          _parameterIdentificationRunResult.BestResult = _optimizationRunResult;
 
 
@@ -109,9 +110,9 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _outputMapping3.WeightedObservedData.ObservedData).Returns(observation3);
 
 
-         _outputResiduals1 = new OutputResiduals("OutputPath1", _outputMapping1.WeightedObservedData, new[] {new Residual(11f, 12f, 1), new Residual(21f, 22f, 1)});
-         _outputResiduals2 = new OutputResiduals("OutputPath2", _outputMapping2.WeightedObservedData, new[] {new Residual(31f, 32f, 1), new Residual(41f, 42f, 1)});
-         _outputResiduals3 = new OutputResiduals("OutputPath1", _outputMapping3.WeightedObservedData, new[] {new Residual(51f, 52f, 1), new Residual(61f, 62f, 1)});
+         _outputResiduals1 = new OutputResiduals("OutputPath1", _outputMapping1.WeightedObservedData, new[] { new Residual(11f, 12f, 1), new Residual(21f, 22f, 1) });
+         _outputResiduals2 = new OutputResiduals("OutputPath2", _outputMapping2.WeightedObservedData, new[] { new Residual(31f, 32f, 1), new Residual(41f, 42f, 1) });
+         _outputResiduals3 = new OutputResiduals("OutputPath1", _outputMapping3.WeightedObservedData, new[] { new Residual(51f, 52f, 1), new Residual(61f, 62f, 1) });
 
          _residualResults.AddOutputResiduals(_outputResiduals1);
          _residualResults.AddOutputResiduals(_outputResiduals2);
@@ -123,8 +124,8 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _outputMapping3.FullOutputPath).Returns("OutputPath1");
 
 
-         A.CallTo(() => _parameterIdentification.AllOutputMappings).Returns(new[] {_outputMapping1, _outputMapping2, _outputMapping3});
-         A.CallTo(() => _parameterIdentification.AllObservedData).Returns(new[] {observation3, observation1, observation2});
+         A.CallTo(() => _parameterIdentification.AllOutputMappings).Returns(new[] { _outputMapping1, _outputMapping2, _outputMapping3 });
+         A.CallTo(() => _parameterIdentification.AllObservedData).Returns(new[] { observation3, observation1, observation2 });
       }
 
       protected override void Because()
@@ -167,12 +168,67 @@ namespace OSPSuite.Presentation.Presentation
       }
    }
 
+   public class When_initializing_a_residual_vs_time_chart_for_a_PI_that_already_has_a_time_profile_chart : concern_for_ParameterIdentificationResidualVsTimeChartPresenter
+   {
+      private static readonly Color CANONICAL_COLOR = Color.Cyan;
+      private ParameterIdentificationTimeProfileChart _existingTimeProfile;
+      private OutputResiduals _outputResiduals1;
+      private OutputMapping _outputMapping1;
+      private DataRepository _observation1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _outputMapping1 = A.Fake<OutputMapping>();
+         _observation1 = DomainHelperForSpecs.ObservedData("OBS1");
+         A.CallTo(() => _outputMapping1.WeightedObservedData.ObservedData).Returns(_observation1);
+
+         _outputResiduals1 = new OutputResiduals("OutputPath1", _outputMapping1.WeightedObservedData, new[] { new Residual(11f, 12f, 1) });
+         _residualResults.AddOutputResiduals(_outputResiduals1);
+
+         A.CallTo(() => _outputMapping1.FullOutputPath).Returns("OutputPath1");
+         A.CallTo(() => _parameterIdentification.AllOutputMappings).Returns(new[] { _outputMapping1 });
+         A.CallTo(() => _parameterIdentification.AllObservedData).Returns(new[] { _observation1 });
+
+         //existing TP chart carries a curve whose yData path matches the residual output path
+         var canonicalColumn = _observation1.ObservationColumns().First();
+         canonicalColumn.QuantityInfo = new QuantityInfo(new[] { "OutputPath1" }, QuantityType.Drug);
+
+         _existingTimeProfile = new ParameterIdentificationTimeProfileChart();
+         var canonicalCurve = new Curve { Name = "Canonical" };
+         var dimensionFactory = A.Fake<IDimensionFactory>();
+         canonicalCurve.SetxData(canonicalColumn.BaseGrid, dimensionFactory);
+         canonicalCurve.SetyData(canonicalColumn, dimensionFactory);
+         canonicalCurve.Color = CANONICAL_COLOR;
+         _existingTimeProfile.AddCurve(canonicalCurve, useAxisDefault: false);
+
+         A.CallTo(() => _parameterIdentification.Analyses).Returns(new ISimulationAnalysis[] { _existingTimeProfile, _residualVsTimeChart });
+         //in production AddAnalysis sets Analysable; mirror that here so PeerColorForPath
+         //(which now lives on the chart) has the analysable handle it needs
+         _existingTimeProfile.Analysable = _parameterIdentification;
+         _residualVsTimeChart.Analysable = _parameterIdentification;
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_residualVsTimeChart, _parameterIdentification);
+      }
+
+      [Observation]
+      public void residual_curves_should_inherit_the_color_from_the_existing_time_profile_chart()
+      {
+         var residualCurve = _residualVsTimeChart.Curves.FirstOrDefault(c => !string.Equals(c.Name, ResidualsVsTimeChart.ZERO));
+         residualCurve.ShouldNotBeNull();
+         residualCurve.Color.ShouldBeEqualTo(CANONICAL_COLOR);
+      }
+   }
+
    public class When_clearing_the_parameter_identification_residual_vs_time_chart_presenter : concern_for_ParameterIdentificationResidualVsTimeChartPresenter
    {
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _parameterIdentification.AllObservedData).Returns(new[] {DomainHelperForSpecs.ObservedData()});
+         A.CallTo(() => _parameterIdentification.AllObservedData).Returns(new[] { DomainHelperForSpecs.ObservedData() });
          sut.InitializeAnalysis(_residualVsTimeChart, _parameterIdentification);
 
          //only zero marker

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
 using OSPSuite.Core.Chart.ParameterIdentifications;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
@@ -17,7 +19,6 @@ using OSPSuite.Presentation.Presenters.ParameterIdentifications;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views.ParameterIdentifications;
-using OSPSuite.Utility.Collections;
 
 namespace OSPSuite.Presentation.Presentation
 {
@@ -125,7 +126,7 @@ namespace OSPSuite.Presentation.Presentation
 
          _parameterIdentification.Configuration.RunMode = new MultipleParameterIdentificationRunMode();
 
-         _allAddedDataRepositories = new List<DataRepository>();;
+         _allAddedDataRepositories = new List<DataRepository>();
          A.CallTo(() => ChartEditorPresenter.AddDataRepositories(A<IEnumerable<DataRepository>>._))
             .Invokes(x => _allAddedDataRepositories.AddRange(x.GetArgument<IEnumerable<DataRepository>>(0)));
       }
@@ -179,6 +180,53 @@ namespace OSPSuite.Presentation.Presentation
       {
          var observedDataCurve = _timeProfileAnalysis.FindCurveWithSameData(_firstObservedData1.BaseGrid, _firstObservedData1);
          observedDataCurve.VisibleInLegend.ShouldBeFalse();
+      }
+   }
+
+   public class When_a_second_time_profile_chart_is_initialized_for_a_parameter_identification_that_already_has_a_time_profile : concern_for_ParameterIdentificationTimeProfileChartPresenter
+   {
+      private static readonly Color CANONICAL_COLOR = Color.Magenta;
+      private ParameterIdentificationTimeProfileChart _existingTimeProfile;
+      private DataRepository _simulationResult;
+      private DataColumn _outputColumn;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationResult = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("SimulationResult");
+         _outputColumn = _simulationResult.AllButBaseGrid().First();
+
+         A.CallTo(() => _outputMapping1.FullOutputPath).Returns(_outputColumn.QuantityInfo.PathAsString);
+         A.CallTo(() => _outputMapping2.FullOutputPath).Returns(_outputColumn.QuantityInfo.PathAsString);
+         _optimizationRunResult.AddResult(_simulationResult);
+         _parameterIdentification.Configuration.RunMode = new MultipleParameterIdentificationRunMode();
+
+         _existingTimeProfile = new ParameterIdentificationTimeProfileChart();
+         var existingCurve = new Curve { Name = "PreviouslyColored" };
+         var dimensionFactory = A.Fake<IDimensionFactory>();
+         existingCurve.SetxData(_outputColumn.BaseGrid, dimensionFactory);
+         existingCurve.SetyData(_outputColumn, dimensionFactory);
+         existingCurve.Color = CANONICAL_COLOR;
+         _existingTimeProfile.AddCurve(existingCurve, useAxisDefault: false);
+
+         //AddAnalysis registers both charts on the PI and sets each chart's Analysable;
+         //real-world callers do this through the analysis creator before handing the chart
+         //to the presenter, so the chart can resolve its peers via Analysable.Analyses
+         _parameterIdentification.AddAnalysis(_existingTimeProfile);
+         _parameterIdentification.AddAnalysis(_timeProfileAnalysis);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_timeProfileAnalysis, _parameterIdentification);
+      }
+
+      [Observation]
+      public void should_inherit_the_color_from_the_existing_time_profile_chart()
+      {
+         var outputCurve = _timeProfileAnalysis.FindCurveWithSameData(_outputColumn.BaseGrid, _outputColumn);
+         outputCurve.ShouldNotBeNull();
+         outputCurve.Color.ShouldBeEqualTo(CANONICAL_COLOR);
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimulationResidualVsTimeChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimulationResidualVsTimeChartPresenterSpecs.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
-using NPOI.HPSF;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
@@ -19,7 +19,6 @@ using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.Charts;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views;
-
 
 namespace OSPSuite.Presentation.Presentation
 {
@@ -72,8 +71,6 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _chartPresenterContext.EditorLayoutTask).Returns(_chartEditorLayoutTask);
          A.CallTo(() => _chartPresenterContext.ProjectRetriever).Returns(_projectRetriever);
          A.CallTo(() => _residualCalculatorFactory.CreateFor(A<ParameterIdentificationConfiguration>._)).Returns(_residualCalculator);
-
-
 
 
          _residualVsTimeChart = new SimulationResidualVsTimeChart().WithAxes();
@@ -136,7 +133,6 @@ namespace OSPSuite.Presentation.Presentation
       {
          _residualVsTimeChart.Curves.Count.ShouldBeEqualTo(_residualResults.AllOutputResiduals.Count + 1);
       }
-
    }
 
    public class When_clearing_the_simulation_residual_vs_time_chart_presenter : concern_for_SimulationResidualVsTimeChartPresenter
@@ -160,6 +156,40 @@ namespace OSPSuite.Presentation.Presentation
       {
          //zero marker removed
          _residualVsTimeChart.Curves.Count.ShouldBeEqualTo(_residualResults.AllOutputResiduals.Count);
+      }
+   }
+
+   public class When_a_simulation_residual_vs_time_chart_is_re_rendered_after_first_init : concern_for_SimulationResidualVsTimeChartPresenter
+   {
+      private CurveChartTemplate _capturedTemplate;
+
+      protected override void Context()
+      {
+         base.Context();
+         _capturedTemplate = new CurveChartTemplate();
+         sut.InitializeAnalysis(_residualVsTimeChart, _simulation);
+         A.CallTo(() => _chartPresenterContext.TemplatingTask.TemplateFrom(sut.Chart, false)).Returns(_capturedTemplate);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateAnalysisBasedOn(_simulation);
+      }
+
+      [Observation]
+      public void should_snapshot_the_chart_into_a_template_before_clearing()
+      {
+         A.CallTo(() => _chartPresenterContext.TemplatingTask.TemplateFrom(sut.Chart, false)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_re_apply_the_captured_template_after_the_rebuild_so_user_color_edits_survive()
+      {
+         A.CallTo(() => _chartPresenterContext.TemplatingTask.InitializeChartFromTemplate(sut.Chart, A<IEnumerable<DataColumn>>._,
+            _capturedTemplate,
+            A<Func<DataColumn, string>>._,
+            false,
+            true)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
## Summary

In short - it's a better default color selection for charts in a simulation. When a curve is added to a chart (on creation for example) peer charts are checked for an existing path/color match to use as default. The selection prefers to check TimeProfile charts first, and if no match is found, then check other charts for curves with the same path.

- New `AnalysisChartTypes` enum + abstract `AnalysisChartType` on `AnalysisChart`. `PeerColorForPath` on `AnalysisChart` returns the canonical color for an output path by walking the analysable's other analyses, preferring Time Profile peers.
- `SimulationAnalysisChartPresenter.SelectColorForPath` and `CurveChartExtensions.UpdateCurveColorAndStyle` both consult `PeerColorForPath` first, so the same output renders in the same color across TP / PvO / Residuals — both on initial render **and** on the data-browser Used checkbox re-add path.
- `SimulationVsObservedDataChartPresenter.UpdateAnalysisBasedOn` mirrors the PI gating (snapshot template before clear, re-apply template after rebuild). User color edits to simulation PvO / Residuals curves now survive subsequent renders.

## Downstream impact

The new abstract `AnalysisChartType` property is a breaking change for concrete `AnalysisChart` subclasses in PK-Sim and MoBi. Companion one-line overrides were verified locally:

- MoBi: `MoBiSimulationTimeProfileChart` → `AnalysisChartTypes.TimeProfile`
- PK-Sim: `SimulationTimeProfileChart` → `AnalysisChartTypes.TimeProfile`

Those will need follow-up PRs when this lands.

## Test plan

- [x] `dotnet test tests/OSPSuite.Core.Tests` — 2030 passed (incl. 5 new `AnalysisChart.PeerColorForPath` specs)
- [x] `dotnet test tests/OSPSuite.Presentation.Tests` — 1259 passed (incl. new TP-peer, Residuals-peer, sim-flow-template-retention specs)
- [x] `dotnet test tests/OSPSuite.Core.IntegrationTests` — 509 passed
- [x] MoBi build + test suites green against the local nuget (with the one-line override added)
- [x] PK-Sim build + test suites green against the local nuget (with the one-line override added)
- [x] Manual MoBi: render TP + PvO + Residuals → same color per output; edit a color in TP, re-render PvO → still consistent; Used checkbox remove + re-add round-trip preserves color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Curves in analysis charts now automatically inherit colors from peer charts, maintaining visual consistency across related analyses in parameter identification workflows.

* **Tests**
  * Added comprehensive test coverage for chart color inheritance and matching behavior across analysis chart types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite.Core/pull/2876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->