### PR TITLE
Fixes #2880 Add additional legend positions for charts

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -113,6 +113,12 @@ namespace OSPSuite.Assets
       public static readonly string SideMarginsEnabled = "Side Margins Enabled";
       public static readonly string Edit = "Edit";
       public static readonly string LegendPosition = "Legend Position";
+      public static readonly string Top = "Top";
+      public static readonly string Bottom = "Bottom";
+      public static readonly string Left = "Left";
+      public static readonly string Right = "Right";
+      public static readonly string Inside = "Inside";
+      public static readonly string Outside = "Outside";
       public static readonly string Title = "Title";
       public static readonly string CurveAndAxisSettings = "Curve and Axis Settings";
       public static readonly string ChartSettings = "Chart Options";

--- a/src/OSPSuite.Core/Chart/ChartSettings.cs
+++ b/src/OSPSuite.Core/Chart/ChartSettings.cs
@@ -11,7 +11,11 @@ namespace OSPSuite.Core.Chart
       Right,
       RightInside,
       Bottom,
-      BottomInside
+      BottomInside,
+      TopLeftOutside,
+      TopLeftInside,
+      BottomLeftOutside,
+      BottomLeftInside
    }
 
    public enum GridGroupRowFormats

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartSettingsPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartSettingsPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OSPSuite.Assets;
 using OSPSuite.Core.Chart;
 using OSPSuite.Presentation.Views.Charts;
 
@@ -22,6 +23,12 @@ namespace OSPSuite.Presentation.Presenters.Charts
       event EventHandler ChartSettingsChanged;
 
       void NotifyChartSettingsChanged();
+
+      /// <summary>
+      ///    Returns the display string shown in the legend position selection, indicating the vertical and horizontal
+      ///    alignment as well as whether the legend is placed inside or outside the diagram.
+      /// </summary>
+      string LegendPositionDisplayFor(LegendPositions legendPosition);
    }
 
    internal class ChartSettingsPresenter : AbstractPresenter<IChartSettingsView, IChartSettingsPresenter>, IChartSettingsPresenter
@@ -53,6 +60,36 @@ namespace OSPSuite.Presentation.Presenters.Charts
       public void Edit(IChart chart)
       {
          _view.BindTo(chart);
+      }
+
+      public string LegendPositionDisplayFor(LegendPositions legendPosition)
+      {
+         switch (legendPosition)
+         {
+            case LegendPositions.Right:
+               return legendPositionDisplay(Captions.Top, Captions.Right, isInside: false);
+            case LegendPositions.RightInside:
+               return legendPositionDisplay(Captions.Top, Captions.Right, isInside: true);
+            case LegendPositions.Bottom:
+               return legendPositionDisplay(Captions.Bottom, Captions.Right, isInside: false);
+            case LegendPositions.BottomInside:
+               return legendPositionDisplay(Captions.Bottom, Captions.Right, isInside: true);
+            case LegendPositions.TopLeftOutside:
+               return legendPositionDisplay(Captions.Top, Captions.Left, isInside: false);
+            case LegendPositions.TopLeftInside:
+               return legendPositionDisplay(Captions.Top, Captions.Left, isInside: true);
+            case LegendPositions.BottomLeftOutside:
+               return legendPositionDisplay(Captions.Bottom, Captions.Left, isInside: false);
+            case LegendPositions.BottomLeftInside:
+               return legendPositionDisplay(Captions.Bottom, Captions.Left, isInside: true);
+            default:
+               return legendPosition.ToString();
+         }
+      }
+
+      private static string legendPositionDisplay(string vertical, string horizontal, bool isInside)
+      {
+         return $"{vertical} {horizontal} ({(isInside ? Captions.Inside : Captions.Outside)})";
       }
    }
 }

--- a/src/OSPSuite.UI/Extensions/LegendExtensions.cs
+++ b/src/OSPSuite.UI/Extensions/LegendExtensions.cs
@@ -15,29 +15,40 @@ namespace OSPSuite.UI.Extensions
                legend.Visibility = DefaultBoolean.False;
                break;
             case LegendPositions.Right:
