### PR TITLE
Fixes #2431 Chart templates for more curve charts

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1627,6 +1627,11 @@ namespace OSPSuite.Assets
          return $"Could not load chart template. Make sure that the file '{templateFilePath}' is a template file.";
       }
 
+      public static string CannotLoadTemplateCreatedForAnotherChartType(string templateName, string templateChartType, string managedChartType)
+      {
+         return $"Cannot load the template '{templateName}'. The template was created for charts of type '{templateChartType}' and cannot be used for charts of type '{managedChartType}'.";
+      }
+
       public static string CannotFindResource(string resourceFullPath) => $"Cannot find resource located at '{resourceFullPath}'";
 
       public static string CannotFindSimulationParameterForIdentificationParameter(string fullQuantityPath, string name)

--- a/src/OSPSuite.Core/Chart/AnalysisChart.cs
+++ b/src/OSPSuite.Core/Chart/AnalysisChart.cs
@@ -5,67 +5,64 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Utility.Extensions;
 
-namespace OSPSuite.Core.Chart
+namespace OSPSuite.Core.Chart;
+
+public abstract class AnalysisChart : ChartWithObservedData, ISimulationAnalysis
 {
-   public abstract class AnalysisChart : ChartWithObservedData, ISimulationAnalysis
+   public IAnalysable Analysable { get; set; }
+
+   /// <summary>
+   ///    Returns the color another <see cref="AnalysisChart" /> on the same <see cref="Analysable" />
+   ///    already assigned to the given output <paramref name="path" />, preferring a peer marked
+   ///    <see cref="CurveChartTypes.TimeProfile" /> as the canonical color source.
+   ///    Returns <c>null</c> when no peer carries a curve for that path.
+   /// </summary>
+   public virtual Color? PeerColorForPath(string path)
    {
-      public IAnalysable Analysable { get; set; }
+      if (Analysable == null)
+         return null;
 
-      public abstract AnalysisChartTypes AnalysisChartType { get; }
+      var peers = Analysable.Analyses
+         .OfType<AnalysisChart>()
+         .Where(c => !ReferenceEquals(c, this))
+         .ToList();
 
-      /// <summary>
-      ///    Returns the color another <see cref="AnalysisChart" /> on the same <see cref="Analysable" />
-      ///    already assigned to the given output <paramref name="path" />, preferring a peer marked
-      ///    <see cref="AnalysisChartTypes.TimeProfile" /> as the canonical color source.
-      ///    Returns <c>null</c> when no peer carries a curve for that path.
-      /// </summary>
-      public virtual Color? PeerColorForPath(string path)
-      {
-         if (Analysable == null)
-            return null;
+      //prefer a Time Profile peer so the canonical color source wins
+      var fromTimeProfile = peers.Where(c => c.CurveChartType == CurveChartTypes.TimeProfile)
+         .SelectMany(c => c.Curves)
+         .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
+      if (fromTimeProfile != null)
+         return fromTimeProfile.Color;
 
-         var peers = Analysable.Analyses
-            .OfType<AnalysisChart>()
-            .Where(c => !ReferenceEquals(c, this))
-            .ToList();
+      //fall back to any peer chart that already chose a color for this path
+      var fromAnyPeer = peers.SelectMany(c => c.Curves)
+         .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
+      return fromAnyPeer?.Color;
+   }
+}
 
-         //prefer a Time Profile peer so the canonical color source wins
-         var fromTimeProfile = peers.Where(c => c.AnalysisChartType == AnalysisChartTypes.TimeProfile)
-            .SelectMany(c => c.Curves)
-            .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
-         if (fromTimeProfile != null)
-            return fromTimeProfile.Color;
+public abstract class AnalysisChartWithLocalRepositories : AnalysisChart
+{
+   private readonly List<DataRepository> _dataRepositories;
+   public virtual IReadOnlyList<DataRepository> DataRepositories => _dataRepositories;
 
-         //fall back to any peer chart that already chose a color for this path
-         var fromAnyPeer = peers.SelectMany(c => c.Curves)
-            .FirstOrDefault(c => string.Equals(c.yData?.PathAsString, path));
-         return fromAnyPeer?.Color;
-      }
+   protected AnalysisChartWithLocalRepositories()
+   {
+      _dataRepositories = new List<DataRepository>();
    }
 
-   public abstract class AnalysisChartWithLocalRepositories : AnalysisChart
+   public virtual void AddRepository(DataRepository dataRepository)
    {
-      private readonly List<DataRepository> _dataRepositories;
-      public virtual IReadOnlyList<DataRepository> DataRepositories => _dataRepositories;
+      _dataRepositories.Add(dataRepository);
+   }
 
-      protected AnalysisChartWithLocalRepositories()
-      {
-         _dataRepositories = new List<DataRepository>();
-      }
+   public virtual void ClearDataRepositories()
+   {
+      _dataRepositories.Clear();
+   }
 
-      public virtual void AddRepository(DataRepository dataRepository)
-      {
-         _dataRepositories.Add(dataRepository);
-      }
-
-      public virtual void ClearDataRepositories()
-      {
-         _dataRepositories.Clear();
-      }
-
-      public virtual void AddRepositories(IEnumerable<DataRepository> dataRepositories)
-      {
-         dataRepositories.Each(AddRepository);
-      }
+   public virtual void AddRepositories(IEnumerable<DataRepository> dataRepositories)
+   {
+      dataRepositories.Each(AddRepository);
    }
 }

--- a/src/OSPSuite.Core/Chart/CurveChart.cs
+++ b/src/OSPSuite.Core/Chart/CurveChart.cs
@@ -25,6 +25,8 @@ namespace OSPSuite.Core.Chart
       public Scalings DefaultYAxisScaling { get; set; }
       public bool AutoUpdateEnabled { get; set; } = true;
 
+      public virtual CurveChartTypes CurveChartType => CurveChartTypes.TimeProfile;
+
       public CurveChart()
       {
          Id = string.Empty;

--- a/src/OSPSuite.Core/Chart/CurveChartTemplate.cs
+++ b/src/OSPSuite.Core/Chart/CurveChartTemplate.cs
@@ -17,6 +17,12 @@ namespace OSPSuite.Core.Chart
       public ChartSettings ChartSettings { set; get; }
       public ChartFontAndSizeSettings FontAndSize { get; set; }
       public bool IncludeOriginData { get; set; }
+
+      /// <summary>
+      ///    Type of chart the template was created from. Templates are only offered for charts of the same type.
+      ///    Defaults to <see cref="CurveChartTypes.TimeProfile" /> for templates created before the type was introduced.
+      /// </summary>
+      public CurveChartTypes ChartType { get; set; } = CurveChartTypes.TimeProfile;
       public IReadOnlyCollection<Axis> Axes => _axes;
 
       public Axis AxisBy(AxisTypes axisTypes) => _axes[axisTypes];
@@ -47,6 +53,7 @@ namespace OSPSuite.Core.Chart
          sourceChartTemplate.Curves.Each(curve => Curves.Add(cloneManager.Clone(curve)));
          IsDefault = sourceChartTemplate.IsDefault;
          PreviewSettings = sourceChartTemplate.PreviewSettings;
+         ChartType = sourceChartTemplate.ChartType;
       }
 
       public void AddAxis(Axis axis)

--- a/src/OSPSuite.Core/Chart/CurveChartTypes.cs
+++ b/src/OSPSuite.Core/Chart/CurveChartTypes.cs
@@ -1,6 +1,6 @@
 namespace OSPSuite.Core.Chart;
 
