### PR TITLE
Fixes #2894 Override SQLitePCLRaw.bundle_e_sqlite3 to 3.0.3 to clear CVE-2025-6965

### DIFF
--- a/src/OSPSuite.Infrastructure.Serialization/OSPSuite.Infrastructure.Serialization.csproj
+++ b/src/OSPSuite.Infrastructure.Serialization/OSPSuite.Infrastructure.Serialization.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
    <PackageReference Include="NHibernate" Version="5.5.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OSPSuite.R.Performance/OSPSuite.R.Performance.csproj
+++ b/tests/OSPSuite.R.Performance/OSPSuite.R.Performance.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OSPSuite.Core\OSPSuite.Core.csproj" />

--- a/tests/OSPSuite.Starter/OSPSuite.Starter.csproj
+++ b/tests/OSPSuite.Starter/OSPSuite.Starter.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OSPSuite.Assets.Images\OSPSuite.Assets.Images.csproj" />


### PR DESCRIPTION
Clears **NU1903** for **CVE-2025-6965 / [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)** (High, CVSS 9.8): SQLite before 3.50.2 can suffer memory corruption when aggregate terms exceed available columns. The vulnerable `SQLitePCLRaw.lib.e_sqlite3 2.1.11` enters via the direct `Microsoft.Data.Sqlite 10.0.7` reference in `OSPSuite.Infrastructure.Serialization` (and the R.Performance / Starter test projects).

## Fix
Add a direct override so the patched native ships:
```xml
<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
```
Note: even the latest `Microsoft.Data.Sqlite` (10.0.9) still depends on `SQLitePCLRaw.core 2.1.11`, so bumping it does not help. `SQLitePCLRaw.bundle_e_sqlite3 3.0.3` pulls in `SourceGear.sqlite3 3.50.4.5` (SQLite **3.50.4**) and drops `SQLitePCLRaw.lib.e_sqlite3` from the graph entirely. SQLitePCLRaw v3 has "no code changes in SQLitePCLRaw.core", so it stays compatible with `Microsoft.Data.Sqlite 10.0.7`. (The package version is `3.0.3`; the `3.50.x` in the issue is the SQLite native version.)

## Verification
`dotnet restore` + `dotnet list package --vulnerable --include-transitive` → **no vulnerable packages**; `--include-transitive` shows `SourceGear.sqlite3 3.50.4.5` / `SQLitePCLRaw.core 3.0.3` and no `lib.e_sqlite3`.

Fixes #2894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a SQLite runtime package to the application and related test projects, improving consistency for SQLite-based functionality and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->