-               legend.Visibility = DefaultBoolean.True;
-               legend.AlignmentHorizontal = LegendAlignmentHorizontal.RightOutside;
-               legend.AlignmentVertical = LegendAlignmentVertical.Top;
-               break;
-            case LegendPositions.Bottom:
-               legend.Visibility = DefaultBoolean.True;
-               legend.AlignmentHorizontal = LegendAlignmentHorizontal.Right;
-               legend.AlignmentVertical = LegendAlignmentVertical.BottomOutside;
+               setLegend(legend, LegendAlignmentHorizontal.RightOutside, LegendAlignmentVertical.Top);
                break;
             case LegendPositions.RightInside:
-               legend.Visibility = DefaultBoolean.True;
-               legend.AlignmentHorizontal = LegendAlignmentHorizontal.Right;
-               legend.AlignmentVertical = LegendAlignmentVertical.Top;
+               setLegend(legend, LegendAlignmentHorizontal.Right, LegendAlignmentVertical.Top);
+               break;
+            case LegendPositions.Bottom:
+               setLegend(legend, LegendAlignmentHorizontal.Right, LegendAlignmentVertical.BottomOutside);
                break;
             case LegendPositions.BottomInside:
-               legend.Visibility = DefaultBoolean.True;
-               legend.AlignmentHorizontal = LegendAlignmentHorizontal.Right;
-               legend.AlignmentVertical = LegendAlignmentVertical.Bottom;
+               setLegend(legend, LegendAlignmentHorizontal.Right, LegendAlignmentVertical.Bottom);
+               break;
+            case LegendPositions.TopLeftOutside:
+               setLegend(legend, LegendAlignmentHorizontal.LeftOutside, LegendAlignmentVertical.Top);
+               break;
+            case LegendPositions.TopLeftInside:
+               setLegend(legend, LegendAlignmentHorizontal.Left, LegendAlignmentVertical.Top);
+               break;
+            case LegendPositions.BottomLeftOutside:
+               setLegend(legend, LegendAlignmentHorizontal.Left, LegendAlignmentVertical.BottomOutside);
+               break;
+            case LegendPositions.BottomLeftInside:
+               setLegend(legend, LegendAlignmentHorizontal.Left, LegendAlignmentVertical.Bottom);
                break;
 
             default:
                throw new ArgumentException("LegendPosition " + legendPosition + " not implemented.");
          }
+      }
+
+      private static void setLegend(Legend legend, LegendAlignmentHorizontal horizontal, LegendAlignmentVertical vertical)
+      {
+         legend.Visibility = DefaultBoolean.True;
+         legend.AlignmentHorizontal = horizontal;
+         legend.AlignmentVertical = vertical;
       }
    }
 }

--- a/src/OSPSuite.UI/Views/Charts/ChartSettingsView.cs
+++ b/src/OSPSuite.UI/Views/Charts/ChartSettingsView.cs
@@ -110,6 +110,7 @@ namespace OSPSuite.UI.Views.Charts
          _settingsBinder.Bind(c => c.LegendPosition)
             .To(legendPositionComboBoxEdit)
             .WithValues(EnumHelper.AllValuesFor<LegendPositions>())