-public enum AnalysisChartTypes
+public enum CurveChartTypes
 {
    TimeProfile,
    PredictedVsObserved,

--- a/src/OSPSuite.Core/Chart/Mappers/CurveChartToCurveChartTemplateMapper.cs
+++ b/src/OSPSuite.Core/Chart/Mappers/CurveChartToCurveChartTemplateMapper.cs
@@ -26,6 +26,7 @@ namespace OSPSuite.Core.Chart.Mappers
 
          template.IncludeOriginData = curveChart.IncludeOriginData;
          template.PreviewSettings = curveChart.PreviewSettings;
+         template.ChartType = curveChart.CurveChartType;
          template.ChartSettings.UpdatePropertiesFrom(curveChart.ChartSettings, _cloneManager);
          template.FontAndSize.UpdatePropertiesFrom(curveChart.FontAndSize, _cloneManager);
          curveChart.Curves.Each(curve => template.Curves.Add(curveFrom(curve)));

--- a/src/OSPSuite.Core/Chart/ParameterIdentifications/ParameterIdentificationAnalysisChart.cs
+++ b/src/OSPSuite.Core/Chart/ParameterIdentifications/ParameterIdentificationAnalysisChart.cs
@@ -1,30 +1,25 @@
-﻿namespace OSPSuite.Core.Chart.ParameterIdentifications
+﻿namespace OSPSuite.Core.Chart.ParameterIdentifications;
+
+public class ParameterIdentificationTimeProfileChart : AnalysisChart
 {
-   public class ParameterIdentificationTimeProfileChart : AnalysisChart
-   {
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
-   }
+}
 
-   public class ParameterIdentificationTimeProfileConfidenceIntervalChart : AnalysisChartWithLocalRepositories
-   {
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
-   }
+public class ParameterIdentificationTimeProfileConfidenceIntervalChart : AnalysisChartWithLocalRepositories
+{
+}
 
-   public class ParameterIdentificationTimeProfilePredictionIntervalChart : AnalysisChartWithLocalRepositories
-   {
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
-   }
+public class ParameterIdentificationTimeProfilePredictionIntervalChart : AnalysisChartWithLocalRepositories
+{
+}
 
-   public class ParameterIdentificationTimeProfileVPCIntervalChart : AnalysisChartWithLocalRepositories
-   {
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.TimeProfile;
-   }
+public class ParameterIdentificationTimeProfileVPCIntervalChart : AnalysisChartWithLocalRepositories
+{
+}
 
-   public class ParameterIdentificationResidualVsTimeChart : ResidualsVsTimeChart
-   {
-   }
+public class ParameterIdentificationResidualVsTimeChart : ResidualsVsTimeChart
+{
+}
 
-   public class ParameterIdentificationPredictedVsObservedChart : PredictedVsObservedChart
-   {
-   }
+public class ParameterIdentificationPredictedVsObservedChart : PredictedVsObservedChart
+{
 }

--- a/src/OSPSuite.Core/Chart/PredictedVsObservedChart.cs
+++ b/src/OSPSuite.Core/Chart/PredictedVsObservedChart.cs
@@ -16,7 +16,7 @@ namespace OSPSuite.Core.Chart
       private readonly Cache<float, IReadOnlyList<DataRepository>> _deviationRepositoryCache = new Cache<float, IReadOnlyList<DataRepository>>(onMissingKey: x => null);
       public List<float> DeviationFoldValues { get; } = new List<float>();
 
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.PredictedVsObserved;
+      public override CurveChartTypes CurveChartType => CurveChartTypes.PredictedVsObserved;
 
       protected PredictedVsObservedChart()
       {

--- a/src/OSPSuite.Core/Chart/ResidualsVsTimeChart.cs
+++ b/src/OSPSuite.Core/Chart/ResidualsVsTimeChart.cs
@@ -8,7 +8,7 @@ namespace OSPSuite.Core.Chart
    {
       public const string ZERO = "Zero";
 
-      public override AnalysisChartTypes AnalysisChartType => AnalysisChartTypes.ResidualVsTime;
+      public override CurveChartTypes CurveChartType => CurveChartTypes.ResidualVsTime;
 
       public override Curve CreateCurve(DataColumn columnX, DataColumn columnY, string curveName, IDimensionFactory dimensionFactory)
       {

--- a/src/OSPSuite.Core/Domain/Builder/SimulationSettings.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationSettings.cs
@@ -31,11 +31,6 @@ namespace OSPSuite.Core.Domain.Builder
          OutputSelections = new OutputSelections();
       }
 
-      public CurveChartTemplate DefaultChartTemplate
-      {
-         get { return ChartTemplates.FirstOrDefault(x => x.IsDefault) ?? ChartTemplates.OrderBy(x => x.Name).FirstOrDefault(); }
-      }
-
       public CurveChartTemplate ChartTemplateByName(string templateName)
       {
          return _chartTemplates[templateName];

--- a/src/OSPSuite.Core/Domain/IWith.cs
+++ b/src/OSPSuite.Core/Domain/IWith.cs
@@ -69,12 +69,6 @@ namespace OSPSuite.Core.Domain
 
       void RemoveChartTemplate(string chartTemplateName);
 
-      /// <summary>
-      ///    Returns the default curve chart template if one is defined, otherwise the first chart template ordered
-      ///    alphabetically. If not template is defined, returns null
-      /// </summary>
-      CurveChartTemplate DefaultChartTemplate { get; }
-
       CurveChartTemplate ChartTemplateByName(string templateName);
 
       void RemoveAllChartTemplates();

--- a/src/OSPSuite.Core/Domain/Project.cs
+++ b/src/OSPSuite.Core/Domain/Project.cs
@@ -160,11 +160,13 @@ namespace OSPSuite.Core.Domain
       public void AddChartTemplate(CurveChartTemplate chartTemplate)
       {
          _chartTemplates.Add(chartTemplate);
+         HasChanged = true;
       }
 
       public void RemoveChartTemplate(string chartTemplateName)
       {
-         _chartTemplates.Remove(chartTemplateName); ;
+         _chartTemplates.Remove(chartTemplateName);
+         HasChanged = true;
       }
 
       public CurveChartTemplate ChartTemplateByName(string templateName)
@@ -175,6 +177,7 @@ namespace OSPSuite.Core.Domain
       public void RemoveAllChartTemplates()
       {
          _chartTemplates.Clear();
+         HasChanged = true;
       }
 
       public IEnumerable<CurveChartTemplate> ChartTemplates => _chartTemplates;

--- a/src/OSPSuite.Core/Domain/Project.cs
+++ b/src/OSPSuite.Core/Domain/Project.cs
@@ -182,11 +182,6 @@ namespace OSPSuite.Core.Domain
 
       public IEnumerable<CurveChartTemplate> ChartTemplates => _chartTemplates;
 
-      public CurveChartTemplate DefaultChartTemplate
-      {
-         get { return ChartTemplates.FirstOrDefault(x => x.IsDefault) ?? ChartTemplates.OrderBy(x => x.Name).FirstOrDefault(); }
-      }
-
       public IReadOnlyCollection<ParameterIdentification> AllParameterIdentifications => _allParameterIdentifications;
 
       public virtual void AddParameterIdentification(ParameterIdentification parameterIdentification)

--- a/src/OSPSuite.Core/Extensions/WithChartTemplatesExtensions.cs
+++ b/src/OSPSuite.Core/Extensions/WithChartTemplatesExtensions.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Extensions
+{
+   public static class WithChartTemplatesExtensions
+   {
+      /// <summary>
+      ///    Returns the default template among the templates defined for the given <paramref name="chartType" />:
+      ///    the first one flagged as default, otherwise the first one by name. Returns <c>null</c> if no template
+      ///    is defined for <paramref name="chartType" />.
+      /// </summary>
+      public static CurveChartTemplate DefaultChartTemplateFor(this IWithChartTemplates withChartTemplates, CurveChartTypes chartType)
+      {
+         var templatesForChartType = withChartTemplates.ChartTemplates.Where(x => x.ChartType == chartType).ToList();
+         return templatesForChartType.FirstOrDefault(x => x.IsDefault) ?? templatesForChartType.OrderBy(x => x.Name).FirstOrDefault();
+      }
+   }
+}

--- a/src/OSPSuite.Core/Serialization/Chart/CurveChartTemplateXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Chart/CurveChartTemplateXmlSerializer.cs
@@ -15,6 +15,7 @@ namespace OSPSuite.Core.Serialization.Chart
          MapEnumerable(x => x.Axes, x => x.AddAxis);
          MapEnumerable(x => x.Curves, x => x.Curves.Add);
          Map(x => x.IsDefault);
+         Map(x => x.ChartType);
       }
    }
 }

--- a/src/OSPSuite.Core/Serialization/Xml/OSPSuiteXmlSerializerRepository.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/OSPSuiteXmlSerializerRepository.cs
@@ -40,6 +40,7 @@ namespace OSPSuite.Core.Serialization.Xml
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<ContainerType, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<PKParameterMode, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<AxisTypes, SerializationContext>());
+         AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<CurveChartTypes, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<Scalings, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<NumberModes, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<LegendPositions, SerializationContext>());

--- a/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
+++ b/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
@@ -78,12 +78,14 @@ namespace OSPSuite.Core.Services
          {
             Values = identityValues
          };
+         baseGrid.QuantityInfo.Path = new[] {mergedDimension.Name};
          var values = new DataColumn("Marker_Identity", mergedDimension, baseGrid)
          {
             Values = identityValues,
             Name = IDENTITY,
             DataInfo = new DataInfo(ColumnOrigins.DeviationLine, AuxiliaryType.Undefined, string.Empty, string.Empty, null)
          };
+         values.QuantityInfo.Path = new[] {IDENTITY};
          return values;
       }
 
@@ -188,6 +190,7 @@ namespace OSPSuite.Core.Services
                {
                   Values = new List<float>() {identityMinimum, identityMaximum}
                };
+               baseGridDeviation.QuantityInfo.Path = new[] {mergedDimension.Name};
 
                var valuesUpper = new DataColumn(Captions.Chart.DeviationLines.DeviationLineNameUpper(foldValue), mergedDimension,
                   baseGridDeviation)
@@ -199,6 +202,7 @@ namespace OSPSuite.Core.Services
                   },
                   DataInfo = new DataInfo(ColumnOrigins.DeviationLine, AuxiliaryType.Undefined, string.Empty, string.Empty, null)
                };
+               valuesUpper.QuantityInfo.Path = new[] {valuesUpper.Name};
                deviationDataRepository.Add(valuesUpper);
 
                var valuesLower = new DataColumn(Captions.Chart.DeviationLines.DeviationLineNameLower(foldValue), mergedDimension,
@@ -207,6 +211,7 @@ namespace OSPSuite.Core.Services
                   Values = new List<float>() {identityMinimum / foldValue, identityMaximum / foldValue},
                   DataInfo = new DataInfo(ColumnOrigins.DeviationLine, AuxiliaryType.Undefined, string.Empty, string.Empty, null)
                };
+               valuesLower.QuantityInfo.Path = new[] {valuesLower.Name};
                deviationDataRepository.Add(valuesLower);
                break;
             case DeviationLineType.Identity:

--- a/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
+++ b/src/OSPSuite.Core/Services/PredictedVsObservedChartService.cs
@@ -78,7 +78,7 @@ namespace OSPSuite.Core.Services
          {
             Values = identityValues
          };
-         baseGrid.QuantityInfo.Path = new[] {mergedDimension.Name};
+         baseGrid.QuantityInfo.Path = new[] {mergedDimension.DisplayName};
          var values = new DataColumn("Marker_Identity", mergedDimension, baseGrid)
          {
             Values = identityValues,
@@ -190,7 +190,7 @@ namespace OSPSuite.Core.Services
                {
                   Values = new List<float>() {identityMinimum, identityMaximum}
                };
-               baseGridDeviation.QuantityInfo.Path = new[] {mergedDimension.Name};
+               baseGridDeviation.QuantityInfo.Path = new[] {mergedDimension.DisplayName};
 
                var valuesUpper = new DataColumn(Captions.Chart.DeviationLines.DeviationLineNameUpper(foldValue), mergedDimension,
                   baseGridDeviation)

--- a/src/OSPSuite.Core/Services/ResidualsVsTimeChartService.cs
+++ b/src/OSPSuite.Core/Services/ResidualsVsTimeChartService.cs
@@ -82,8 +82,10 @@ namespace OSPSuite.Core.Services
       {
          var dataRepository = new DataRepository(id) {Name = name};
          var baseGrid = new BaseGrid($"{id}-Time", "Time", _dimensionFactory.Dimension(Constants.Dimension.TIME));
+         baseGrid.QuantityInfo.Path = new[] {baseGrid.Name};
          var values = new DataColumn($"{id}-{valueName}", valueName, _dimensionFactory.NoDimension, baseGrid)
             {DataInfo = {Origin = ColumnOrigins.CalculationAuxiliary}};
+         values.QuantityInfo.Path = new[] {valueName};
          dataRepository.Add(values);
          return dataRepository;
       }
@@ -125,6 +127,11 @@ namespace OSPSuite.Core.Services
          {
             dataRepository = CreateScatterDataRepository(id, repositoryName, outputResidual);
             chart.AddRepository(dataRepository);
+         }
+         else
+         {
+            //repositories persisted with the chart may have been created before the base grid path was introduced
+            dataRepository.BaseGrid.QuantityInfo.Path = new[] {dataRepository.BaseGrid.Name};
          }
 
          dataRepository.BaseGrid.Values = residuals.Select(x => x.Time).ToFloatArray();

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
@@ -4,6 +4,7 @@ using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Events;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Settings;
@@ -86,7 +87,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          updateViewCaptionFromChart();
       }
 
