### PR TITLE
Fixes #2886 ModelConstructor is not thread-safe: sub-tasks hold per-run state in instance fields

### DIFF
--- a/src/OSPSuite.Core/Domain/Services/CalculationMethodTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/CalculationMethodTask.cs
@@ -20,11 +20,6 @@ namespace OSPSuite.Core.Domain.Services
       private readonly IKeywordReplacerTask _keywordReplacerTask;
       private readonly IFormulaBuilderToFormulaMapper _formulaMapper;
       private readonly IParameterBuilderToParameterMapper _parameterMapper;
-      private EntityDescriptorMapList<IContainer> _allContainers;
-      private IList<IParameter> _allBlackBoxParameters;
-      private IModel _model;
-      private SimulationBuilder _simulationBuilder;
-      private ReplacementContext _replacementContext;
 
       public CalculationMethodTask(
          IKeywordReplacerTask keywordReplacerTask,
@@ -39,80 +34,68 @@ namespace OSPSuite.Core.Domain.Services
 
       public void MergeCalculationMethodInModel(ModelConfiguration modelConfiguration)
       {
-         try
+         var context = new MergeContext(modelConfiguration);
+         var simulationConfiguration = modelConfiguration.SimulationConfiguration;
+         foreach (var calculationMethod in simulationConfiguration.AllCalculationMethods)
          {
-            (_model, _simulationBuilder, _replacementContext) = modelConfiguration;
-            var simulationConfiguration = modelConfiguration.SimulationConfiguration;
-            _allContainers = _model.Root.GetAllContainersAndSelf<IContainer>().ToEntityDescriptorMapList();
-            _allBlackBoxParameters = _model.Root.GetAllChildren<IParameter>().Where(p => p.Formula.IsBlackBox()).ToList();
-            foreach (var calculationMethod in simulationConfiguration.AllCalculationMethods)
-            {
-               var allMoleculesUsingMethod = allMoleculesUsing(calculationMethod, _simulationBuilder.Molecules, simulationConfiguration).ToList();
+            var allMoleculesUsingMethod = allMoleculesUsing(calculationMethod, context.SimulationBuilder.Molecules, simulationConfiguration).ToList();
 
-               createFormulaForBlackBoxParameters(calculationMethod, allMoleculesUsingMethod);
+            createFormulaForBlackBoxParameters(calculationMethod, allMoleculesUsingMethod, context);
 
-               addHelpParametersFor(calculationMethod, allMoleculesUsingMethod);
-            }
-         }
-         finally
-         {
-            _simulationBuilder = null;
-            _allContainers.Clear();
-            _allBlackBoxParameters.Clear();
-            _model = null;
+            addHelpParametersFor(calculationMethod, allMoleculesUsingMethod, context);
          }
       }
 
-      private void addHelpParametersFor(CoreCalculationMethod calculationMethod, IList<MoleculeBuilder> allMoleculesUsingMethod)
+      private void addHelpParametersFor(CoreCalculationMethod calculationMethod, IList<MoleculeBuilder> allMoleculesUsingMethod, MergeContext context)
       {
          foreach (var helpParameter in calculationMethod.AllHelpParameters())
          {
             var containerDescriptor = calculationMethod.DescriptorFor(helpParameter);
-            _simulationBuilder.AddToBuilderSource(helpParameter, calculationMethod);
+            context.SimulationBuilder.AddToBuilderSource(helpParameter, calculationMethod);
             foreach (var molecule in allMoleculesUsingMethod)
             {
-               foreach (var container in allMoleculeContainersFor(containerDescriptor, molecule))
+               foreach (var container in allMoleculeContainersFor(containerDescriptor, molecule, context))
                {
                   //make sure we remove the parameter if it exists already
                   var existingParameter = container.Parameter(helpParameter.Name);
                   if (existingParameter != null)
                      container.RemoveChild(existingParameter);
 
-                  var parameter = _parameterMapper.MapFrom(helpParameter, _simulationBuilder);
+                  var parameter = _parameterMapper.MapFrom(helpParameter, context.SimulationBuilder);
                   container.Add(parameter);
-                  replaceKeyWordsIn(parameter, molecule.Name);
+                  replaceKeyWordsIn(parameter, molecule.Name, context.ReplacementContext);
                }
             }
          }
       }
 
-      private void createFormulaForBlackBoxParameters(CoreCalculationMethod calculationMethod, IList<MoleculeBuilder> allMoleculesUsingMethod)
+      private void createFormulaForBlackBoxParameters(CoreCalculationMethod calculationMethod, IList<MoleculeBuilder> allMoleculesUsingMethod, MergeContext context)
       {
          foreach (var formula in calculationMethod.AllOutputFormulas())
          {
             var parameterDescriptor = calculationMethod.DescriptorFor(formula);
             foreach (var molecule in allMoleculesUsingMethod)
             {
-               foreach (var parameter in allMoleculeParameterForFormula(parameterDescriptor, molecule))
+               foreach (var parameter in allMoleculeParameterForFormula(parameterDescriptor, molecule, context))
                {
                   //not a black box parameter. Should not be overridden by cm
-                  if (parameterIsNotBlackBoxParameter(parameter))
+                  if (parameterIsNotBlackBoxParameter(parameter, context))
                      continue;
 
-                  parameter.Formula = _formulaMapper.MapFrom(formula, _simulationBuilder);
-                  replaceKeyWordsIn(parameter, molecule.Name);
+                  parameter.Formula = _formulaMapper.MapFrom(formula, context.SimulationBuilder);
+                  replaceKeyWordsIn(parameter, molecule.Name, context.ReplacementContext);
                }
             }
          }
       }
 
-      private void replaceKeyWordsIn(IParameter parameter, string moleculeName)
+      private void replaceKeyWordsIn(IParameter parameter, string moleculeName, ReplacementContext replacementContext)
       {
-         _keywordReplacerTask.ReplaceIn(parameter, moleculeName, _replacementContext);
+         _keywordReplacerTask.ReplaceIn(parameter, moleculeName, replacementContext);
          //check if parameter is in neighborhood. In that case, retrieve the neighborhood and replace the keywords as well
          var neighborhood = neighborhoodAncestorFor(parameter);
          if (neighborhood == null) return;
-         _keywordReplacerTask.ReplaceIn(neighborhood, _replacementContext);
+         _keywordReplacerTask.ReplaceIn(neighborhood, replacementContext);
       }
 
       private static Neighborhood neighborhoodAncestorFor(IEntity entity)
@@ -126,7 +109,7 @@ namespace OSPSuite.Core.Domain.Services
          return neighborhoodAncestorFor(entity.ParentContainer);
       }
 
