### PR TITLE
Fixes #2891 Axis Settings shows an empty Dimension for merged dimensions

### DIFF
--- a/src/OSPSuite.Core/Domain/UnitSystem/DimensionFactoryExtensions.cs
+++ b/src/OSPSuite.Core/Domain/UnitSystem/DimensionFactoryExtensions.cs
@@ -25,14 +25,19 @@ namespace OSPSuite.Core.Domain.UnitSystem
       {
          var dimensionCache = new Cache<string, IDimension>();
 
-         if (defaultDimension != null)
-            dimensionCache[defaultDimension.DisplayName] = defaultDimension;
-
          foreach (var dimension in dimensionFactory.Dimensions)
          {
             var optimalDimension = OptimalDimension(dimensionFactory, dimension);
             dimensionCache[optimalDimension.DisplayName] = optimalDimension;
          }
+
+         // Add the axis's own dimension last so that its exact instance wins the DisplayName key.
+         // MergedDimensionFor mints a new merged dimension instance on every call, so the loop above
+         // produces a different instance with the same DisplayName for mergeable dimensions. Editors
+         // select the combo value by reference, so the list must contain the instance held by the axis
+         // for it to be selectable. See issue #2891.
+         if (defaultDimension != null)
+            dimensionCache[defaultDimension.DisplayName] = defaultDimension;
 
          return dimensionCache;
       }

--- a/tests/OSPSuite.Core.Tests/Domain/DimensionFactoryExtensionSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/DimensionFactoryExtensionSpecs.cs
@@ -34,4 +34,31 @@ namespace OSPSuite.Core.Domain
          _result.ShouldOnlyContainInOrder(_factory.Dimensions.OrderBy(dimension => dimension.DisplayName).ToArray());
       }
    }
+
+   public class When_getting_all_dimensions_for_editors_for_an_axis_holding_a_merged_dimension : StaticContextSpecification
+   {
+      private IDimensionFactory _mergingFactory;
+      private IDimension _axisDimension;
+
+      protected override void Context()
+      {
+         _mergingFactory = new DimensionFactory();
+
+         var molarConcentration = new Dimension(new BaseDimensionRepresentation(), "MolarConcentration", "µmol/l");
+         var massConcentration = new Dimension(new BaseDimensionRepresentation(), "MassConcentration", "µg/l");
+         _mergingFactory.AddDimension(molarConcentration);
+         _mergingFactory.AddDimension(massConcentration);
+         _mergingFactory.AddMergingInformation(new SimpleDimensionMergingInformation(molarConcentration, massConcentration));
+
+         // Mimics how an axis stores its dimension: a freshly minted merged dimension instance.
+         // MergedDimensionFor returns a new instance on every call for mergeable dimensions.
+         _axisDimension = _mergingFactory.OptimalDimension(molarConcentration);
+      }
+
+      [Observation]
+      public void should_return_the_exact_dimension_instance_held_by_the_axis_so_it_is_selectable_by_reference_in_the_editor()
+      {
+         _mergingFactory.AllDimensionsForEditors(_axisDimension).ShouldContain(_axisDimension);
+      }
+   }
 }


### PR DESCRIPTION
## Problem
In the single-axis **Axis Settings** dialog, the **Dimension** field rendered blank for an axis whose dimension is a *merged* dimension (e.g. a Concentration axis with unit `µmol/l`), even though the Unit was populated and the axis-options grid showed the dimension correctly.

## Root cause
`getMergedDimensions` inserted the axis's own dimension instance first (keyed by `DisplayName`), then the loop overwrote that same key with a freshly-minted merged-dimension instance (`IDimensionFactory.MergedDimensionFor` is not cached — it returns a new object on every call). Since `Dimension`/`MergedDimensionFor` compare by reference, the combo binder could no longer match the axis's instance to any list item, so it rendered blank. Only mergeable dimensions (e.g. molar↔mass Concentration) hit this; non-mergeable dimensions return the same factory-owned instance each call and were unaffected.

## Fix
Move the `defaultDimension` insertion to *after* the loop in `getMergedDimensions`, so the axis's actual instance wins the `DisplayName` key and reference-matches in the editor. No behavior change for non-mergeable dimensions.

## Test
Added a regression spec that builds a dimension factory with merging information and asserts the editor list contains the *exact* merged-dimension instance held by the axis (fails without the fix, passes with it).

Verified manually in PK-Sim: opening **Axis Settings** on a concentration axis of a time profile now shows the populated Dimension combo.

Fixes #2891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dimension selection in editors to reliably return and select the correct dimension instance when dealing with merged dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->