-      protected CurveChartTemplate DefaultChartTemplate => _withChartTemplates?.DefaultChartTemplate;
+      protected CurveChartTemplate DefaultChartTemplate => _withChartTemplates?.DefaultChartTemplateFor(Chart.CurveChartType);
 
       protected void UpdateTemplatesBasedOn(IWithChartTemplates withChartTemplates)
       {

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateManagerPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateManagerPresenter.cs
@@ -17,6 +17,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
       private readonly IChartTemplateDetailsPresenter _chartTemplateDetailsPresenter;
       private readonly IDialogCreator _dialogCreator;
       private List<CurveChartTemplate> _chartTemplatesToEdit;
+      private List<string> _forbiddenNames = new List<string>();
+      private CurveChartTypes? _managedChartType;
       public bool HasChanged { private set; get; }
 
       public ChartTemplateManagerPresenter(IChartTemplateManagerView view, IChartTemplatingTask chartTemplatingTask,
@@ -32,12 +34,24 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public void SetDefaultTemplateValue(CurveChartTemplate template, bool isDefault)
       {
-         _chartTemplatesToEdit.Each(x => x.IsDefault = false);
+         _chartTemplatesToEdit.Where(x => x.ChartType == template.ChartType).Each(x => x.IsDefault = false);
          rebindAction(() => template.IsDefault = isDefault);
       }
 
       public void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates)
       {
+         editTemplates(chartTemplates, new List<string>(), managedChartType: null);
+      }
+
+      public void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates, IReadOnlyList<string> forbiddenNames, CurveChartTypes managedChartType)
+      {
+         editTemplates(chartTemplates, forbiddenNames, managedChartType);
+      }
+
+      private void editTemplates(IEnumerable<CurveChartTemplate> chartTemplates, IReadOnlyList<string> forbiddenNames, CurveChartTypes? managedChartType)
+      {
+         _managedChartType = managedChartType;
+         _forbiddenNames = forbiddenNames.ToList();
          _chartTemplatesToEdit = chartTemplates.OrderBy(x => x.Name).ToList();
          rebind();
          showFirstTemplateIfAvailable();
@@ -62,11 +76,21 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public void CloneTemplate(CurveChartTemplate templateToClone)
       {
-         var newTemplate = _chartTemplatingTask.CloneTemplate(templateToClone, _chartTemplatesToEdit);
+         var newTemplate = _chartTemplatingTask.CloneTemplate(templateToClone, allForbiddenNames());
          if (newTemplate == null)
             return;
 
          addTemplate(newTemplate);
+      }
+
+      private IReadOnlyList<string> allForbiddenNames()
+      {
+         return _chartTemplatesToEdit.AllNames().Concat(_forbiddenNames).ToList();
+      }
+
+      private bool templateMatchesManagedChartType(CurveChartTemplate template)
+      {
+         return _managedChartType == null || template.ChartType == _managedChartType.Value;
       }
 
       public void DeleteTemplate(CurveChartTemplate chartTemplate)
@@ -89,9 +113,15 @@ namespace OSPSuite.Presentation.Presenters.Charts
          var file = _dialogCreator.AskForFileToOpen(Captions.LoadChartTemplateFromFile, Constants.Filter.CHART_TEMPLATE_FILTER, Constants.DirectoryKey.MODEL_PART);
          if (string.IsNullOrEmpty(file)) return;
 
-         var template = _chartTemplatingTask.LoadTemplateFromFile(file, _chartTemplatesToEdit);
+         var template = _chartTemplatingTask.LoadTemplateFromFile(file, allForbiddenNames());
          if (template == null)
             return;
+
+         if (!templateMatchesManagedChartType(template))
+         {
+            _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(template.Name, template.ChartType.ToString(), _managedChartType.ToString()));
+            return;
+         }
 
          addTemplate(template);
       }

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateManagerPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateManagerPresenter.cs
@@ -5,6 +5,7 @@ using OSPSuite.Assets;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views;
@@ -119,7 +120,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
          if (!templateMatchesManagedChartType(template))
          {
-            _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(template.Name, template.ChartType.ToString(), _managedChartType.ToString()));
+            _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(template.Name, template.ChartType.ToString().SplitToUpperCase(), _managedChartType.ToString().SplitToUpperCase()));
             return;
          }
 

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateMenuPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartTemplateMenuPresenter.cs
@@ -18,7 +18,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       ///    Creates the chart template menu button with all sub menus filled in according to the subject
       ///    <paramref name="withChartTemplates" />
       /// </summary>
-      /// <param name="withChartTemplates">This is the active simulation settings object containing the templates</param>
+      /// <param name="withChartTemplates">The object owning the curve chart templates (e.g. the project or a simulation)</param>
       /// <param name="retrieveActiveCurveChartFunc">retrieves the current CurveChart</param>
       /// <param name="applyTemplateAction">How to apply the template to the active curve chart</param>
       /// <returns>The menu button that should be added to the chart presenter</returns>
@@ -43,6 +43,11 @@ namespace OSPSuite.Presentation.Presenters.Charts
       {
          return _withChartTemplates.ChartTemplates;
       }
+
+      private CurveChartTypes activeCurveChartType => _curveChart().CurveChartType;
+
+      private IEnumerable<CurveChartTemplate> allTemplatesForActiveChart() => 
+         allSimulationTemplates().Where(template => template.ChartType == activeCurveChartType);
 
       protected CurveChartTemplate CreateNewTemplateFromCurrent(IEnumerable<CurveChartTemplate> existingTemplates)
       {
@@ -125,7 +130,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       private void createUpdateMenu(IMenuBarSubMenu chartTemplate)
       {
-         var chartTemplates = allSimulationTemplates().ToList();
+         var chartTemplates = allTemplatesForActiveChart().ToList();
          if (chartTemplates.Any())
          {
             var overwrite = CreateSubMenu.WithCaption(MenuNames.UpdateExistingTemplate)
@@ -138,7 +143,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       private void manageTemplates()
       {
-         AddCommand(_chartTemplatingTask.ManageTemplates(_withChartTemplates));
+         AddCommand(_chartTemplatingTask.ManageTemplates(_withChartTemplates, activeCurveChartType));
       }
 
       private IMenuBarItem createLoadButton(Func<CurveChartTemplate, IMenuBarButton> loadMenuFor)
@@ -147,7 +152,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
             .WithIcon(ApplicationIcons.Load);
 
          var noTemplateAvailable = CreateMenuButton.WithCaption(MenuNames.NoTemplateAvailable).WithActionCommand(() => { });
-         var chartTemplates = _withChartTemplates.ChartTemplates.ToList();
+         var chartTemplates = allTemplatesForActiveChart().ToList();
          if (chartTemplates.Any())
             chartTemplates.Each(t => loadTemplate.AddItem(loadMenuFor(t)));
          else

--- a/src/OSPSuite.Presentation/Presenters/Charts/ModalChartTemplateManagerPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ModalChartTemplateManagerPresenter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Chart;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Presentation.Views.Charts;
 
@@ -9,6 +10,13 @@ namespace OSPSuite.Presentation.Presenters.Charts
    public interface IModalChartTemplateManagerPresenter : IPresenter<IModalChartTemplateManagerView>, IDisposablePresenter
    {
       void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates);
+
+      /// <summary>
+      ///    Edits the templates created for charts of type <paramref name="chartTypeToManage" /> only. Templates created for
+      ///    other chart types are not shown but are preserved and returned as part of <see cref="EditedTemplates" />
+      /// </summary>
+      void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates, CurveChartTypes chartTypeToManage);
+
       bool HasChanged { get; }
       IEnumerable<CurveChartTemplate> EditedTemplates { get; }
       bool Canceled();
@@ -19,6 +27,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
    {
       private readonly IChartTemplateManagerPresenter _chartTemplateManagerPresenter;
       private readonly ICloneManager _cloneManager;
+      private readonly List<CurveChartTemplate> _hiddenTemplates = [];
 
       public ModalChartTemplateManagerPresenter(IModalChartTemplateManagerView view, IChartTemplateManagerPresenter chartTemplateManagerPresenter, ICloneManager cloneManager)
          : base(view)
@@ -31,34 +40,35 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates)
       {
-         var chartTemplatesToEdit = chartTemplates.Select(x =>
+         _hiddenTemplates.Clear();
+         _chartTemplateManagerPresenter.EditTemplates(cloneOf(chartTemplates));
+      }
+
+      public void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates, CurveChartTypes chartTypeToManage)
+      {
+         var clonedTemplates = cloneOf(chartTemplates);
+         _hiddenTemplates.Clear();
+         _hiddenTemplates.AddRange(clonedTemplates.Where(x => x.ChartType != chartTypeToManage));
+         _chartTemplateManagerPresenter.EditTemplates(clonedTemplates.Where(x => x.ChartType == chartTypeToManage), _hiddenTemplates.AllNames(), chartTypeToManage);
+      }
+
+      private List<CurveChartTemplate> cloneOf(IEnumerable<CurveChartTemplate> chartTemplates)
+      {
+         return chartTemplates.Select(x =>
          {
             var curveChartTemplate = _cloneManager.Clone(x);
             // setting IsDefault is not part of general cloning and is done when cloning the set only
             curveChartTemplate.IsDefault = x.IsDefault;
             return curveChartTemplate;
-         });
-         _chartTemplateManagerPresenter.EditTemplates(chartTemplatesToEdit);
+         }).ToList();
       }
 
-      public bool HasChanged
-      {
-         get { return _chartTemplateManagerPresenter.HasChanged; }
-      }
+      public bool HasChanged => _chartTemplateManagerPresenter.HasChanged;
 
-      public IEnumerable<CurveChartTemplate> EditedTemplates
-      {
-         get { return _chartTemplateManagerPresenter.EditedTemplates; }
-      }
+      public IEnumerable<CurveChartTemplate> EditedTemplates => _chartTemplateManagerPresenter.EditedTemplates.Concat(_hiddenTemplates);
 
-      public bool Canceled()
-      {
-         return _view.Canceled;
-      }
+      public bool Canceled() => _view.Canceled;
 
-      public void Display()
-      {
-         _view.Display();
-      }
+      public void Display() => _view.Display();
    }
 }

--- a/src/OSPSuite.Presentation/Presenters/IChartTemplateManagerPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/IChartTemplateManagerPresenter.cs
@@ -7,10 +7,17 @@ namespace OSPSuite.Presentation.Presenters
    public interface IChartTemplateManagerPresenter : IPresenter<IChartTemplateManagerView>,  IDisposablePresenter
    {
       /// <summary>
-      ///    Edits the chart templates <paramref name="chartTemplates" /> given as parameters and a brand new enumeration
+      ///    Edits the chart templates <paramref name="chartTemplates" /> given as parameters and a brand-new enumeration
       ///    containing the edited templates. Returns true if the edit was performed otherwise false
       /// </summary>
       void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates);
+
+      /// <summary>
+      ///    Edits the chart templates <paramref name="chartTemplates" /> created for charts of type
+      ///    <paramref name="managedChartType" />. The <paramref name="forbiddenNames" /> are taken into account when
+      ///    validating template names. Loading a template created for another chart type from file is rejected
+      /// </summary>
+      void EditTemplates(IEnumerable<CurveChartTemplate> chartTemplates, IReadOnlyList<string> forbiddenNames, CurveChartTypes managedChartType);
 
       /// <summary>
       ///    This method should be called to show the details of a <paramref name="chartTemplate" />
@@ -46,8 +53,8 @@ namespace OSPSuite.Presentation.Presenters
       bool HasChanged { get; }
 
       /// <summary>
-      /// Sets the <paramref name="template"/> DefaultTemplate to <paramref name="isDefault"/>. 
-      /// Also clears DefaultTemplate value for all other templates
+      /// Sets the <paramref name="template"/> DefaultTemplate to <paramref name="isDefault"/>.
+      /// Also clears DefaultTemplate value for all other templates of the same chart type
       /// </summary>
       void SetDefaultTemplateValue(CurveChartTemplate template, bool isDefault);
    }