+            .AndDisplays(_presenter.LegendPositionDisplayFor)
             .OnValueUpdated += notifyChartSettingsChanged;
 
          _settingsBinder.Bind(c => c.BackColor)

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartSettingsPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartSettingsPresenterSpecs.cs
@@ -108,7 +108,40 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_hide_the_name_in_the_view()
       {
-         _view.NameVisible.ShouldBeFalse();   
+         _view.NameVisible.ShouldBeFalse();
+      }
+   }
+
+   public class When_the_chart_settings_presenter_is_asked_for_the_display_string_of_a_legend_position : concern_for_ChartSettingsPresenter
+   {
+      [Observation]
+      public void should_describe_a_legacy_outside_position_with_its_vertical_horizontal_and_placement()
+      {
+         sut.LegendPositionDisplayFor(LegendPositions.Right).ShouldBeEqualTo("Top Right (Outside)");
+      }
+
+      [Observation]
+      public void should_describe_a_legacy_inside_position_with_its_vertical_horizontal_and_placement()
+      {
+         sut.LegendPositionDisplayFor(LegendPositions.BottomInside).ShouldBeEqualTo("Bottom Right (Inside)");
+      }
+
+      [Observation]
+      public void should_describe_a_new_left_outside_position()
+      {
+         sut.LegendPositionDisplayFor(LegendPositions.TopLeftOutside).ShouldBeEqualTo("Top Left (Outside)");
+      }
+
+      [Observation]
+      public void should_describe_a_new_left_inside_position()
+      {
+         sut.LegendPositionDisplayFor(LegendPositions.BottomLeftInside).ShouldBeEqualTo("Bottom Left (Inside)");
+      }
+
+      [Observation]
+      public void should_return_the_enum_name_when_the_legend_is_hidden()
+      {
+         sut.LegendPositionDisplayFor(LegendPositions.None).ShouldBeEqualTo("None");
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartSettingsPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartSettingsPresenterSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using FakeItEasy;
+using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
@@ -114,34 +115,18 @@ namespace OSPSuite.Presentation.Presentation
 
    public class When_the_chart_settings_presenter_is_asked_for_the_display_string_of_a_legend_position : concern_for_ChartSettingsPresenter
    {
-      [Observation]
-      public void should_describe_a_legacy_outside_position_with_its_vertical_horizontal_and_placement()
+      [TestCase(LegendPositions.None, "None")]
+      [TestCase(LegendPositions.Right, "Top Right (Outside)")]
+      [TestCase(LegendPositions.RightInside, "Top Right (Inside)")]
+      [TestCase(LegendPositions.Bottom, "Bottom Right (Outside)")]
+      [TestCase(LegendPositions.BottomInside, "Bottom Right (Inside)")]
+      [TestCase(LegendPositions.TopLeftOutside, "Top Left (Outside)")]
+      [TestCase(LegendPositions.TopLeftInside, "Top Left (Inside)")]
+      [TestCase(LegendPositions.BottomLeftOutside, "Bottom Left (Outside)")]
+      [TestCase(LegendPositions.BottomLeftInside, "Bottom Left (Inside)")]
+      public void should_describe_the_legend_position_by_its_vertical_horizontal_and_placement(LegendPositions legendPosition, string expectedDisplay)
       {
-         sut.LegendPositionDisplayFor(LegendPositions.Right).ShouldBeEqualTo("Top Right (Outside)");
-      }
-
-      [Observation]
-      public void should_describe_a_legacy_inside_position_with_its_vertical_horizontal_and_placement()
-      {
-         sut.LegendPositionDisplayFor(LegendPositions.BottomInside).ShouldBeEqualTo("Bottom Right (Inside)");
-      }
-
-      [Observation]
-      public void should_describe_a_new_left_outside_position()
-      {
-         sut.LegendPositionDisplayFor(LegendPositions.TopLeftOutside).ShouldBeEqualTo("Top Left (Outside)");
-      }
-
-      [Observation]
-      public void should_describe_a_new_left_inside_position()
-      {
-         sut.LegendPositionDisplayFor(LegendPositions.BottomLeftInside).ShouldBeEqualTo("Bottom Left (Inside)");
-      }
-
-      [Observation]
-      public void should_return_the_enum_name_when_the_legend_is_hidden()
-      {
-         sut.LegendPositionDisplayFor(LegendPositions.None).ShouldBeEqualTo("None");
+         sut.LegendPositionDisplayFor(legendPosition).ShouldBeEqualTo(expectedDisplay);
       }
    }
 }


### PR DESCRIPTION
## Summary

Adds four new legend positions and makes the legend-position dropdown labels self-explanatory.

### Positions
The `LegendPositions` enum gains four left-side options, **appended after** the existing values. The existing values keep their names and order, so charts saved in existing projects load unchanged (no project conversion needed):

- `TopLeftOutside`, `TopLeftInside`, `BottomLeftOutside`, `BottomLeftInside`

`LegendExtensions` maps each to the matching DevExpress horizontal/vertical alignment.

### Display labels
The dropdown now shows each position as `{Vertical} {Horizontal} (Inside/Outside)` — e.g. `RightInside` → "Top Right (Inside)", `BottomLeftOutside` → "Bottom Left (Outside)". The formatting lives in `ChartSettingsPresenter` (kept out of the view), and the words `Top`/`Bottom`/`Left`/`Right`/`Inside`/`Outside` are centralized in `Captions`.

### Tests
Added `ChartSettingsPresenter` specs covering the display strings.

<img width="514" height="752" alt="image" src="https://github.com/user-attachments/assets/99baee09-cd84-4546-a3fb-ad13f1d49041" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded legend positioning options with additional corner and inside/outside placements for finer chart layout control
  * UI text keys added for positional labels (Top, Bottom, Left, Right, Inside, Outside) so placement choices display clearer, human-readable labels
  * Chart settings UI now shows a descriptive legend position label alongside the selection control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->