-      private bool parameterIsNotBlackBoxParameter(IParameter parameter) => !_allBlackBoxParameters.Contains(parameter);
+      private bool parameterIsNotBlackBoxParameter(IParameter parameter, MergeContext context) => !context.AllBlackBoxParameters.Contains(parameter);
 
       private IEnumerable<MoleculeBuilder> allMoleculesUsing(CoreCalculationMethod calculationMethod, IReadOnlyCollection<MoleculeBuilder> molecules, SimulationConfiguration simulationConfiguration)
       {
@@ -150,20 +133,43 @@ namespace OSPSuite.Core.Domain.Services
          return cache;
       }
 
-      private IEnumerable<IContainer> allMoleculeContainersFor(DescriptorCriteria containerDescriptor, MoleculeBuilder molecule)
+      private IEnumerable<IContainer> allMoleculeContainersFor(DescriptorCriteria containerDescriptor, MoleculeBuilder molecule, MergeContext context)
       {
-         return from container in _allContainers.AllSatisfiedBy(containerDescriptor)
+         return from container in context.AllContainers.AllSatisfiedBy(containerDescriptor)
             let moleculeContainer = container.GetSingleChildByName<IContainer>(molecule.Name)
             where moleculeContainer != null
             select moleculeContainer;
       }
 