--- a/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationAnalysisChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/ParameterIdentifications/ParameterIdentificationAnalysisChartPresenter.cs
@@ -38,6 +38,7 @@ namespace OSPSuite.Presentation.Presenters.ParameterIdentifications
       public override void UpdateAnalysisBasedOn(IAnalysable analysable)
       {
          _parameterIdentification = analysable.DowncastTo<ParameterIdentification>();
+         UpdateTemplatesBasedOn(_chartPresenterContext.ProjectRetriever.CurrentProject);
 
          if (ChartIsBeingUpdated)
          {

--- a/src/OSPSuite.Presentation/Presenters/SimulationVsObservedDataChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/SimulationVsObservedDataChartPresenter.cs
@@ -37,6 +37,7 @@ namespace OSPSuite.Presentation.Presenters
       public override void UpdateAnalysisBasedOn(IAnalysable analysable)
       {
          _simulation = analysable.DowncastTo<ISimulation>();
+         UpdateTemplatesBasedOn(_simulation as IWithChartTemplates);
 
          if (ChartIsBeingUpdated)
          {

--- a/src/OSPSuite.Presentation/Services/Charts/ChartTemplatingTask.cs
+++ b/src/OSPSuite.Presentation/Services/Charts/ChartTemplatingTask.cs
@@ -23,14 +23,24 @@ namespace OSPSuite.Presentation.Services.Charts
       /// <summary>
       ///    Starts the management interface for curve chart templates
       /// </summary>
-      /// <param name="withChartTemplates">An object which contains simulation settings, which contains curve chart templates</param>
+      /// <param name="withChartTemplates">The object owning the curve chart templates (e.g. the project or a simulation)</param>
       /// <returns>Any commands used to manipulate the templates</returns>
       ICommand ManageTemplates(IWithChartTemplates withChartTemplates);
 
       /// <summary>
-      ///    Returns a default template. The user will be asked to enter a unique name for the template
+      ///    Starts the management interface for the curve chart templates created for charts of type <paramref name="chartType" />.
+      ///    Templates created for other chart types are preserved unchanged
       /// </summary>
-      CurveChartTemplate CloneTemplate(CurveChartTemplate templateToClone, IEnumerable<CurveChartTemplate> existingTemplates);
+      /// <param name="withChartTemplates">The object owning the curve chart templates (e.g. the project or a simulation)</param>
+      /// <param name="chartType">Type of chart whose templates will be managed</param>
+      /// <returns>Any commands used to manipulate the templates</returns>
+      ICommand ManageTemplates(IWithChartTemplates withChartTemplates, CurveChartTypes chartType);
+
+      /// <summary>
+      ///    Returns a clone of the <paramref name="templateToClone" />. The user will be asked to enter a unique name for the
+      ///    template that is not part of the <paramref name="forbiddenNames" />
+      /// </summary>
+      CurveChartTemplate CloneTemplate(CurveChartTemplate templateToClone, IReadOnlyList<string> forbiddenNames);
 
       /// <summary>
       ///    Saves the given <paramref name="template" /> to the file with path <paramref name="filePath" />
@@ -39,9 +49,10 @@ namespace OSPSuite.Presentation.Services.Charts
 
       /// <summary>
       ///    Returns the template supposedly serialized in the file with path <paramref name="filePath" />.
-      ///    The user will be asked to enter a unique name for the template if the deserialized template name already exists.
+      ///    The user will be asked to enter a unique name for the template if the deserialized template name is part of the
+      ///    <paramref name="forbiddenNames" />
       /// </summary>
-      CurveChartTemplate LoadTemplateFromFile(string filePath, IReadOnlyList<CurveChartTemplate> existingTemplates);
+      CurveChartTemplate LoadTemplateFromFile(string filePath, IReadOnlyList<string> forbiddenNames);
 
       /// <summary>
       /// Initializes the given <paramref name="chart"/> from the <paramref name="template"/>.
@@ -113,33 +124,33 @@ namespace OSPSuite.Presentation.Services.Charts
          _chartTemplatePersistor.SerializeToFile(template, filePath);
       }
 
-      public CurveChartTemplate CloneTemplate(CurveChartTemplate templateToClone, IEnumerable<CurveChartTemplate> existingTemplates)
+      public CurveChartTemplate CloneTemplate(CurveChartTemplate templateToClone, IReadOnlyList<string> forbiddenNames)
       {
-         return createTemplate(existingTemplates, () => _cloneManager.Clone(templateToClone), Captions.CloneTemplate);
+         return createTemplate(forbiddenNames, () => _cloneManager.Clone(templateToClone), Captions.CloneTemplate);
       }
 
-      private CurveChartTemplate createTemplate(IEnumerable<CurveChartTemplate> existingTemplates, Func<CurveChartTemplate> createAction, string caption, string defaultName = null)
+      private CurveChartTemplate createTemplate(IReadOnlyList<string> forbiddenNames, Func<CurveChartTemplate> createAction, string caption, string defaultName = null)
       {
          var template = createAction();
          if (!template.Curves.Any())
             throw new OSPSuiteException(Error.TemplateShouldContainAtLeastOneCurve);
 
-         var newName = retrieveNewNamesForTemplate(existingTemplates, caption, defaultName);
+         var newName = retrieveNewNamesForTemplate(forbiddenNames, caption, defaultName);
          if (string.IsNullOrEmpty(newName))
             return null;
 
          return createAction().WithName(newName);
       }
 
-      public CurveChartTemplate LoadTemplateFromFile(string filePath, IReadOnlyList<CurveChartTemplate> existingTemplates)
+      public CurveChartTemplate LoadTemplateFromFile(string filePath, IReadOnlyList<string> forbiddenNames)
       {
          var template = _chartTemplatePersistor.DeserializeFromFile(filePath);
          if (template == null)
             return null;
 
-         if (existingTemplates.ExistsByName(template.Name))
+         if (forbiddenNames.Contains(template.Name))
          {
-            var newName = retrieveNewNamesForTemplate(existingTemplates, Captions.RenameTemplate, template.Name);
+            var newName = retrieveNewNamesForTemplate(forbiddenNames, Captions.RenameTemplate, template.Name);
             if (string.IsNullOrEmpty(newName))
                return null;
 
@@ -148,10 +159,9 @@ namespace OSPSuite.Presentation.Services.Charts
          return template;
       }
 
-      private string retrieveNewNamesForTemplate(IEnumerable<CurveChartTemplate> existingTemplates, string caption, string defaultName)
+      private string retrieveNewNamesForTemplate(IReadOnlyList<string> forbiddenNames, string caption, string defaultName)
       {
-         var usedNames = existingTemplates.Select(x => x.Name).ToList();
-         return AskForInput(Captions.NewName, caption, defaultName, usedNames);
+         return AskForInput(Captions.NewName, caption, defaultName, forbiddenNames.ToList());
       }
 
       protected string AskForInput(string caption, string text, string defaultName, List<string> usedNames)
@@ -163,9 +173,19 @@ namespace OSPSuite.Presentation.Services.Charts
 
       public ICommand ManageTemplates(IWithChartTemplates withChartTemplates)
       {
+         return manageTemplates(withChartTemplates, presenter => presenter.EditTemplates(withChartTemplates.ChartTemplates));
+      }
+
+      public ICommand ManageTemplates(IWithChartTemplates withChartTemplates, CurveChartTypes chartType)
+      {
+         return manageTemplates(withChartTemplates, presenter => presenter.EditTemplates(withChartTemplates.ChartTemplates, chartType));
+      }
+
+      private ICommand manageTemplates(IWithChartTemplates withChartTemplates, Action<IModalChartTemplateManagerPresenter> editTemplatesAction)
+      {
          using (var presenter = _applicationController.Start<IModalChartTemplateManagerPresenter>())
          {
-            presenter.EditTemplates(withChartTemplates.ChartTemplates);
+            editTemplatesAction(presenter);
 
             presenter.Display();
 
@@ -226,7 +246,7 @@ namespace OSPSuite.Presentation.Services.Charts
 
       public CurveChartTemplate CreateNewTemplateFromChart(CurveChart chart, IEnumerable<CurveChartTemplate> existingTemplates)
       {
-         return createTemplate(existingTemplates, () => TemplateFrom(chart), Captions.CreateNewTemplate, chart.Name);
+         return createTemplate(existingTemplates.AllNames(), () => TemplateFrom(chart), Captions.CreateNewTemplate, chart.Name);
       }
 
       public abstract ICommand AddChartTemplateCommand(CurveChartTemplate template, IWithChartTemplates withChartTemplates);

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/CurveChartTemplateXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/CurveChartTemplateXmlSerializerSpecs.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Serialization;
+using OSPSuite.Utility.Container;
+
+namespace OSPSuite.Core.Serializers
+{
+   public class CurveChartTemplateXmlSerializerSpecs : ModelingXmlSerializerBaseSpecs
+   {
+      [Test]
+      public void TestSerialization()
+      {
+         var x1 = new CurveChartTemplate
+         {
+            Name = "Template",
+            IsDefault = true,
+            PreviewSettings = true,
+            ChartType = CurveChartTypes.PredictedVsObserved
+         };
+
+         var x2 = SerializeAndDeserialize(x1);
+
+         x2.Name.ShouldBeEqualTo(x1.Name);
+         x2.IsDefault.ShouldBeEqualTo(x1.IsDefault);
+         x2.PreviewSettings.ShouldBeEqualTo(x1.PreviewSettings);
+         x2.ChartType.ShouldBeEqualTo(CurveChartTypes.PredictedVsObserved);
+      }
+
+      [Test]
+      public void TestDeserializationOfTemplateCreatedBeforeChartTypeWasIntroduced()
+      {
+         var x1 = new CurveChartTemplate {Name = "Template", ChartType = CurveChartTypes.PredictedVsObserved};
+
+         using (var serializationContext = SerializationTransaction.Create(IoC.Container))
+         {
+            var serializer = SerializerRepository.SerializerFor(x1);
+            var xel = serializer.Serialize(x1, serializationContext);
+
+            //legacy templates were serialized without the chart type attribute
+            xel.Attributes().Single(x => string.Equals(x.Name.LocalName, "chartType", StringComparison.OrdinalIgnoreCase)).Remove();
+
+            using (var deserializationContext = NewDeserializationContext())
+            {
+               var x2 = serializer.Deserialize<CurveChartTemplate>(xel, deserializationContext);
+               x2.ChartType.ShouldBeEqualTo(CurveChartTypes.TimeProfile);
+            }
+         }
+      }
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Domain/CurveChartTemplateSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/CurveChartTemplateSpecs.cs
@@ -25,7 +25,7 @@ namespace OSPSuite.Core.Domain
       {
          base.Context();
          _cloneManager= A.Fake<ICloneManager>();
-         _sourceTemplate = new CurveChartTemplate {Name = "TOTO",ChartSettings = {BackColor = Color.Red}};
+         _sourceTemplate = new CurveChartTemplate {Name = "TOTO",ChartSettings = {BackColor = Color.Red}, ChartType = CurveChartTypes.PredictedVsObserved};
          _sourceTemplate.AddAxis(new Axis(AxisTypes.X));
          var curveTemplate = new CurveTemplate{Name = "XX"};
          _cloneCurve = new CurveTemplate();
@@ -43,6 +43,7 @@ namespace OSPSuite.Core.Domain
       {
          sut.ChartSettings.BackColor.ShouldBeEqualTo(Color.Red);
          sut.Name.ShouldBeEqualTo("TOTO");
+         sut.ChartType.ShouldBeEqualTo(CurveChartTypes.PredictedVsObserved);
       }
 
       [Observation]

--- a/tests/OSPSuite.Core.Tests/Domain/ProjectSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ProjectSpecs.cs
@@ -1,0 +1,73 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Helpers;
+
+namespace OSPSuite.Core.Domain;
+
+public abstract class concern_for_Project : ContextSpecification<Project>
+{
+   protected CurveChartTemplate _chartTemplate;
+
+   protected override void Context()
+   {
+      _chartTemplate = new CurveChartTemplate {Name = "Template"};
+      sut = new TestProject();
+   }
+}
+
+public class When_adding_a_chart_template_to_a_project : concern_for_Project
+{
+   protected override void Because()
+   {
+      sut.AddChartTemplate(_chartTemplate);
+   }
+
+   [Observation]
+   public void should_mark_the_project_as_changed()
+   {
+      sut.HasChanged.ShouldBeTrue();
+   }
+}
+
+public class When_removing_a_chart_template_from_a_project : concern_for_Project
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut.AddChartTemplate(_chartTemplate);
+      sut.HasChanged = false;
+   }
+
+   protected override void Because()
+   {
+      sut.RemoveChartTemplate(_chartTemplate.Name);
+   }
+
+   [Observation]
+   public void should_mark_the_project_as_changed()
+   {
+      sut.HasChanged.ShouldBeTrue();
+   }
+}
+
+public class When_removing_all_chart_templates_from_a_project : concern_for_Project
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut.AddChartTemplate(_chartTemplate);
+      sut.HasChanged = false;
+   }
+
+   protected override void Because()
+   {
+      sut.RemoveAllChartTemplates();
+   }
+
+   [Observation]
+   public void should_mark_the_project_as_changed()
+   {
+      sut.HasChanged.ShouldBeTrue();
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Extensions/WithChartTemplatesExtensionsSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Extensions/WithChartTemplatesExtensionsSpecs.cs
@@ -1,0 +1,52 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Extensions;
+
+public abstract class concern_for_WithChartTemplatesExtensions : StaticContextSpecification
+{
+   protected IWithChartTemplates _withChartTemplates;
+   protected CurveChartTemplate _timeProfileTemplate;
+   protected CurveChartTemplate _defaultTimeProfileTemplate;
+   protected CurveChartTemplate _predictedVsObservedTemplate;
+
+   protected override void Context()
+   {
+      _timeProfileTemplate = new CurveChartTemplate {Name = "A time profile", ChartType = CurveChartTypes.TimeProfile};
+      _defaultTimeProfileTemplate = new CurveChartTemplate {Name = "Z time profile", ChartType = CurveChartTypes.TimeProfile, IsDefault = true};
+      _predictedVsObservedTemplate = new CurveChartTemplate {Name = "Predicted vs observed", ChartType = CurveChartTypes.PredictedVsObserved};
+
+      _withChartTemplates = A.Fake<IWithChartTemplates>();
+      A.CallTo(() => _withChartTemplates.ChartTemplates).Returns(new[] {_timeProfileTemplate, _defaultTimeProfileTemplate, _predictedVsObservedTemplate});
+   }
+}
+
+public class When_retrieving_the_default_chart_template_for_a_chart_type_with_a_flagged_default : concern_for_WithChartTemplatesExtensions
+{
+   [Observation]
+   public void should_return_the_template_flagged_as_default_among_the_templates_of_this_type()
+   {
+      _withChartTemplates.DefaultChartTemplateFor(CurveChartTypes.TimeProfile).ShouldBeEqualTo(_defaultTimeProfileTemplate);
+   }
+}
+
+public class When_retrieving_the_default_chart_template_for_a_chart_type_without_a_flagged_default : concern_for_WithChartTemplatesExtensions
+{
+   [Observation]
+   public void should_return_the_first_template_of_this_type_by_name()
+   {
+      _withChartTemplates.DefaultChartTemplateFor(CurveChartTypes.PredictedVsObserved).ShouldBeEqualTo(_predictedVsObservedTemplate);
+   }
+}
+
+public class When_retrieving_the_default_chart_template_for_a_chart_type_without_any_template : concern_for_WithChartTemplatesExtensions
+{
+   [Observation]
+   public void should_return_null()
+   {
+      _withChartTemplates.DefaultChartTemplateFor(CurveChartTypes.ResidualVsTime).ShouldBeNull();
+   }
+}

--- a/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/CurveChartToCurveChartTemplateMapperSpecs.cs
@@ -3,6 +3,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Chart.Mappers;
+using OSPSuite.Core.Chart.ParameterIdentifications;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Services;
@@ -89,6 +90,28 @@ namespace OSPSuite.Core.Mappers
       public void should_have_the_preview_settings_set()
       {
          _curveChart.PreviewSettings.ShouldBeEqualTo(_curveChartTemplate.PreviewSettings);
+      }
+
+      [Observation]
+      public void should_mark_the_template_as_time_profile()
+      {
+         _curveChartTemplate.ChartType.ShouldBeEqualTo(CurveChartTypes.TimeProfile);
+      }
+   }
+
+   public class When_mapping_an_analysis_chart_to_a_curve_chart_template : concern_for_CurveChartToCurveChartTemplateMapper
+   {
+      private CurveChartTemplate _curveChartTemplate;
+
+      protected override void Because()
+      {
+         _curveChartTemplate = sut.MapFrom(new ParameterIdentificationPredictedVsObservedChart());
+      }
+
+      [Observation]
+      public void should_set_the_chart_type_of_the_template_to_the_chart_type_of_the_analysis_chart()
+      {
+         _curveChartTemplate.ChartType.ShouldBeEqualTo(CurveChartTypes.PredictedVsObserved);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateManagerPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateManagerPresenterSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
@@ -89,7 +90,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_create_a_new_template_with_the_predefined_settings()
       {
-         A.CallTo(() => _chartTemplatingTask.CloneTemplate(_templateToClone, A<IEnumerable<CurveChartTemplate>>._)).MustHaveHappened();
+         A.CallTo(() => _chartTemplatingTask.CloneTemplate(_templateToClone, A<IReadOnlyList<string>>._)).MustHaveHappened();
       }
 
       [Observation]
@@ -102,6 +103,129 @@ namespace OSPSuite.Presentation.Presentation
       public void should_show_the_details_of_the_selected_template()
       {
          A.CallTo(() => _chartTemplateDetailsPresenter.Edit(_newTemplate)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_user_is_adding_a_new_template_while_additional_template_names_are_forbidden : concern_for_ChartTemplateManagerPresenter
+   {
+      private List<string> _namesUsedForValidation;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _chartTemplatingTask.CloneTemplate(A<CurveChartTemplate>._, A<IReadOnlyList<string>>._))
+            .Invokes(x => _namesUsedForValidation = x.GetArgument<IReadOnlyList<string>>(1).ToList())
+            .Returns(new CurveChartTemplate {Name = "Clone"});
+
+         sut.EditTemplates(_templatesToManage, new[] {"ForbiddenName"}, CurveChartTypes.TimeProfile);
+      }
+
+      protected override void Because()
+      {
+         sut.CloneTemplate(_template1);
+      }
+
+      [Observation]
+      public void should_validate_the_template_name_against_the_edited_templates_and_the_forbidden_names()
+      {
+         _namesUsedForValidation.ShouldOnlyContain(_template1.Name, _template2.Name, "ForbiddenName");
+      }
+   }
+
+   public class When_setting_the_default_curve_template_for_a_template_of_a_given_chart_type : concern_for_ChartTemplateManagerPresenter
+   {
+      private CurveChartTemplate _otherTimeProfileTemplate;
+
+      protected override void Context()
+      {
+         base.Context();
+         _otherTimeProfileTemplate = new CurveChartTemplate {Name = "OtherTimeProfile", IsDefault = true};
+         _template2.ChartType = CurveChartTypes.PredictedVsObserved;
+         _template2.IsDefault = true;
+         _templatesToManage.Add(_otherTimeProfileTemplate);
+
+         sut.EditTemplates(_templatesToManage);
+      }
+
+      protected override void Because()
+      {
+         sut.SetDefaultTemplateValue(_template1, true);
+      }
+
+      [Observation]
+      public void should_clear_the_default_flag_of_the_other_templates_of_the_same_chart_type()
+      {
+         _otherTimeProfileTemplate.IsDefault.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_keep_the_default_flag_of_the_templates_of_other_chart_types()
+      {
+         _template2.IsDefault.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_make_the_indicated_template_the_default()
+      {
+         _template1.IsDefault.ShouldBeTrue();
+      }
+   }
+
+   public class When_the_user_loads_a_template_of_another_chart_type_while_managing_the_templates_of_a_given_chart_type : concern_for_ChartTemplateManagerPresenter
+   {
+      private CurveChartTemplate _loadedTemplate;
+
+      protected override void Context()
+      {
+         base.Context();
+         _loadedTemplate = new CurveChartTemplate {Name = "LoadedTemplate", ChartType = CurveChartTypes.TimeProfile};
+         A.CallTo(_dialogCreator).WithReturnType<string>().Returns("FilePath");
+         A.CallTo(() => _chartTemplatingTask.LoadTemplateFromFile("FilePath", A<IReadOnlyList<string>>._)).Returns(_loadedTemplate);
+
+         sut.EditTemplates(_templatesToManage, new List<string>(), CurveChartTypes.PredictedVsObserved);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadTemplateFromFile();
+      }
+
+      [Observation]
+      public void should_notify_the_user_that_the_template_cannot_be_used_for_the_managed_chart_type()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(_loadedTemplate.Name, CurveChartTypes.TimeProfile.ToString(), CurveChartTypes.PredictedVsObserved.ToString()))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_add_the_template_to_the_edited_templates()
+      {
+         sut.EditedTemplates.ShouldNotContain(_loadedTemplate);
+      }
+   }
+
+   public class When_the_user_loads_a_template_of_the_managed_chart_type_from_file : concern_for_ChartTemplateManagerPresenter
+   {
+      private CurveChartTemplate _loadedTemplate;
+
+      protected override void Context()
+      {
+         base.Context();
+         _loadedTemplate = new CurveChartTemplate {Name = "LoadedTemplate", ChartType = CurveChartTypes.PredictedVsObserved};
+         A.CallTo(_dialogCreator).WithReturnType<string>().Returns("FilePath");
+         A.CallTo(() => _chartTemplatingTask.LoadTemplateFromFile("FilePath", A<IReadOnlyList<string>>._)).Returns(_loadedTemplate);
+
+         sut.EditTemplates(_templatesToManage, new List<string>(), CurveChartTypes.PredictedVsObserved);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadTemplateFromFile();
+      }
+
+      [Observation]
+      public void should_add_the_loaded_template_to_the_edited_templates()
+      {
+         sut.EditedTemplates.ShouldContain(_loadedTemplate);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateManagerPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateManagerPresenterSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.Charts;
@@ -193,7 +194,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_notify_the_user_that_the_template_cannot_be_used_for_the_managed_chart_type()
       {
-         A.CallTo(() => _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(_loadedTemplate.Name, CurveChartTypes.TimeProfile.ToString(), CurveChartTypes.PredictedVsObserved.ToString()))).MustHaveHappened();
+         A.CallTo(() => _dialogCreator.MessageBoxError(Error.CannotLoadTemplateCreatedForAnotherChartType(_loadedTemplate.Name, CurveChartTypes.TimeProfile.ToString().SplitToUpperCase(), CurveChartTypes.PredictedVsObserved.ToString().SplitToUpperCase()))).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateMenuPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplateMenuPresenterSpecs.cs
@@ -1,0 +1,124 @@
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Chart.ParameterIdentifications;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters.Charts;
+using OSPSuite.Presentation.Services.Charts;
+
+namespace OSPSuite.Presentation.Presentation
+{
+   public abstract class concern_for_ChartTemplateMenuPresenter : ContextSpecification<ChartTemplateMenuPresenter>
+   {
+      protected IChartTemplatingTask _chartTemplatingTask;
+      protected IWithChartTemplates _withChartTemplates;
+      protected CurveChartTemplate _timeProfileTemplate;
+      protected CurveChartTemplate _predictedVsObservedTemplate;
+      protected IMenuBarSubMenu _chartTemplateMenu;
+
+      protected override void Context()
+      {
+         _chartTemplatingTask = A.Fake<IChartTemplatingTask>();
+         _timeProfileTemplate = new CurveChartTemplate {Name = "TimeProfileTemplate", ChartType = CurveChartTypes.TimeProfile};
+         _predictedVsObservedTemplate = new CurveChartTemplate {Name = "PredictedVsObservedTemplate", ChartType = CurveChartTypes.PredictedVsObserved};
+
+         _withChartTemplates = A.Fake<IWithChartTemplates>();
+         A.CallTo(() => _withChartTemplates.ChartTemplates).Returns(new[] {_timeProfileTemplate, _predictedVsObservedTemplate});
+
+         sut = new ChartTemplateMenuPresenter(_chartTemplatingTask);
+      }
+
+      protected IMenuBarSubMenu ApplyTemplateMenu => subMenuByCaption(_chartTemplateMenu, MenuNames.ApplyChartTemplate);
+
+      protected IMenuBarSubMenu UpdateTemplateMenu => subMenuByCaption(subMenuByCaption(_chartTemplateMenu, MenuNames.FromCurrentChart), MenuNames.UpdateExistingTemplate);
+
+      private static IMenuBarSubMenu subMenuByCaption(IMenuBarSubMenu menu, string caption)
+      {
+         return menu?.AllItems().OfType<IMenuBarSubMenu>().FirstOrDefault(x => string.Equals(x.Caption, caption));
+      }
+   }
+
+   public class When_creating_the_chart_template_menu_for_a_predicted_vs_observed_chart : concern_for_ChartTemplateMenuPresenter
+   {
+      protected override void Because()
+      {
+         _chartTemplateMenu = sut.CreateChartTemplateButton(_withChartTemplates, () => new ParameterIdentificationPredictedVsObservedChart(), template => { });
+      }
+
+      [Observation]
+      public void should_only_offer_to_apply_templates_created_from_charts_of_the_same_type()
+      {
+         ApplyTemplateMenu.AllItems().Select(x => x.Caption).ShouldOnlyContain(_predictedVsObservedTemplate.Name);
+      }
+
+      [Observation]
+      public void should_only_offer_to_update_templates_created_from_charts_of_the_same_type()
+      {
+         UpdateTemplateMenu.AllItems().Select(x => x.Caption).ShouldOnlyContain(_predictedVsObservedTemplate.Name);
+      }
+   }
+
+   public class When_creating_the_chart_template_menu_for_a_time_profile_chart : concern_for_ChartTemplateMenuPresenter
+   {
+      protected override void Because()
+      {
+         _chartTemplateMenu = sut.CreateChartTemplateButton(_withChartTemplates, () => new CurveChart(), template => { });
+      }
+
+      [Observation]
+      public void should_only_offer_to_apply_time_profile_templates()
+      {
+         ApplyTemplateMenu.AllItems().Select(x => x.Caption).ShouldOnlyContain(_timeProfileTemplate.Name);
+      }
+
+      [Observation]
+      public void should_only_offer_to_update_time_profile_templates()
+      {
+         UpdateTemplateMenu.AllItems().Select(x => x.Caption).ShouldOnlyContain(_timeProfileTemplate.Name);
+      }
+   }
+
+   public class When_the_user_manages_the_templates_from_the_chart_template_menu : concern_for_ChartTemplateMenuPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _chartTemplateMenu = sut.CreateChartTemplateButton(_withChartTemplates, () => new ParameterIdentificationPredictedVsObservedChart(), template => { });
+      }
+
+      protected override void Because()
+      {
+         _chartTemplateMenu.AllItems().OfType<IMenuBarButton>().First(x => string.Equals(x.Caption, MenuNames.ManageTemplates)).Command.Execute();
+      }
+
+      [Observation]
+      public void should_manage_the_templates_created_for_the_type_of_the_active_chart()
+      {
+         A.CallTo(() => _chartTemplatingTask.ManageTemplates(_withChartTemplates, CurveChartTypes.PredictedVsObserved)).MustHaveHappened();
+      }
+   }
+
+   public class When_creating_the_chart_template_menu_for_a_chart_type_without_any_matching_template : concern_for_ChartTemplateMenuPresenter
+   {
+      protected override void Because()
+      {
+         _chartTemplateMenu = sut.CreateChartTemplateButton(_withChartTemplates, () => new ParameterIdentificationResidualVsTimeChart(), template => { });
+      }
+
+      [Observation]
+      public void should_indicate_that_no_template_is_available()
+      {
+         ApplyTemplateMenu.AllItems().Select(x => x.Caption).ShouldOnlyContain(MenuNames.NoTemplateAvailable);
+      }
+
+      [Observation]
+      public void should_not_offer_to_update_any_template()
+      {
+         UpdateTemplateMenu.ShouldBeNull();
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplatingTaskSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartTemplatingTaskSpecs.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Chart.Mappers;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Presenters.Charts;
+using OSPSuite.Presentation.Services.Charts;
+
+namespace OSPSuite.Presentation.Presentation
+{
+   public abstract class concern_for_ChartTemplatingTask : ContextSpecification<TestChartTemplatingTask>
+   {
+      protected IApplicationController _applicationController;
+      protected IModalChartTemplateManagerPresenter _modalChartTemplateManagerPresenter;
+      protected IWithChartTemplates _withChartTemplates;
+      protected CurveChartTemplate _timeProfileTemplate;
+      protected CurveChartTemplate _predictedVsObservedTemplate;
+
+      protected override void Context()
+      {
+         _applicationController = A.Fake<IApplicationController>();
+         _modalChartTemplateManagerPresenter = A.Fake<IModalChartTemplateManagerPresenter>();
+         A.CallTo(() => _applicationController.Start<IModalChartTemplateManagerPresenter>()).Returns(_modalChartTemplateManagerPresenter);
+
+         _timeProfileTemplate = new CurveChartTemplate {Name = "TimeProfileTemplate", ChartType = CurveChartTypes.TimeProfile};
+         _predictedVsObservedTemplate = new CurveChartTemplate {Name = "PredictedVsObservedTemplate", ChartType = CurveChartTypes.PredictedVsObserved};
+         _withChartTemplates = A.Fake<IWithChartTemplates>();
+         A.CallTo(() => _withChartTemplates.ChartTemplates).Returns(new[] {_timeProfileTemplate, _predictedVsObservedTemplate});
+
+         sut = new TestChartTemplatingTask(_applicationController, A.Fake<IChartTemplatePersistor>(), A.Fake<ICloneManager>(),
+            A.Fake<ICurveChartToCurveChartTemplateMapper>(), A.Fake<IChartFromTemplateService>(), A.Fake<IChartUpdater>(), A.Fake<IDialogCreator>());
+      }
+   }
+
+   public class TestChartTemplatingTask : ChartTemplatingTask
+   {
+      public IWithChartTemplates ReplacedIn { get; private set; }
+      public IReadOnlyList<CurveChartTemplate> ReplacedTemplates { get; private set; }
+
+      public TestChartTemplatingTask(IApplicationController applicationController, IChartTemplatePersistor chartTemplatePersistor, ICloneManager cloneManager,
+         ICurveChartToCurveChartTemplateMapper chartTemplateMapper, IChartFromTemplateService chartFromTemplateService, IChartUpdater chartUpdater, IDialogCreator dialogCreator)
+         : base(applicationController, chartTemplatePersistor, cloneManager, chartTemplateMapper, chartFromTemplateService, chartUpdater, dialogCreator)
+      {
+      }
+
+      protected override ICommand ReplaceTemplatesCommand(IWithChartTemplates withChartTemplates, IEnumerable<CurveChartTemplate> curveChartTemplates)
+      {
+         ReplacedIn = withChartTemplates;
+         ReplacedTemplates = curveChartTemplates.ToList();
+         return new OSPSuiteEmptyCommand<IOSPSuiteExecutionContext>();
+      }
+
+      public override ICommand AddChartTemplateCommand(CurveChartTemplate template, IWithChartTemplates withChartTemplates)
+      {
+         return new OSPSuiteEmptyCommand<IOSPSuiteExecutionContext>();
+      }
+
+      public override ICommand UpdateChartTemplateCommand(CurveChartTemplate template, IWithChartTemplates withChartTemplates, string templateName)
+      {
+         return new OSPSuiteEmptyCommand<IOSPSuiteExecutionContext>();
+      }
+   }
+
+   public class When_managing_the_chart_templates_for_a_given_chart_type : concern_for_ChartTemplatingTask
+   {
+      private List<CurveChartTemplate> _editedTemplates;
+
+      protected override void Context()
+      {
+         base.Context();
+         _editedTemplates = new List<CurveChartTemplate> {_predictedVsObservedTemplate, _timeProfileTemplate};
+         A.CallTo(() => _modalChartTemplateManagerPresenter.HasChanged).Returns(true);
+         A.CallTo(() => _modalChartTemplateManagerPresenter.Canceled()).Returns(false);
+         A.CallTo(() => _modalChartTemplateManagerPresenter.EditedTemplates).Returns(_editedTemplates);
+      }
+
+      protected override void Because()
+      {
+         sut.ManageTemplates(_withChartTemplates, CurveChartTypes.PredictedVsObserved);
+      }
+
+      [Observation]
+      public void should_edit_the_templates_for_the_given_chart_type()
+      {
+         A.CallTo(() => _modalChartTemplateManagerPresenter.EditTemplates(A<IEnumerable<CurveChartTemplate>>._, CurveChartTypes.PredictedVsObserved)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_replace_the_templates_with_the_edited_templates_including_the_templates_of_other_chart_types()
+      {
+         sut.ReplacedIn.ShouldBeEqualTo(_withChartTemplates);
+         sut.ReplacedTemplates.ShouldOnlyContain(_predictedVsObservedTemplate, _timeProfileTemplate);
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ModalChartTemplateManagerPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ModalChartTemplateManagerPresenterSpecs.cs
@@ -61,4 +61,57 @@ namespace OSPSuite.Presentation.Presentation
          _editedTemplates.ShouldOnlyContain(_cloneTemplate1, _cloneTemplate2);
       }
    }
+
+   public class When_editing_templates_for_a_given_chart_type : concern_for_ModalChartTemplateManagerPresenter
+   {
+      private List<CurveChartTemplate> _editedTemplates;
+      private List<string> _forbiddenNames;
+      private CurveChartTemplate _timeProfileTemplate;
+      private CurveChartTemplate _predictedVsObservedTemplate;
+      private CurveChartTemplate _cloneTimeProfileTemplate;
+      private CurveChartTemplate _clonePredictedVsObservedTemplate;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _chartTemplateManagerPresenter.EditTemplates(A<IEnumerable<CurveChartTemplate>>._, A<IReadOnlyList<string>>._, CurveChartTypes.PredictedVsObserved))
+            .Invokes(x =>
+            {
+               _editedTemplates = x.GetArgument<IEnumerable<CurveChartTemplate>>(0).ToList();
+               _forbiddenNames = x.GetArgument<IReadOnlyList<string>>(1).ToList();
+            });
+
+         _timeProfileTemplate = new CurveChartTemplate {Name = "TimeProfileTemplate", ChartType = CurveChartTypes.TimeProfile};
+         _predictedVsObservedTemplate = new CurveChartTemplate {Name = "PredictedVsObservedTemplate", ChartType = CurveChartTypes.PredictedVsObserved};
+         _cloneTimeProfileTemplate = new CurveChartTemplate {Name = "TimeProfileTemplate", ChartType = CurveChartTypes.TimeProfile};
+         _clonePredictedVsObservedTemplate = new CurveChartTemplate {Name = "PredictedVsObservedTemplate", ChartType = CurveChartTypes.PredictedVsObserved};
+         A.CallTo(() => _cloneManager.Clone(_timeProfileTemplate)).Returns(_cloneTimeProfileTemplate);
+         A.CallTo(() => _cloneManager.Clone(_predictedVsObservedTemplate)).Returns(_clonePredictedVsObservedTemplate);
+
+         A.CallTo(() => _chartTemplateManagerPresenter.EditedTemplates).Returns(new[] {_clonePredictedVsObservedTemplate});
+      }
+
+      protected override void Because()
+      {
+         sut.EditTemplates(new[] {_timeProfileTemplate, _predictedVsObservedTemplate}, CurveChartTypes.PredictedVsObserved);
+      }
+
+      [Observation]
+      public void should_only_edit_the_templates_matching_the_chart_type()
+      {
+         _editedTemplates.ShouldOnlyContain(_clonePredictedVsObservedTemplate);
+      }
+
+      [Observation]
+      public void should_pass_the_names_of_the_templates_of_other_chart_types_as_forbidden_names()
+      {
+         _forbiddenNames.ShouldOnlyContain(_cloneTimeProfileTemplate.Name);
+      }
+
+      [Observation]
+      public void should_return_the_templates_of_other_chart_types_unchanged_together_with_the_edited_templates()
+      {
+         sut.EditedTemplates.ShouldOnlyContain(_clonePredictedVsObservedTemplate, _cloneTimeProfileTemplate);
+      }
+   }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationPredictedVsObservedChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationPredictedVsObservedChartPresenterSpecs.cs
@@ -25,7 +25,7 @@ namespace OSPSuite.Presentation.Presentation
    public abstract class concern_for_ParameterIdentificationPredictedVsObservedChartPresenter : ContextSpecification<ParameterIdentificationPredictedVsObservedChartPresenter>
    {
       private IParameterIdentificationSingleRunAnalysisView _view;
-      private IChartEditorAndDisplayPresenter _chartEditorAndDisplayPresenter;
+      protected IChartEditorAndDisplayPresenter _chartEditorAndDisplayPresenter;
       private ICurveNamer _curveNamer;
       private IDataColumnToPathElementsMapper _dataColumnToPathElementsMapper;
       private IChartTemplatingTask _chartTemplatingTask;
@@ -40,7 +40,7 @@ namespace OSPSuite.Presentation.Presentation
       protected IPredictedVsObservedChartService _predictedVsObservedService;
       protected DataRepository _observationData;
       private IChartEditorLayoutTask _chartEditorLayoutTask;
-      private IProjectRetriever _projectRetreiver;
+      protected IProjectRetriever _projectRetreiver;
       protected ChartPresenterContext _chartPresenterContext;
       protected DataRepository _simulationData;
 
@@ -195,11 +195,34 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_reload_the_chart_from_template()
       {
-         A.CallTo(() => _chartPresenterContext.TemplatingTask.InitializeChartFromTemplate(sut.Chart, A<IEnumerable<DataColumn>>._, 
-            _template, 
+         A.CallTo(() => _chartPresenterContext.TemplatingTask.InitializeChartFromTemplate(sut.Chart, A<IEnumerable<DataColumn>>._,
+            _template,
             A<Func<DataColumn, string>>._,
             false,
             true)).MustHaveHappened();
+      }
+   }
+
+   public class When_initializing_the_predicted_vs_observed_analysis_for_a_parameter_identification : concern_for_ParameterIdentificationPredictedVsObservedChartPresenter
+   {
+      private IProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = A.Fake<IProject>();
+         A.CallTo(() => _projectRetreiver.CurrentProject).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_predictedVsObservedChart, _parameterIdentification);
+      }
+
+      [Observation]
+      public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_project()
+      {
+         A.CallTo(() => _chartEditorAndDisplayPresenter.EditorPresenter.AddChartTemplateMenu(_project, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationPredictedVsObservedChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationPredictedVsObservedChartPresenterSpecs.cs
@@ -26,6 +26,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       private IParameterIdentificationSingleRunAnalysisView _view;
       protected IChartEditorAndDisplayPresenter _chartEditorAndDisplayPresenter;
+      protected IChartEditorPresenter _chartEditorPresenter;
       private ICurveNamer _curveNamer;
       private IDataColumnToPathElementsMapper _dataColumnToPathElementsMapper;
       private IChartTemplatingTask _chartTemplatingTask;
@@ -48,6 +49,8 @@ namespace OSPSuite.Presentation.Presentation
       {
          _view = A.Fake<IParameterIdentificationSingleRunAnalysisView>();
          _chartEditorAndDisplayPresenter = A.Fake<IChartEditorAndDisplayPresenter>();
+         _chartEditorPresenter = A.Fake<IChartEditorPresenter>();
+         A.CallTo(() => _chartEditorAndDisplayPresenter.EditorPresenter).Returns(_chartEditorPresenter);
          _curveNamer = A.Fake<ICurveNamer>();
          _dataColumnToPathElementsMapper = A.Fake<IDataColumnToPathElementsMapper>();
          _chartTemplatingTask = A.Fake<IChartTemplatingTask>();
@@ -222,7 +225,7 @@ namespace OSPSuite.Presentation.Presentation
       [Observation]
       public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_project()
       {
-         A.CallTo(() => _chartEditorAndDisplayPresenter.EditorPresenter.AddChartTemplateMenu(_project, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
+         A.CallTo(() => _chartEditorPresenter.AddChartTemplateMenu(_project, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using FakeItEasy;
@@ -38,7 +39,7 @@ namespace OSPSuite.Presentation.Presentation
       protected ResidualsResult _residualResults;
       protected ResidualsVsTimeChartService _residualsVsTimeChartService;
       private IChartEditorLayoutTask _chartEditorLayoutTask;
-      private IProjectRetriever _projectRetriever;
+      protected IProjectRetriever _projectRetriever;
       private ChartPresenterContext _chartPresenterContext;
       private ICurveNamer _curveNamer;
 
@@ -245,6 +246,29 @@ namespace OSPSuite.Presentation.Presentation
       {
          //zero marker removed
          _residualVsTimeChart.Curves.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_initializing_the_residuals_vs_time_analysis_for_a_parameter_identification : concern_for_ParameterIdentificationResidualVsTimeChartPresenter
+   {
+      private IProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = A.Fake<IProject>();
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_residualVsTimeChart, _parameterIdentification);
+      }
+
+      [Observation]
+      public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_project()
+      {
+         A.CallTo(() => ChartEditorPresenter.AddChartTemplateMenu(_project, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationResidualVsTimeChartPresenterSpecs.cs
@@ -43,7 +43,7 @@ namespace OSPSuite.Presentation.Presentation
       private ChartPresenterContext _chartPresenterContext;
       private ICurveNamer _curveNamer;
 
-      protected IChartEditorPresenter ChartEditorPresenter => _chartEditorAndDisplayPresenter.EditorPresenter;
+      protected IChartEditorPresenter ChartEditorPresenter { get; private set; }
 
       protected override void Context()
       {
@@ -51,6 +51,8 @@ namespace OSPSuite.Presentation.Presentation
          _residualsVsTimeChartService = A.Fake<ResidualsVsTimeChartService>();
          _view = A.Fake<IParameterIdentificationSingleRunAnalysisView>();
          _chartEditorAndDisplayPresenter = A.Fake<IChartEditorAndDisplayPresenter>();
+         ChartEditorPresenter = A.Fake<IChartEditorPresenter>();
+         A.CallTo(() => _chartEditorAndDisplayPresenter.EditorPresenter).Returns(ChartEditorPresenter);
          _curveNamer = A.Fake<ICurveNamer>();
          _pathElementsMapper = A.Fake<IDataColumnToPathElementsMapper>();
          _chartTemplatingTask = A.Fake<IChartTemplatingTask>();

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
@@ -51,6 +51,8 @@ namespace OSPSuite.Presentation.Presentation
          _presentationSettingsTask = A.Fake<IPresentationSettingsTask>();
          _view = A.Fake<IParameterIdentificationMultipleRunsAnalysisView>();
          _chartEditorAndDisplayPresenter = A.Fake<IChartEditorAndDisplayPresenter>();
+         ChartEditorPresenter = A.Fake<IChartEditorPresenter>();
+         A.CallTo(() => _chartEditorAndDisplayPresenter.EditorPresenter).Returns(ChartEditorPresenter);
          _curveNamer = A.Fake<ICurveNamer>();
          _pathElementsMapper = A.Fake<IDataColumnToPathElementsMapper>();
          _chartTemplatingTask = A.Fake<IChartTemplatingTask>();
@@ -96,7 +98,7 @@ namespace OSPSuite.Presentation.Presentation
          _parameterIdentificationRunResult.BestResult = _optimizationRunResult2;
       }
 
-      protected IChartEditorPresenter ChartEditorPresenter => _chartEditorAndDisplayPresenter.EditorPresenter;
+      protected IChartEditorPresenter ChartEditorPresenter { get; private set; }
    }
 
    public class When_displaying_the_results_of_a_given_parameter_identification_as_time_profile : concern_for_ParameterIdentificationTimeProfileChartPresenter

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ParameterIdentificationTimeProfileChartPresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using FakeItEasy;
@@ -41,7 +42,7 @@ namespace OSPSuite.Presentation.Presentation
       private IDisplayUnitRetriever _displayUnitRetriever;
       protected OptimizationRunResult _optimizationRunResult2;
       private IChartEditorLayoutTask _chartEditorLayoutTask;
-      private IProjectRetriever _projectRetreiver;
+      protected IProjectRetriever _projectRetreiver;
       private ChartPresenterContext _chartPresenterContext;
       private ICurveNamer _curveNamer;
 
@@ -227,6 +228,29 @@ namespace OSPSuite.Presentation.Presentation
          var outputCurve = _timeProfileAnalysis.FindCurveWithSameData(_outputColumn.BaseGrid, _outputColumn);
          outputCurve.ShouldNotBeNull();
          outputCurve.Color.ShouldBeEqualTo(CANONICAL_COLOR);
+      }
+   }
+
+   public class When_initializing_the_time_profile_analysis_for_a_parameter_identification : concern_for_ParameterIdentificationTimeProfileChartPresenter
+   {
+      private IProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = A.Fake<IProject>();
+         A.CallTo(() => _projectRetreiver.CurrentProject).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_timeProfileAnalysis, _parameterIdentification);
+      }
+
+      [Observation]
+      public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_project()
+      {
+         A.CallTo(() => ChartEditorPresenter.AddChartTemplateMenu(_project, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
@@ -322,6 +322,14 @@ namespace OSPSuite.Presentation.Presentation
       {
          _predictedVsObservedChart.Curves.Count.ShouldBeEqualTo(2);
       }
+
+      [Observation]
+      public void the_identity_curve_columns_should_have_paths_usable_in_chart_templates()
+      {
+         var identityCurve = _predictedVsObservedChart.Curves.Single(x => Equals(x.Name, "Identity"));
+         identityCurve.yData.QuantityInfo.PathAsString.ShouldBeEqualTo("Identity");
+         identityCurve.xData.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.Name);
+      }
    }
 
    public class When_adding_deviation_lines_to_a_chart_with_fold_value_2 : concern_for_PredictedVsObservedChartService
@@ -372,6 +380,13 @@ namespace OSPSuite.Presentation.Presentation
          var lastObservationValue = _concentrationObservationColumn.Values.Last();
          _deviationLineRepository.AllButBaseGridAsArray[1].Values[0].ShouldBeEqualTo(firstObservationValue / 2);
          _deviationLineRepository.AllButBaseGridAsArray[1].Values.Last().ShouldBeEqualTo(lastObservationValue / 2);
+      }
+
+      [Observation]
+      public void the_deviation_line_columns_should_have_paths_matching_their_fold_specific_names()
+      {
+         _deviationLineRepository.AllButBaseGrid().Each(column => column.QuantityInfo.PathAsString.ShouldBeEqualTo(column.Name));
+         _deviationLineRepository.BaseGrid.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.Name);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/PredictedVsObservedChartServiceSpecs.cs
@@ -328,7 +328,7 @@ namespace OSPSuite.Presentation.Presentation
       {
          var identityCurve = _predictedVsObservedChart.Curves.Single(x => Equals(x.Name, "Identity"));
          identityCurve.yData.QuantityInfo.PathAsString.ShouldBeEqualTo("Identity");
-         identityCurve.xData.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.Name);
+         identityCurve.xData.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.DisplayName);
       }
    }
 
@@ -386,7 +386,7 @@ namespace OSPSuite.Presentation.Presentation
       public void the_deviation_line_columns_should_have_paths_matching_their_fold_specific_names()
       {
          _deviationLineRepository.AllButBaseGrid().Each(column => column.QuantityInfo.PathAsString.ShouldBeEqualTo(column.Name));
-         _deviationLineRepository.BaseGrid.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.Name);
+         _deviationLineRepository.BaseGrid.QuantityInfo.PathAsString.ShouldBeEqualTo(_concentrationObservationColumn.Dimension.DisplayName);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ResidualsVsTimeChartServiceSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ResidualsVsTimeChartServiceSpecs.cs
@@ -63,6 +63,44 @@ namespace OSPSuite.Presentation.Presentation
          }
       }
 
+      public class When_getting_a_scatter_repository_that_was_persisted_in_the_chart_without_base_grid_path : concern_for_ResidualsVsTimeChartService
+      {
+         private OutputResiduals _outputResiduals;
+         private DataRepository _existingRepository;
+         private DataRepository _result;
+
+         protected override void Context()
+         {
+            base.Context();
+            _outputResiduals = A.Fake<OutputResiduals>();
+            A.CallTo(() => _outputResiduals.FullOutputPath).Returns("Output Path");
+            A.CallTo(() => _outputResiduals.Residuals).Returns(new[] {new Residual(1f, 2f, 1)});
+
+            var id = $"{_residualsVsTimeChart.Id}-{_outputResiduals.FullOutputPath}-{_outputResiduals.ObservedData.Id}";
+            _existingRepository = sut.CreateScatterDataRepository(id, "Simulation Results", _outputResiduals);
+            //simulates a repository persisted with the chart before the base grid path was introduced
+            _existingRepository.BaseGrid.QuantityInfo.Path = new string[0];
+            _residualsVsTimeChart.AddRepository(_existingRepository);
+         }
+
+         protected override void Because()
+         {
+            _result = sut.GetOrCreateScatterDataRepositoryInChart(_residualsVsTimeChart, _outputResiduals);
+         }
+
+         [Observation]
+         public void should_reuse_the_existing_repository()
+         {
+            _result.ShouldBeEqualTo(_existingRepository);
+         }
+
+         [Observation]
+         public void should_set_the_base_grid_path()
+         {
+            _result.BaseGrid.QuantityInfo.PathAsString.ShouldBeEqualTo("Time");
+         }
+      }
+
       public class When_generating_the_zero_marker : concern_for_ResidualsVsTimeChartService
       {
          private readonly float _minObservedDataTime = 1;
@@ -97,6 +135,14 @@ namespace OSPSuite.Presentation.Presentation
          {
             _residualsVsTimeChart.Curves.First().xData.InternalValues[0].ShouldBeEqualTo(1);
             _residualsVsTimeChart.Curves.First().xData.InternalValues[1].ShouldBeEqualTo(10);
+         }
+
+         [Observation]
+         public void the_zero_curve_columns_should_have_paths_usable_in_chart_templates()
+         {
+            var curve = _residualsVsTimeChart.Curves.First();
+            curve.yData.QuantityInfo.PathAsString.ShouldBeEqualTo("Zero");
+            curve.xData.QuantityInfo.PathAsString.ShouldBeEqualTo("Time");
          }
       }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimulationPredictedVsObservedChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimulationPredictedVsObservedChartPresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
@@ -272,6 +273,29 @@ namespace OSPSuite.Presentation.Presentation
          sut.Chart.Curves.Count(curve => curve.Name.Equals("2-fold deviation")).ShouldBeEqualTo(1);
          sut.Chart.Curves.Count(curve => curve.Name.Equals("2-fold deviation Lower")).ShouldBeEqualTo(1);
 
+      }
+   }
+
+   public class When_initializing_the_predicted_vs_observed_analysis_for_a_simulation_with_chart_templates : concern_for_SimulationPredictedVsObservedChartPresenter
+   {
+      private ISimulation _simulationWithTemplates;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationWithTemplates = A.Fake<ISimulation>(x => x.Implements<IWithChartTemplates>());
+         A.CallTo(() => _simulationWithTemplates.ResultsDataRepository).Returns(null);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_predictedVsObservedChart, _simulationWithTemplates);
+      }
+
+      [Observation]
+      public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_simulation()
+      {
+         A.CallTo(() => _chartEditorPresenter.AddChartTemplateMenu((IWithChartTemplates) _simulationWithTemplates, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimulationResidualVsTimeChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimulationResidualVsTimeChartPresenterSpecs.cs
@@ -209,4 +209,27 @@ namespace OSPSuite.Presentation.Presentation
          sut.Clear();
       }
    }
+
+   public class When_initializing_the_residuals_vs_time_analysis_for_a_simulation_with_chart_templates : concern_for_SimulationResidualVsTimeChartPresenter
+   {
+      private ISimulation _simulationWithTemplates;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationWithTemplates = A.Fake<ISimulation>(x => x.Implements<IWithChartTemplates>());
+         A.CallTo(() => _simulationWithTemplates.ResultsDataRepository).Returns(null);
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(_residualVsTimeChart, _simulationWithTemplates);
+      }
+
+      [Observation]
+      public void should_add_the_chart_template_menu_based_on_the_chart_templates_defined_in_the_simulation()
+      {
+         A.CallTo(() => ChartEditorPresenter.AddChartTemplateMenu((IWithChartTemplates) _simulationWithTemplates, A<Action<CurveChartTemplate>>._)).MustHaveHappened();
+      }
+   }
 }

--- a/tests/OSPSuite.Starter/Domain/TestSimulation.cs
+++ b/tests/OSPSuite.Starter/Domain/TestSimulation.cs
@@ -42,8 +42,6 @@ namespace OSPSuite.Starter.Domain
 
       public IEnumerable<CurveChartTemplate> ChartTemplates => Settings.ChartTemplates;
 
-      public CurveChartTemplate DefaultChartTemplate => Settings.DefaultChartTemplate;
-
       public bool IsLoaded { get; set; }
 
       public void RemoveAnalysis(ISimulationAnalysis simulationAnalysis)


### PR DESCRIPTION
﻿Fixes #2431

There isn't any support for chart templates in parameter identification charts. Simulation time profile charts offer a chart template menu (apply / create from current chart / update existing / manage), but the PI analyses do not.

## Scope

- All PI curve-chart analyses get the chart template menu:
  - Time Profile
  - Time Profile Confidence Interval
  - Time Profile Prediction Interval
  - Time Profile VPC Interval
  - Predicted vs Observed
  - Residuals vs Time

  Since a PI spans multiple simulations, templates are sourced from the **project** (the same source the multi-simulation comparison charts use).
- The simulation-level analyses also newly get the chart template menu, sourced from the **simulation** (the same source as the simulation time profile chart):
  - Predicted vs Observed
  - Residuals vs Time
- Because a template pool can now mix templates created from charts with different axes (time profile vs predicted vs observed vs residuals vs time), templates are discriminated by chart type:
  - `CurveChart` gets a `CurveChartType` (enum `CurveChartTypes`: `TimeProfile`, `PredictedVsObserved`, `ResidualVsTime`), promoted from the former abstract `AnalysisChart.AnalysisChartType`. The PI interval analyses (Confidence/Prediction/VPC Interval) are time profile charts with the same time-based axes, so they classify as `TimeProfile` — one time profile template is shared across the whole time profile family.
  - Templates record the chart type they were created from; the *Apply Chart Template* and *Update Existing Template* menus only offer templates matching the active chart's type. Templates created before the type existed load as time profiles (no converter required).
  - The *Manage Templates* dialog only manages the templates of the active chart's type (templates of other types are preserved untouched), which also allows **one default template per chart type**. Importing a template file created for another chart type is rejected with an error message.
  - The type-unaware `IWithChartTemplates.DefaultChartTemplate` is removed in favor of `DefaultChartTemplateFor(CurveChartTypes)` (breaking change; MoBi/PK-Sim call sites follow in their core-update PRs).
- The constructed marker columns (zero marker, identity line, deviation lines) now carry stable quantity paths (`Time`/`Zero`, merged dimension display name/`Identity`, fold-specific names), so template entries are self-describing, satisfy the template manager validation, and deviation fold styling is matched deterministically. Scatter repositories persisted with residual charts self-heal their base grid path on the next chart update.
- Adding/removing project templates marks the project as changed so templates are not silently lost when closing without saving.