-      private IEnumerable<IParameter> allMoleculeParameterForFormula(ParameterDescriptor parameterDescriptor, MoleculeBuilder molecule)
+      private IEnumerable<IParameter> allMoleculeParameterForFormula(ParameterDescriptor parameterDescriptor, MoleculeBuilder molecule, MergeContext context)
       {
-         return from container in allMoleculeContainersFor(parameterDescriptor.ContainerCriteria, molecule)
+         return from container in allMoleculeContainersFor(parameterDescriptor.ContainerCriteria, molecule, context)
             let parameter = container.GetSingleChildByName<IParameter>(parameterDescriptor.ParameterName)
             where parameter != null
             select parameter;
+      }
+
+      /// <summary>
+      ///    Per-call state required to merge the calculation methods in one model. Created per call so that the task remains
+      ///    stateless
+      /// </summary>
+      private class MergeContext
+      {
+         public SimulationBuilder SimulationBuilder { get; }
+         public ReplacementContext ReplacementContext { get; }
+
+         //caches only used to speed up the merge
+         public EntityDescriptorMapList<IContainer> AllContainers { get; }
+         public IList<IParameter> AllBlackBoxParameters { get; }
+
+         public MergeContext(ModelConfiguration modelConfiguration)
+         {
+            var (model, simulationBuilder, replacementContext) = modelConfiguration;
+            SimulationBuilder = simulationBuilder;
+            ReplacementContext = replacementContext;
+            AllContainers = model.Root.GetAllContainersAndSelf<IContainer>().ToEntityDescriptorMapList();
+            AllBlackBoxParameters = model.Root.GetAllChildren<IParameter>().Where(p => p.Formula.IsBlackBox()).ToList();
+         }
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/EventBuilderTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/EventBuilderTask.cs
@@ -21,12 +21,8 @@ namespace OSPSuite.Core.Domain.Services
       private readonly IEventGroupBuilderToEventGroupMapper _eventGroupMapper;
       private readonly IKeywordReplacerTask _keywordReplacerTask;
       private readonly ITransportBuilderToTransportMapper _transportMapper;
-      private Cache<DescriptorCriteria, IEnumerable<IContainer>> _sourceCriteriaTargetContainerCache;
-      private Cache<DescriptorCriteria, IEnumerable<IContainer>> _applicationTransportTargetContainerCache;
-      private EntityDescriptorMapList<IContainer> _allModelContainerDescriptors;
 
       public EventBuilderTask(
-         IContainerMergeTask containerMergeTask,
          IEventGroupBuilderToEventGroupMapper eventGroupMapper,
          IKeywordReplacerTask keywordReplacerTask,
          ITransportBuilderToTransportMapper transportMapper)
@@ -38,50 +34,36 @@ namespace OSPSuite.Core.Domain.Services
 
       public void CreateEvents(ModelConfiguration modelConfiguration)
       {
-         try
+         var (model, simulationBuilder) = modelConfiguration;
+         var caches = new EventBuilderCaches(model.Root.GetAllContainersAndSelf<IContainer>().ToEntityDescriptorMapList());
+
+         //Cache all containers where the event group builder will be created using the source criteria
+         foreach (var eventGroupBuilder in simulationBuilder.EventGroups)
          {
-            var (model, simulationBuilder) = modelConfiguration;
-            _allModelContainerDescriptors = model.Root.GetAllContainersAndSelf<IContainer>().ToEntityDescriptorMapList();
+            if (caches.SourceCriteriaTargetContainers.Contains(eventGroupBuilder.SourceCriteria))
+               continue;
 
-            _sourceCriteriaTargetContainerCache = new Cache<DescriptorCriteria, IEnumerable<IContainer>>();
-            _applicationTransportTargetContainerCache = new Cache<DescriptorCriteria, IEnumerable<IContainer>>();
-
-            //Cache all containers where the event group builder will be created using the source criteria
-            foreach (var eventGroupBuilder in simulationBuilder.EventGroups)
-            {
-               if (_sourceCriteriaTargetContainerCache.Contains(eventGroupBuilder.SourceCriteria))
-                  continue;
-
-               _sourceCriteriaTargetContainerCache.Add(eventGroupBuilder.SourceCriteria, _allModelContainerDescriptors.AllSatisfiedBy(eventGroupBuilder.SourceCriteria));
-            }
-
-            simulationBuilder.EventGroups.Each(x => createEventGroupFrom(x, modelConfiguration));
+            caches.SourceCriteriaTargetContainers.Add(eventGroupBuilder.SourceCriteria, caches.AllModelContainerDescriptors.AllSatisfiedBy(eventGroupBuilder.SourceCriteria));
          }
-         finally
-         {
-            _allModelContainerDescriptors = null;
-            _sourceCriteriaTargetContainerCache.Clear();
-            _sourceCriteriaTargetContainerCache = null;
-            _applicationTransportTargetContainerCache.Clear();
-            _applicationTransportTargetContainerCache = null;
-         }
+
+         simulationBuilder.EventGroups.Each(x => createEventGroupFrom(x, modelConfiguration, caches));
       }
 
       /// <summary>
       ///    Adds event group to all model containers with defined criteria
       /// </summary>
-      private void createEventGroupFrom(EventGroupBuilder eventGroupBuilder, ModelConfiguration modelConfiguration)
+      private void createEventGroupFrom(EventGroupBuilder eventGroupBuilder, ModelConfiguration modelConfiguration, EventBuilderCaches caches)
       {
-         foreach (var sourceContainer in _sourceCriteriaTargetContainerCache[eventGroupBuilder.SourceCriteria])
+         foreach (var sourceContainer in caches.SourceCriteriaTargetContainers[eventGroupBuilder.SourceCriteria])
          {
-            createEventGroupInContainer(eventGroupBuilder, sourceContainer, modelConfiguration);
+            createEventGroupInContainer(eventGroupBuilder, sourceContainer, modelConfiguration, caches);
          }
       }
 
       /// <summary>
       ///    Adds event group to source container where event takes place
       /// </summary>
-      private void createEventGroupInContainer(EventGroupBuilder eventGroupBuilder, IContainer sourceContainer, ModelConfiguration modelConfiguration)
+      private void createEventGroupInContainer(EventGroupBuilder eventGroupBuilder, IContainer sourceContainer, ModelConfiguration modelConfiguration, EventBuilderCaches caches)
       {
          //this creates recursively all event groups for the given builder
          var (_, simulationBuilder, replacementContext) = modelConfiguration;
@@ -93,29 +75,29 @@ namespace OSPSuite.Core.Domain.Services
          {
             var childEventGroupBuilder = simulationBuilder.BuilderFor(childEventGroup).DowncastTo<EventGroupBuilder>();
             if (childEventGroupBuilder is ApplicationBuilder applicationBuilder)
-               addApplicationTransports(applicationBuilder, childEventGroup, modelConfiguration);
+               addApplicationTransports(applicationBuilder, childEventGroup, modelConfiguration, caches);
 
             _keywordReplacerTask.ReplaceIn(childEventGroup, childEventGroupBuilder, replacementContext);
          }
       }
 
-      private void addApplicationTransports(ApplicationBuilder applicationBuilder, EventGroup eventGroup, ModelConfiguration modelConfiguration)
+      private void addApplicationTransports(ApplicationBuilder applicationBuilder, EventGroup eventGroup, ModelConfiguration modelConfiguration, EventBuilderCaches caches)
       {
          var allEventGroupParentChildContainers = eventGroup.GetAllContainersAndSelf<IContainer>().ToEntityDescriptorMapList();
          foreach (var appTransport in applicationBuilder.Transports)
          {
             var transportBuilder = appTransport;
-            if (!_applicationTransportTargetContainerCache.Contains(transportBuilder.TargetCriteria))
-               _applicationTransportTargetContainerCache.Add(appTransport.TargetCriteria, _allModelContainerDescriptors.AllSatisfiedBy(transportBuilder.TargetCriteria));
+            if (!caches.ApplicationTransportTargetContainers.Contains(transportBuilder.TargetCriteria))
+               caches.ApplicationTransportTargetContainers.Add(appTransport.TargetCriteria, caches.AllModelContainerDescriptors.AllSatisfiedBy(transportBuilder.TargetCriteria));
 
-            addApplicationTransportToModel(transportBuilder, allEventGroupParentChildContainers, applicationBuilder.MoleculeName, modelConfiguration);
+            addApplicationTransportToModel(transportBuilder, allEventGroupParentChildContainers, applicationBuilder.MoleculeName, modelConfiguration, caches);
          }
       }
 
-      private void addApplicationTransportToModel(TransportBuilder appTransport, EntityDescriptorMapList<IContainer> allEventGroupParentChildContainers, string moleculeName, ModelConfiguration modelConfiguration)
+      private void addApplicationTransportToModel(TransportBuilder appTransport, EntityDescriptorMapList<IContainer> allEventGroupParentChildContainers, string moleculeName, ModelConfiguration modelConfiguration, EventBuilderCaches caches)
       {
          var appTransportSourceContainers = sourceContainersFor(appTransport, allEventGroupParentChildContainers);
-         var appTransportTargetContainers = _applicationTransportTargetContainerCache[appTransport.TargetCriteria].ToList();
+         var appTransportTargetContainers = caches.ApplicationTransportTargetContainers[appTransport.TargetCriteria].ToList();
          var (_, simulationBuilder, replacementContext) = modelConfiguration;
 
          foreach (var sourceContainer in appTransportSourceContainers)
@@ -151,6 +133,21 @@ namespace OSPSuite.Core.Domain.Services
       private IEnumerable<IContainer> sourceContainersFor(TransportBuilder transport, EntityDescriptorMapList<IContainer> allEventGroupParentChildContainers)
       {
          return allEventGroupParentChildContainers.AllSatisfiedBy(transport.SourceCriteria);
+      }
+
+      /// <summary>
+      ///    Caches only used to speed up the creation of events for one model. Created per call so that the task remains stateless
+      /// </summary>
+      private class EventBuilderCaches
+      {
+         public Cache<DescriptorCriteria, IEnumerable<IContainer>> SourceCriteriaTargetContainers { get; } = new Cache<DescriptorCriteria, IEnumerable<IContainer>>();
+         public Cache<DescriptorCriteria, IEnumerable<IContainer>> ApplicationTransportTargetContainers { get; } = new Cache<DescriptorCriteria, IEnumerable<IContainer>>();
+         public EntityDescriptorMapList<IContainer> AllModelContainerDescriptors { get; }
+
+         public EventBuilderCaches(EntityDescriptorMapList<IContainer> allModelContainerDescriptors)
+         {
+            AllModelContainerDescriptors = allModelContainerDescriptors;
+         }
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/FormulaTask.cs
@@ -61,16 +61,13 @@ namespace OSPSuite.Core.Domain.Services
       string AddParentVolumeReferenceToFormula(IFormula formula);
    }
 
-   public class FormulaTask : IFormulaTask,
-      IVisitor<IUsingFormula>,
-      IVisitor<IParameter>
+   public class FormulaTask : IFormulaTask
    {
       private readonly IObjectPathFactory _objectPathFactory;
       private readonly IObjectBaseFactory _objectBaseFactory;
       private readonly IAliasCreator _aliasCreator;
       private readonly IDimensionFactory _dimensionFactory;
       private readonly IEntityPathResolver _entityPathResolver;
-      private readonly ICache<string, IList<ExplicitFormula>> _originIdToFormulaCache = new Cache<string, IList<ExplicitFormula>>();
 
       public FormulaTask(
          IObjectPathFactory objectPathFactory,
@@ -88,17 +85,11 @@ namespace OSPSuite.Core.Domain.Services
 
       public void CheckFormulaOriginIn(IModel model)
       {
-         try
+         var formulaOriginVisitor = new FormulaOriginVisitor();
+         model.AcceptVisitor(formulaOriginVisitor);
+         foreach (var formulasWithSameOrigin in formulaOriginVisitor.OriginIdToFormulaCache)
          {
-            model.AcceptVisitor(this);
-            foreach (var formulasWithSameOrigin in _originIdToFormulaCache)
-            {
-               resetOriginIdIfFormulasAreNotTheSame(formulasWithSameOrigin);
-            }
-         }
-         finally
-         {
-            _originIdToFormulaCache.Clear();
+            resetOriginIdIfFormulasAreNotTheSame(formulasWithSameOrigin);
          }
       }
 
@@ -423,34 +414,42 @@ namespace OSPSuite.Core.Domain.Services
          }
       }
 
-      public void Visit(IUsingFormula usingFormula)
+      /// <summary>
+      ///    Collects all explicit formulas by origin id in one model. Created per call so that the task remains stateless
+      /// </summary>
+      private class FormulaOriginVisitor : IVisitor<IUsingFormula>, IVisitor<IParameter>
       {
-         addFormulaToCache(usingFormula?.Formula);
-      }
+         public ICache<string, IList<ExplicitFormula>> OriginIdToFormulaCache { get; } = new Cache<string, IList<ExplicitFormula>>();
 
-      private void addFormulaToCache(IFormula formula)
-      {
-         if (!(formula is ExplicitFormula explicitFormula))
-            return;
+         public void Visit(IUsingFormula usingFormula)
+         {
+            addFormulaToCache(usingFormula?.Formula);
+         }
 
-         if (string.IsNullOrEmpty(explicitFormula.OriginId))
-            return;
+         public void Visit(IParameter parameter)
+         {
+            Visit(parameter as IUsingFormula);
+            addFormulaToCache(parameter.RHSFormula);
+         }
 
-         listFor(explicitFormula.OriginId).Add(explicitFormula);
-      }
+         private void addFormulaToCache(IFormula formula)
+         {
+            if (!(formula is ExplicitFormula explicitFormula))
+               return;
 
-      private IList<ExplicitFormula> listFor(string originId)
-      {
-         if (!_originIdToFormulaCache.Contains(originId))
-            _originIdToFormulaCache.Add(originId, new List<ExplicitFormula>());
+            if (string.IsNullOrEmpty(explicitFormula.OriginId))
+               return;
 
-         return _originIdToFormulaCache[originId];
-      }
+            listFor(explicitFormula.OriginId).Add(explicitFormula);
+         }
 
-      public void Visit(IParameter parameter)
-      {
-         Visit(parameter as IUsingFormula);
-         addFormulaToCache(parameter.RHSFormula);
+         private IList<ExplicitFormula> listFor(string originId)
+         {
+            if (!OriginIdToFormulaCache.Contains(originId))
+               OriginIdToFormulaCache.Add(originId, new List<ExplicitFormula>());
+
+            return OriginIdToFormulaCache[originId];
+         }
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Services/ObserverBuilderTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObserverBuilderTask.cs
@@ -23,10 +23,6 @@ namespace OSPSuite.Core.Domain.Services
       private readonly IObserverBuilderToObserverMapper _observerMapper;
       private readonly IContainerTask _containerTask;
       private readonly IKeywordReplacerTask _keywordReplacerTask;
-
-      //cache only used to speed up task
-      private EntityDescriptorMapList<IContainer> _allContainerDescriptors;
-      private SimulationBuilder _simulationBuilder;
       private readonly IEntityTracker _entityTracker;
 
       public ObserverBuilderTask(
@@ -43,24 +39,17 @@ namespace OSPSuite.Core.Domain.Services
       public void CreateObservers(ModelConfiguration modelConfiguration)
       {
          var (model, simulationBuilder, replacementContext) = modelConfiguration;
-         _allContainerDescriptors = model.Root.GetAllChildren<IContainer>().ToEntityDescriptorMapList();
-         _simulationBuilder = simulationBuilder;
+         //cache only used to speed up task
+         var allContainerDescriptors = model.Root.GetAllChildren<IContainer>().ToEntityDescriptorMapList();
          var observers = simulationBuilder.Observers;
          var presentMolecules = simulationBuilder.AllPresentMolecules().ToList();
-         try
-         {
-            foreach (var observerBuilder in observers.OfType<AmountObserverBuilder>())
-               createAmountObserver(observerBuilder, presentMolecules, replacementContext, simulationBuilder);
+
+         foreach (var observerBuilder in observers.OfType<AmountObserverBuilder>())
+            createAmountObserver(observerBuilder, presentMolecules, allContainerDescriptors, replacementContext, simulationBuilder);
 
 
-            foreach (var observerBuilder in observers.OfType<ContainerObserverBuilder>())
-               createContainerObserver(observerBuilder, presentMolecules, replacementContext, simulationBuilder);
-         }
-         finally
-         {
-            _allContainerDescriptors = null;
-            _simulationBuilder = null;
-         }
+         foreach (var observerBuilder in observers.OfType<ContainerObserverBuilder>())
+            createContainerObserver(observerBuilder, presentMolecules, allContainerDescriptors, replacementContext, simulationBuilder);
       }
 
       /// <summary>
@@ -79,18 +68,18 @@ namespace OSPSuite.Core.Domain.Services
       ///    in the spatial structure of the model.
       ///    Typical example: "Concentration"-Observer (M/V)
       /// </summary>
-      private void createAmountObserver(AmountObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
+      private void createAmountObserver(AmountObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, EntityDescriptorMapList<IContainer> allContainerDescriptors, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
       {
          var moleculeNamesForObserver = moleculeBuildersValidFor(simulationBuilder.MoleculeListFor(observerBuilder), presentMolecules)
             .Select(x => x.Name).ToList();
 
-         foreach (var container in _allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
+         foreach (var container in allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
          {
             var amountsForObserver = container.GetChildren<MoleculeAmount>(ma => moleculeNamesForObserver.Contains(ma.Name));
 
             foreach (var amount in amountsForObserver)
             {
-               var observer = addObserverInContainer(observerBuilder, amount, amount.QuantityType);
+               var observer = addObserverInContainer(observerBuilder, amount, amount.QuantityType, simulationBuilder);
                _keywordReplacerTask.ReplaceIn(observer, amount.Name, replacementContext);
             }
          }
@@ -102,11 +91,11 @@ namespace OSPSuite.Core.Domain.Services
       ///    of the model.
       ///    Typical example is average drug concentration in an organ
       /// </summary>
-      private void createContainerObserver(ContainerObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
+      private void createContainerObserver(ContainerObserverBuilder observerBuilder, IEnumerable<MoleculeBuilder> presentMolecules, EntityDescriptorMapList<IContainer> allContainerDescriptors, ReplacementContext replacementContext, SimulationBuilder simulationBuilder)
       {
          var moleculeBuildersForObserver = moleculeBuildersValidFor(simulationBuilder.MoleculeListFor(observerBuilder), presentMolecules).ToList();
          //retrieve a list here to avoid endless loop if observers criteria is not well defined
-         foreach (var container in _allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
+         foreach (var container in allContainerDescriptors.AllSatisfiedBy(observerBuilder.ContainerCriteria))
          {
             foreach (var moleculeBuilder in moleculeBuildersForObserver)
             {
@@ -119,15 +108,15 @@ namespace OSPSuite.Core.Domain.Services
                   _entityTracker.Track(moleculeContainer, observerBuilder, simulationBuilder);
                }
 
-               var observer = addObserverInContainer(observerBuilder, moleculeContainer, moleculeBuilder.QuantityType);
+               var observer = addObserverInContainer(observerBuilder, moleculeContainer, moleculeBuilder.QuantityType, simulationBuilder);
                _keywordReplacerTask.ReplaceIn(observer, moleculeBuilder.Name, replacementContext);
             }
          }
       }
 
-      private Observer addObserverInContainer(ObserverBuilder observerBuilder, IContainer observerContainer, QuantityType moleculeType)
+      private Observer addObserverInContainer(ObserverBuilder observerBuilder, IContainer observerContainer, QuantityType moleculeType, SimulationBuilder simulationBuilder)
       {
-         var observer = _observerMapper.MapFrom(observerBuilder, _simulationBuilder);
+         var observer = _observerMapper.MapFrom(observerBuilder, simulationBuilder);
          observer.QuantityType = QuantityType.Observer | moleculeType;
          observerContainer.Add(observer);
          return observer;

--- a/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
+++ b/src/OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs
@@ -34,7 +34,7 @@ namespace OSPSuite.Core.Domain.Services
       private readonly IConcentrationBasedFormulaUpdater _concentrationBasedFormulaUpdater;
       private readonly IParameterValueToParameterMapper _parameterValueToParameterMapper;
       private readonly IEntityTracker _entityTracker;
-      private readonly ValidatorForForFormula _formulaValidator;
+      private readonly IModelValidatorFactory _modelValidatorFactory;
 
       public QuantityValuesUpdater(
          IKeywordReplacerTask keywordReplacerTask,
@@ -43,7 +43,7 @@ namespace OSPSuite.Core.Domain.Services
          IConcentrationBasedFormulaUpdater concentrationBasedFormulaUpdater,
          IParameterValueToParameterMapper parameterValueToParameterMapper,
          IEntityTracker entityTracker,
-         ValidatorForForFormula formulaValidator)
+         IModelValidatorFactory modelValidatorFactory)
       {
          _keywordReplacerTask = keywordReplacerTask;
          _cloneManagerForModel = cloneManagerForModel;
@@ -51,12 +51,13 @@ namespace OSPSuite.Core.Domain.Services
          _concentrationBasedFormulaUpdater = concentrationBasedFormulaUpdater;
          _parameterValueToParameterMapper = parameterValueToParameterMapper;
          _entityTracker = entityTracker;
-         _formulaValidator = formulaValidator;
+         _modelValidatorFactory = modelValidatorFactory;
       }
 
       public ValidationResult UpdateQuantitiesValues(ModelConfiguration modelConfiguration)
       {
-         var valueUpdater = new ValueUpdaterParams(modelConfiguration);
+         //the validator is stateful and is created per call so that the updater remains stateless
+         var valueUpdater = new ValueUpdaterParams(modelConfiguration, _modelValidatorFactory.Create<ValidatorForForFormula>());
          updateMoleculeAmountFromInitialConditions(modelConfiguration);
 
          //Add expressions profile before individual as some settings might be overwritten in the individual for aging
@@ -205,7 +206,7 @@ namespace OSPSuite.Core.Domain.Services
          if (parameter.Formula is ConstantFormula constantFormula)
             constantFormula.Value = actualParameterValue;
          //now we have a non constant formula. Let's try to see if the reference can be resolved. If yes, we will simply set the value of the parameter
-         else if (_formulaValidator.IsFormulaValid(parameter))
+         else if (valueUpdater.FormulaValidator.IsFormulaValid(parameter))
             parameter.Value = actualParameterValue;
          //Otherwise, we will create a new constant formula with the value
          else
@@ -309,10 +310,12 @@ namespace OSPSuite.Core.Domain.Services
       {
          public ModelConfiguration ModelConfiguration { get; }
          public ValidationResult ValidationResult { get; }
+         public ValidatorForForFormula FormulaValidator { get; }
 
-         public ValueUpdaterParams(ModelConfiguration modelConfiguration)
+         public ValueUpdaterParams(ModelConfiguration modelConfiguration, ValidatorForForFormula formulaValidator)
          {
             ModelConfiguration = modelConfiguration;
+            FormulaValidator = formulaValidator;
             ValidationResult = new ValidationResult();
          }
 

--- a/src/OSPSuite.Core/Services/CircularReferenceChecker.cs
+++ b/src/OSPSuite.Core/Services/CircularReferenceChecker.cs
@@ -34,33 +34,25 @@ namespace OSPSuite.Core.Services
    {
       private readonly IObjectPathFactory _objectPathFactory;
       private readonly IObjectTypeResolver _objectTypeResolver;
-      private readonly Cache<IEntity, List<IEntity>> _entityReferenceCache;
 
       public CircularReferenceChecker(IObjectPathFactory objectPathFactory, IObjectTypeResolver objectTypeResolver)
       {
          _objectPathFactory = objectPathFactory;
          _objectTypeResolver = objectTypeResolver;
-         _entityReferenceCache = new Cache<IEntity, List<IEntity>>(x => new List<IEntity>());
       }
 
       public bool HasCircularReference(ObjectPath path, IEntity referenceObject)
       {
-         try
-         {
-            var referencedObject = path.TryResolve<IUsingFormula>(referenceObject);
-            if (referencedObject == null)
-               return false;
+         var referencedObject = path.TryResolve<IUsingFormula>(referenceObject);
+         if (referencedObject == null)
+            return false;
 
-            if (referencedObject == referenceObject)
-               return true;
+         if (referencedObject == referenceObject)
+            return true;
 
-            buildEntityReferenceCache(referencedObject);
-            return _entityReferenceCache[referencedObject].Contains(referenceObject);
-         }
-         finally
-         {
-            _entityReferenceCache.Clear();
-         }
+         var entityReferenceCache = newEntityReferenceCache();
+         buildEntityReferenceCache(referencedObject, entityReferenceCache);
+         return entityReferenceCache[referencedObject].Contains(referenceObject);
       }
 
       public ValidationResult CheckCircularReferencesIn(ModelConfiguration modelConfiguration)
@@ -74,62 +66,50 @@ namespace OSPSuite.Core.Services
          return validationResult;
       }
 
+      private static Cache<IEntity, List<IEntity>> newEntityReferenceCache() => new Cache<IEntity, List<IEntity>>(x => new List<IEntity>());
+
       private void checkEvents(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult)
       {
-         try
-         {
-            checkReferencesInEvents(model, simulationBuilder, validationResult);
-         }
-         finally
-         {
-            _entityReferenceCache.Clear();
-         }
+         checkReferencesInEvents(model, simulationBuilder, validationResult, newEntityReferenceCache());
       }
 
       private void checkFormulas(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult)
       {
-         try
-         {
-            checkReferencesInAllFormulas(model, simulationBuilder, validationResult);
-         }
-         finally
-         {
-            _entityReferenceCache.Clear();
-         }
+         checkReferencesInAllFormulas(model, simulationBuilder, validationResult, newEntityReferenceCache());
       }
 
-      private void checkReferencesInAllFormulas(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult)
+      private void checkReferencesInAllFormulas(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
          var allUsingFormulas = model.Root.GetAllChildren<IUsingFormula>();
-         allUsingFormulas.Each(buildEntityReferenceCache);
-         allUsingFormulas.Each(x => checkCircularReferencesIn(x, simulationBuilder, validationResult, (entityType, entityAbsolutePath, allReferencesName) => Validation.CircularReferenceFoundInFormula(x.Name, entityType, entityAbsolutePath, allReferencesName)));
+         allUsingFormulas.Each(x => buildEntityReferenceCache(x, entityReferenceCache));
+         allUsingFormulas.Each(x => checkCircularReferencesIn(x, simulationBuilder, validationResult, (entityType, entityAbsolutePath, allReferencesName) => Validation.CircularReferenceFoundInFormula(x.Name, entityType, entityAbsolutePath, allReferencesName), entityReferenceCache));
       }
 
-      private void checkReferencesInEvents(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult)
+      private void checkReferencesInEvents(IModel model, SimulationBuilder simulationBuilder, ValidationResult validationResult, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
-         model.Root.GetAllChildren<Event>().Each(@event => checkCircularReferencesInEventAssignments(simulationBuilder, validationResult, @event));
+         model.Root.GetAllChildren<Event>().Each(@event => checkCircularReferencesInEventAssignments(simulationBuilder, validationResult, @event, entityReferenceCache));
       }
 
-      private void checkCircularReferencesInEventAssignments(SimulationBuilder simulationBuilder, ValidationResult validationResult, Event @event)
+      private void checkCircularReferencesInEventAssignments(SimulationBuilder simulationBuilder, ValidationResult validationResult, Event @event, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
          var allEventAssignments = @event.GetAllChildren<EventAssignment>().Where(x => !x.UseAsValue).ToList();
-         allEventAssignments.Each(assignment => buildAssignmentEntityCache(assignment, assignment.ObjectPath.TryResolve<IUsingFormula>(assignment)));
-         allEventAssignments.Each(x => checkCircularReferencesInEventAssignment(simulationBuilder, validationResult, @event, x));
+         allEventAssignments.Each(assignment => buildAssignmentEntityCache(assignment, assignment.ObjectPath.TryResolve<IUsingFormula>(assignment), entityReferenceCache));
+         allEventAssignments.Each(x => checkCircularReferencesInEventAssignment(simulationBuilder, validationResult, @event, x, entityReferenceCache));
       }
 
-      private void checkCircularReferencesInEventAssignment(SimulationBuilder simulationBuilder, ValidationResult validationResult, Event @event, EventAssignment x)
+      private void checkCircularReferencesInEventAssignment(SimulationBuilder simulationBuilder, ValidationResult validationResult, Event @event, EventAssignment x, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
          var changedEntity = x.ObjectPath.TryResolve<IUsingFormula>(x);
-         checkCircularReferencesIn(changedEntity, simulationBuilder, validationResult, (entityType, entityAbsolutePath, allReferencesName) => Validation.CircularReferenceFoundInEventAssignment(@event.Name, changedEntity.Name, entityType, entityAbsolutePath, allReferencesName));
+         checkCircularReferencesIn(changedEntity, simulationBuilder, validationResult, (entityType, entityAbsolutePath, allReferencesName) => Validation.CircularReferenceFoundInEventAssignment(@event.Name, changedEntity.Name, entityType, entityAbsolutePath, allReferencesName), entityReferenceCache);
       }
 
-      private void buildAssignmentEntityCache(EventAssignment assignment, IEntity changedEntity)
+      private void buildAssignmentEntityCache(EventAssignment assignment, IEntity changedEntity, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
          if (changedEntity == null)
             return;
 
-         var references = _entityReferenceCache.Contains(changedEntity) ? _entityReferenceCache[changedEntity] : new List<IEntity>();
-         _entityReferenceCache[changedEntity] = references;
+         var references = entityReferenceCache.Contains(changedEntity) ? entityReferenceCache[changedEntity] : new List<IEntity>();
+         entityReferenceCache[changedEntity] = references;
 
          foreach (var objectPath in assignment.Formula.ObjectPaths)
          {
@@ -141,18 +121,18 @@ namespace OSPSuite.Core.Services
                continue;
 
             references.Add(referencedObject);
-            buildEntityReferenceCache(referencedObject);
-            _entityReferenceCache[changedEntity].AddRange(_entityReferenceCache[referencedObject]);
+            buildEntityReferenceCache(referencedObject, entityReferenceCache);
+            entityReferenceCache[changedEntity].AddRange(entityReferenceCache[referencedObject]);
          }
       }
 
-      private void buildEntityReferenceCache(IUsingFormula usingFormula)
+      private void buildEntityReferenceCache(IUsingFormula usingFormula, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
-         if (_entityReferenceCache.Contains(usingFormula))
+         if (entityReferenceCache.Contains(usingFormula))
             return;
 
          var references = new List<IEntity>();
-         _entityReferenceCache[usingFormula] = references;
+         entityReferenceCache[usingFormula] = references;
 
          if (usingFormula.Formula == null)
             return;
@@ -164,14 +144,14 @@ namespace OSPSuite.Core.Services
                continue;
 
             references.Add(referencedObject);
-            buildEntityReferenceCache(referencedObject);
-            _entityReferenceCache[usingFormula].AddRange(_entityReferenceCache[referencedObject]);
+            buildEntityReferenceCache(referencedObject, entityReferenceCache);
+            entityReferenceCache[usingFormula].AddRange(entityReferenceCache[referencedObject]);
          }
       }
 
-      private void checkCircularReferencesIn(IUsingFormula usingFormula, SimulationBuilder simulationBuilder, ValidationResult validationResult, Func<string, string, IReadOnlyList<string>, string> circularReferenceFoundIn)
+      private void checkCircularReferencesIn(IUsingFormula usingFormula, SimulationBuilder simulationBuilder, ValidationResult validationResult, Func<string, string, IReadOnlyList<string>, string> circularReferenceFoundIn, Cache<IEntity, List<IEntity>> entityReferenceCache)
       {
-         var references = _entityReferenceCache[usingFormula];
+         var references = entityReferenceCache[usingFormula];
          if (!references.Contains(usingFormula))
             return;
 

--- a/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
@@ -782,7 +782,7 @@ namespace OSPSuite.Core
       private const int NUMBER_OF_PARALLEL_RUNS = 8;
       private SimulationConfiguration[] _simulationConfigurations;
       private CreationResult[] _results;
-      private int _expectedEntityCount;
+      private string _expectedModelFingerprint;
 
       protected override void Context()
       {
@@ -798,7 +798,25 @@ namespace OSPSuite.Core
 
          //sequential baseline used to verify that the models created in parallel are complete
          var baselineResult = sut.CreateModelFrom(IoC.Resolve<ModelHelperForSpecs>().CreateSimulationConfiguration(), "MyModel");
-         _expectedEntityCount = baselineResult.Model.Root.GetAllChildren<IEntity>().Count;
+         _expectedModelFingerprint = structuralFingerprintOf(baselineResult.Model);
+      }
+
+      /// <summary>
+      ///    Returns the sorted entity paths of all entities in the model together with the name of the formula they use.
+      ///    Comparing fingerprints catches races that would attach entities or formulas to the wrong nodes
+      /// </summary>
+      private static string structuralFingerprintOf(IModel model)
+      {
+         return model.Root.GetAllChildren<IEntity>()
+            .Select(entityFingerprint)
+            .OrderBy(x => x)
+            .ToString("\n");
+      }
+
+      private static string entityFingerprint(IEntity entity)
+      {
+         var formulaName = (entity as IUsingFormula)?.Formula?.Name;
+         return formulaName == null ? entity.EntityPath() : $"{entity.EntityPath()}|{formulaName}";
       }
 
       protected override void Because()
@@ -817,7 +835,7 @@ namespace OSPSuite.Core
       [Observation]
       public void should_create_models_with_the_same_structure_as_a_model_created_sequentially()
       {
-         _results.Each(result => result.Model.Root.GetAllChildren<IEntity>().Count.ShouldBeEqualTo(_expectedEntityCount));
+         _results.Each(result => structuralFingerprintOf(result.Model).ShouldBeEqualTo(_expectedModelFingerprint));
       }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModelConstructorIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -773,6 +774,50 @@ namespace OSPSuite.Core
          var parameterValues = _simulationConfiguration.ModuleConfigurations[0].SelectedParameterValues;
          var parameterValue = parameterValues.First(x => x.Name == parameter.Name);
          _simulationBuilder.SimulationEntitySourceFor(parameter).SourcePath.ShouldBeEqualTo(parameterValue.Path);
+      }
+   }
+
+   internal class When_creating_models_in_parallel_using_a_shared_model_constructor_instance : ContextForIntegration<IModelConstructor>
+   {
+      private const int NUMBER_OF_PARALLEL_RUNS = 8;
+      private SimulationConfiguration[] _simulationConfigurations;
+      private CreationResult[] _results;
+      private int _expectedEntityCount;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut = IoC.Resolve<IModelConstructor>();
+
+         //one configuration per run created sequentially so that only the model construction itself runs in parallel
+         _simulationConfigurations = new SimulationConfiguration[NUMBER_OF_PARALLEL_RUNS];
+         for (var i = 0; i < NUMBER_OF_PARALLEL_RUNS; i++)
+         {
+            _simulationConfigurations[i] = IoC.Resolve<ModelHelperForSpecs>().CreateSimulationConfiguration();
+         }
+
+         //sequential baseline used to verify that the models created in parallel are complete
+         var baselineResult = sut.CreateModelFrom(IoC.Resolve<ModelHelperForSpecs>().CreateSimulationConfiguration(), "MyModel");
+         _expectedEntityCount = baselineResult.Model.Root.GetAllChildren<IEntity>().Count;
+      }
+
+      protected override void Because()
+      {
+         _results = new CreationResult[NUMBER_OF_PARALLEL_RUNS];
+         Parallel.For(0, NUMBER_OF_PARALLEL_RUNS, i => { _results[i] = sut.CreateModelFrom(_simulationConfigurations[i], "MyModel"); });
+      }
+
+      [Observation]
+      public void should_create_a_valid_model_for_each_parallel_run()
+      {
+         //the case study creates a warning for a parameter not found
+         _results.Each(result => result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.ValidWithWarnings, result.ValidationResult.Messages.Select(m => m.Text).ToString("\n")));
+      }
+
+      [Observation]
+      public void should_create_models_with_the_same_structure_as_a_model_created_sequentially()
+      {
+         _results.Each(result => result.Model.Root.GetAllChildren<IEntity>().Count.ShouldBeEqualTo(_expectedEntityCount));
       }
    }
 }


### PR DESCRIPTION
Fixes #2886

## Problem

A single resolved `IModelConstructor` instance cannot be used to create models from parallel threads. While `ModelConstructor` itself is stateless, several sub-tasks in the `CreateModelFrom` pipeline store per-run data in instance fields (typically reset in `try/finally` blocks) instead of passing it through the call stack. Sharing one constructor instance across threads races on those fields; a parallel integration test reproduced a `NullReferenceException` in `ValidatorForForFormula` (held as a single shared instance by `QuantityValuesUpdater`).

## Changes

- `ObserverBuilderTask` — per-run fields become locals threaded through the private methods
- `EventBuilderTask` — per-run fields move to a per-call `EventBuilderCaches` parameter object; removed an unused constructor parameter
- `CalculationMethodTask` — per-run fields move to a per-call `MergeContext` parameter object
- `FormulaTask` — origin-id collection extracted into a private `FormulaOriginVisitor` instantiated per `CheckFormulaOriginIn` call; `FormulaTask` no longer implements `IVisitor`
- `CircularReferenceChecker` — entity reference cache becomes a local passed through the call stack (also fixes the public `HasCircularReference`)
- `QuantityValuesUpdater` — creates its `ValidatorForForFormula` per call via `IModelValidatorFactory` (consistent with how `ModelConstructor` uses all other validators) instead of holding one shared stateful instance
- New integration test: one shared `IModelConstructor` constructing models concurrently via `Parallel.For`, asserting valid results and structural equality with a sequential baseline

All `try/finally` field-reset blocks are removed — they existed only to clear the per-run fields.

## Tests

All suites pass: Core (2030), IntegrationTests (511), R (218), Infrastructure (158), Presentation (1264), UI (61). The new parallel fixture passed 5/5 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed instance-level mutable state caches from core model construction services to improve thread safety and enable concurrent operations.
  * Refactored calculation methods, event builders, formula processing, and observer creation to use per-call context patterns instead of stateful fields.

* **Tests**
  * Added integration tests verifying concurrent model creation with shared constructor instances produces valid models with consistent structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->