### PR TITLE
Allow run for PopulationSimulations

### DIFF
--- a/src/OSPSuite.R/Domain/Simulation.cs
+++ b/src/OSPSuite.R/Domain/Simulation.cs
@@ -8,6 +8,7 @@ using OSPSuite.Core.Commands;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.Populations;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Visitor;
 
@@ -25,6 +26,23 @@ namespace OSPSuite.R.Domain
       public SimulationEntitySources EntitySources { get; set; } = new SimulationEntitySources();
       public OutputMappings OutputMappings { get; set; }
       public DataRepository ResultsDataRepository { get; set; }
+
+      /// <summary>
+      ///    The complete per-individual parameter values that turn this simulation into a population run.
+      ///    When <c>null</c> the simulation runs as a single individual.
+      /// </summary>
+      public IndividualValuesCache IndividualValuesCache { get; set; }
+
+      /// <summary>
+      ///    Optional time-varying (aging) parameter data. Only meaningful alongside an
+      ///    <see cref="IndividualValuesCache" />
+      /// </summary>
+      public AgingData AgingData { get; set; }
+
+      /// <summary>
+      ///    <c>true</c> when this simulation carries a population and should be run as a population simulation.
+      /// </summary>
+      public bool IsPopulation => IndividualValuesCache != null;
 
       public void RemoveUsedObservedData(DataRepository dataRepository)
       {

--- a/src/OSPSuite.R/Domain/Simulation.cs
+++ b/src/OSPSuite.R/Domain/Simulation.cs
@@ -27,21 +27,10 @@ namespace OSPSuite.R.Domain
       public OutputMappings OutputMappings { get; set; }
       public DataRepository ResultsDataRepository { get; set; }
 
-      /// <summary>
-      ///    The complete per-individual parameter values that turn this simulation into a population run.
-      ///    When <c>null</c> the simulation runs as a single individual.
-      /// </summary>
       public IndividualValuesCache IndividualValuesCache { get; set; }
 
-      /// <summary>
-      ///    Optional time-varying (aging) parameter data. Only meaningful alongside an
-      ///    <see cref="IndividualValuesCache" />
-      /// </summary>
       public AgingData AgingData { get; set; }
 
-      /// <summary>
-      ///    <c>true</c> when this simulation carries a population and should be run as a population simulation.
-      /// </summary>
       public bool IsPopulation => IndividualValuesCache != null;
 
       public void RemoveUsedObservedData(DataRepository dataRepository)

--- a/src/OSPSuite.R/Services/SimulationRunner.cs
+++ b/src/OSPSuite.R/Services/SimulationRunner.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OSPSuite.Assets;
@@ -10,6 +12,8 @@ using OSPSuite.Core.Serialization.SimModel.Services;
 using OSPSuite.Core.Services;
 using OSPSuite.R.Domain;
 using OSPSuite.Utility.Events;
+using OSPSuite.Utility.Extensions;
+using RSimulation = OSPSuite.R.Domain.Simulation;
 using SimulationRunOptions = OSPSuite.R.Domain.SimulationRunOptions;
 
 namespace OSPSuite.R.Services
@@ -35,6 +39,7 @@ namespace OSPSuite.R.Services
    {
       Task<SimulationResults> RunAsync(SimulationRunArgs simulationRunArgs);
       SimulationResults Run(SimulationRunArgs simulationRunArgs);
+      ConcurrencyManagerResult<SimulationResults>[] RunSimulations(SimulationRunOptions options, params RSimulation[] simulations);
    }
 
    public class SimulationRunner : ISimulationRunner
@@ -45,7 +50,8 @@ namespace OSPSuite.R.Services
       private readonly ISimulationPersistableUpdater _simulationPersistableUpdater;
       private readonly IPopulationTask _populationTask;
       private readonly IProgressManager _progressManager;
-      private IProgressUpdater _progressUpdater;
+      private readonly IConcurrencyManager _concurrencyManager;
+      private readonly Func<ISimulationRunner> _simulationRunnerFactory;
 
       public SimulationRunner(
          ISimModelManager simModelManager,
@@ -53,7 +59,9 @@ namespace OSPSuite.R.Services
          ISimulationResultsCreator simulationResultsCreator,
          ISimulationPersistableUpdater simulationPersistableUpdater,
          IPopulationTask populationTask,
-         IProgressManager progressManager)
+         IProgressManager progressManager,
+         IConcurrencyManager concurrencyManager,
+         Func<ISimulationRunner> simulationRunnerFactory)
       {
          _simModelManager = simModelManager;
          _populationRunner = populationRunner;
@@ -61,34 +69,26 @@ namespace OSPSuite.R.Services
          _simulationPersistableUpdater = simulationPersistableUpdater;
          _populationTask = populationTask;
          _progressManager = progressManager;
+         _concurrencyManager = concurrencyManager;
+         _simulationRunnerFactory = simulationRunnerFactory;
       }
 
-      private void simulationProgress(object sender, MultipleSimulationsProgressEventArgs e)
-      {
-         _progressUpdater.ReportProgress(e.NumberOfCalculatedSimulation, e.NumberOfSimulations,
-            Messages.CalculationPopulationSimulation(e.NumberOfCalculatedSimulation, e.NumberOfSimulations));
-      }
-
-      private void simulationTerminated()
-      {
-         terminated(this, EventArgs.Empty);
-      }
-
-      private void terminated(object sender, EventArgs e)
-      {
-         _progressUpdater?.Dispose();
-         _populationRunner.Terminated -= terminated;
-         _populationRunner.SimulationProgress -= simulationProgress;
-      }
-
-      private async Task<SimulationResults> runAsync(
-         IModelCoreSimulation simulation, 
-         IndividualValuesCache population, 
-         AgingData agingData = null,
-         SimulationRunOptions simulationRunOptions = null)
+      private async Task<SimulationResults> runPopulationAsync(
+         IModelCoreSimulation simulation,
+         IndividualValuesCache population,
+         AgingData agingData,
+         SimulationRunOptions simulationRunOptions)
       {
          var options = simulationRunOptions ?? new SimulationRunOptions();
-         initializeProgress(options);
+
+         //progress state is local so population runs do not share mutable state on this instance
+         var progressUpdater = options.ShowProgress ? _progressManager.Create() : new NoneProgressUpdater();
+
+         void onSimulationProgress(object sender, MultipleSimulationsProgressEventArgs e) =>
+            progressUpdater.ReportProgress(e.NumberOfCalculatedSimulation, e.NumberOfSimulations,
+               Messages.CalculationPopulationSimulation(e.NumberOfCalculatedSimulation, e.NumberOfSimulations));
+
+         _populationRunner.SimulationProgress += onSimulationProgress;
          _simulationPersistableUpdater.UpdateSimulationPersistable(simulation);
          try
          {
@@ -102,18 +102,12 @@ namespace OSPSuite.R.Services
          }
          finally
          {
-            simulationTerminated();
+            _populationRunner.SimulationProgress -= onSimulationProgress;
+            progressUpdater.Dispose();
          }
       }
 
-      private void initializeProgress(SimulationRunOptions options)
-      {
-         _populationRunner.Terminated += terminated;
-         _populationRunner.SimulationProgress += simulationProgress;
-         _progressUpdater = options.ShowProgress ? _progressManager.Create() : new NoneProgressUpdater();
-      }
-
-      private async Task<SimulationResults> runAsync(IModelCoreSimulation simulation, SimulationRunOptions simulationRunOptions)
+      private async Task<SimulationResults> runIndividualAsync(IModelCoreSimulation simulation)
       {
          _simulationPersistableUpdater.UpdateSimulationPersistable(simulation);
          var simulationResults = await _simModelManager.RunSimulationAsync(
@@ -126,17 +120,70 @@ namespace OSPSuite.R.Services
       public Task<SimulationResults> RunAsync(SimulationRunArgs simulationRunArgs)
       {
          var (simulation, population, agingData, simulationRunOptions) = simulationRunArgs;
-         return population == null ? 
-            runAsync(simulation, simulationRunOptions) : 
-            runAsync(simulation, population, agingData, simulationRunOptions);
+         return population == null ?
+            runIndividualAsync(simulation) :
+            runPopulationAsync(simulation, population, agingData, simulationRunOptions);
       }
 
       public SimulationResults Run(SimulationRunArgs simulationRunArgs)
       {
-         var (simulation, population, agingData, simulationRunOptions) = simulationRunArgs;
-         if (population != null)
-            return runAsync(simulation, population, agingData, simulationRunOptions).Result; //Not really without a task
-         return runAsync(simulation, simulationRunOptions).Result;
+         //Not really async without a task
+         return RunAsync(simulationRunArgs).Result;
+      }
+
+      public ConcurrencyManagerResult<SimulationResults>[] RunSimulations(SimulationRunOptions options, params RSimulation[] simulations)
+      {
+         options ??= new SimulationRunOptions();
+
+         var individualSimulations = simulations.Where(x => !x.IsPopulation).ToList();
+         var populationSimulations = simulations.Where(x => x.IsPopulation).ToList();
+
+         return runIndividuals(individualSimulations, options)
+            .Concat(runPopulations(populationSimulations, options))
+            .ToArray();
+      }
+
+      private IEnumerable<ConcurrencyManagerResult<SimulationResults>> runIndividuals(IReadOnlyList<RSimulation> individualSimulations, SimulationRunOptions options)
+      {
+         if (!individualSimulations.Any())
+            return Enumerable.Empty<ConcurrencyManagerResult<SimulationResults>>();
+
+         var coreSimulations = individualSimulations.Select(x => x.CoreSimulation).ToList();
+
+         //a fresh runner per item gives each parallel individual its own (stateful) SimModelManager
+         var resultsByData = _concurrencyManager.RunAsync(
+            coreSimulations,
+            (simulation, ct) => _simulationRunnerFactory().Run(new SimulationRunArgs
+            {
+               Simulation = simulation,
+               SimulationRunOptions = options
+            }),
+            CancellationToken.None,
+            options.NumberOfCoresToUse
+         ).Result;
+
+         return resultsByData.Values;
+      }
+
+      private IEnumerable<ConcurrencyManagerResult<SimulationResults>> runPopulations(IReadOnlyList<RSimulation> populationSimulations, SimulationRunOptions options) =>
+         populationSimulations.Select(x => runPopulation(x, options));
+
+      private ConcurrencyManagerResult<SimulationResults> runPopulation(RSimulation simulation, SimulationRunOptions options)
+      {
+         try
+         {
+            var results = runPopulationAsync(
+               simulation.CoreSimulation,
+               simulation.IndividualValuesCache,
+               simulation.AgingData,
+               options).Result;
+
+            return new ConcurrencyManagerResult<SimulationResults>(simulation.Id, results);
+         }
+         catch (Exception e)
+         {
+            return new ConcurrencyManagerResult<SimulationResults>(simulation.Id, e.FullMessage());
+         }
       }
    }
 }

--- a/tests/OSPSuite.R.Tests/Services/SimulationRunnerIntegrationTests.cs
+++ b/tests/OSPSuite.R.Tests/Services/SimulationRunnerIntegrationTests.cs
@@ -4,6 +4,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Populations;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.R.Domain;
 using OSPSuite.Utility;
 
@@ -116,6 +117,65 @@ namespace OSPSuite.R.Services
       {
          var paths = _results.AllQuantityPaths();
          paths.Any(x => x.ToString().Contains(_newSimulationName)).ShouldBeFalse();
+      }
+   }
+
+   public class When_running_a_population_simulation_through_run_simulations : concern_for_SimulationRunnerIntegration
+   {
+      private IndividualValuesCache _population;
+      private ConcurrencyManagerResult<SimulationResults>[] _results;
+
+      protected override void Context()
+      {
+         base.Context();
+         _population = _populationTask.ImportPopulation(_populationFile);
+         _simulation.IndividualValuesCache = _population;
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunSimulations(new SimulationRunOptions(), _simulation);
+      }
+
+      [Observation]
+      public void should_run_the_cache_bearing_simulation_as_a_population()
+      {
+         _results.Length.ShouldBeEqualTo(1);
+         _results[0].Succeeded.ShouldBeTrue();
+         _results[0].Result.Count.ShouldBeEqualTo(_population.Count);
+         _results[0].Result.Count.ShouldBeGreaterThan(1);
+      }
+   }
+
+   public class When_running_a_mixed_list_of_individual_and_population_simulations_through_run_simulations : concern_for_SimulationRunnerIntegration
+   {
+      private IndividualValuesCache _population;
+      private Simulation _individualSimulation;
+      private Simulation _populationSimulation;
+      private ConcurrencyManagerResult<SimulationResults>[] _results;
+
+      protected override void Context()
+      {
+         base.Context();
+         _population = _populationTask.ImportPopulation(_populationFile);
+         _individualSimulation = _simulationPersister.LoadSimulation(_simulationFile);
+         _populationSimulation = _simulationPersister.LoadSimulation(_simulationFile);
+         _populationSimulation.Id = "population";
+         _populationSimulation.IndividualValuesCache = _population;
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunSimulations(new SimulationRunOptions(), _individualSimulation, _populationSimulation);
+      }
+
+      [Observation]
+      public void should_return_one_coherent_result_set_with_the_individual_and_the_population()
+      {
+         _results.Length.ShouldBeEqualTo(2);
+         _results.All(x => x.Succeeded).ShouldBeTrue();
+         _results.Single(x => x.Id == _individualSimulation.Id).Result.Count.ShouldBeEqualTo(1);
+         _results.Single(x => x.Id == "population").Result.Count.ShouldBeEqualTo(_population.Count);
       }
    }
 }

--- a/tests/OSPSuite.R.Tests/Services/SimulationRunnerSpecs.cs
+++ b/tests/OSPSuite.R.Tests/Services/SimulationRunnerSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,8 @@ using OSPSuite.Helpers;
 using OSPSuite.R.Domain;
 using OSPSuite.SimModel;
 using OSPSuite.Utility.Events;
+using OSPSuite.Utility.Exceptions;
+using RSimulation = OSPSuite.R.Domain.Simulation;
 using SimulationRunOptions = OSPSuite.R.Domain.SimulationRunOptions;
 
 namespace OSPSuite.R.Services
@@ -27,6 +30,8 @@ namespace OSPSuite.R.Services
       protected IPopulationRunner _populationRunner;
       protected IPopulationTask _populationTask;
       protected IProgressManager _progressManager;
+      protected IConcurrencyManager _concurrencyManager;
+      protected ISimulationRunner _individualRunner;
 
       protected override void Context()
       {
@@ -35,10 +40,19 @@ namespace OSPSuite.R.Services
          _populationRunner = A.Fake<IPopulationRunner>();
          _populationTask = A.Fake<IPopulationTask>();
          _progressManager = A.Fake<IProgressManager>();
+         _concurrencyManager = new ConcurrencyManager(A.Fake<IObjectTypeResolver>());
+         _individualRunner = A.Fake<ISimulationRunner>();
+         A.CallTo(() => _progressManager.Create()).Returns(A.Fake<IProgressUpdater>());
          _simulationResultsCreator = new SimulationResultsCreator();
          sut = new SimulationRunner(_simModelManager, _populationRunner, _simulationResultsCreator, _simulationPersitableUpdater, _populationTask,
-            _progressManager);
+            _progressManager, _concurrencyManager, () => _individualRunner);
       }
+
+      protected static RSimulation PopulationSimulationWithId(string id, params int[] individualIds) =>
+         new RSimulation(new ModelCoreSimulation { Id = id })
+         {
+            IndividualValuesCache = new IndividualValuesCache(new ParameterValuesCache(), new CovariateValuesCache(), individualIds.ToList())
+         };
    }
 
    public class When_running_a_simulation : concern_for_SimulationRunner
@@ -174,6 +188,123 @@ namespace OSPSuite.R.Services
       {
          A.CallTo(() => _populationRunner.RunPopulationAsync(_simulation, _simulationRunOptions, _populationData, A<DataTable>._, null, CancellationToken.None))
             .MustHaveHappened();
+      }
+   }
+
+   public class When_running_a_mixed_list_of_individual_and_population_simulations : concern_for_SimulationRunner
+   {
+      private RSimulation _individual;
+      private RSimulation _population;
+      private SimulationResults _individualResults;
+      private SimulationResults _populationResults;
+      private ConcurrencyManagerResult<SimulationResults>[] _results;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individual = new RSimulation(new ModelCoreSimulation { Id = "individual" });
+         _population = PopulationSimulationWithId("population", 0, 1);
+
+         _individualResults = new SimulationResults();
+         A.CallTo(() => _individualRunner.Run(A<SimulationRunArgs>._)).Returns(_individualResults);
+
+         var populationRunResults = new PopulationRunResults();
+         _populationResults = populationRunResults.Results;
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_population.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>._, A<DataTable>._, A<CancellationToken>._))
+            .Returns(Task.FromResult(populationRunResults));
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunSimulations(new SimulationRunOptions(), _individual, _population);
+      }
+
+      [Observation]
+      public void should_return_one_result_per_simulation()
+      {
+         _results.Length.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_run_the_individual_through_a_freshly_resolved_runner()
+      {
+         var result = _results.Single(x => x.Id == "individual");
+         result.Succeeded.ShouldBeTrue();
+         result.Result.ShouldBeEqualTo(_individualResults);
+      }
+
+      [Observation]
+      public void should_run_the_population_through_the_population_runner()
+      {
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_population.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>._, A<DataTable>._, A<CancellationToken>._))
+            .MustHaveHappened();
+         var result = _results.Single(x => x.Id == "population");
+         result.Succeeded.ShouldBeTrue();
+         result.Result.ShouldBeEqualTo(_populationResults);
+      }
+   }
+
+   public class When_running_a_population_simulation_with_aging_data_through_run_simulations : concern_for_SimulationRunner
+   {
+      private RSimulation _population;
+      private ConcurrencyManagerResult<SimulationResults>[] _results;
+
+      protected override void Context()
+      {
+         base.Context();
+         _population = PopulationSimulationWithId("aging", 0, 1);
+         _population.AgingData = new AgingData
+         {
+            IndividualIds = new[] { 0, 1 },
+            ParameterPaths = new[] { "Organism|Liver|Volume", "Organism|Liver|Volume" },
+            Times = new[] { 10.0, 20.0 },
+            Values = new[] { 4.0, 5.0 },
+         };
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_population.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>._, A<DataTable>._, A<CancellationToken>._))
+            .Returns(Task.FromResult(new PopulationRunResults()));
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunSimulations(new SimulationRunOptions(), _population);
+      }
+
+      [Observation]
+      public void should_forward_the_aging_data_to_the_population_runner()
+      {
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_population.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>.That.Not.IsNull(), A<DataTable>._, A<CancellationToken>._))
+            .MustHaveHappened();
+      }
+   }
+
+   public class When_one_population_in_the_list_fails : concern_for_SimulationRunner
+   {
+      private RSimulation _goodPopulation;
+      private RSimulation _badPopulation;
+      private ConcurrencyManagerResult<SimulationResults>[] _results;
+
+      protected override void Context()
+      {
+         base.Context();
+         _goodPopulation = PopulationSimulationWithId("good", 0, 1);
+         _badPopulation = PopulationSimulationWithId("bad", 0, 1);
+
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_goodPopulation.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>._, A<DataTable>._, A<CancellationToken>._))
+            .Returns(Task.FromResult(new PopulationRunResults()));
+         A.CallTo(() => _populationRunner.RunPopulationAsync(_badPopulation.CoreSimulation, A<RunOptions>._, A<DataTable>._, A<DataTable>._, A<DataTable>._, A<CancellationToken>._))
+            .Throws(new OSPSuiteException("the population blew up"));
+      }
+
+      protected override void Because()
+      {
+         _results = sut.RunSimulations(new SimulationRunOptions(), _goodPopulation, _badPopulation);
+      }
+
+      [Observation]
+      public void should_isolate_the_failure_and_still_complete_the_other_population()
+      {
+         _results.Single(x => x.Id == "good").Succeeded.ShouldBeTrue();
+         _results.Single(x => x.Id == "bad").Succeeded.ShouldBeFalse();
       }
    }
 }


### PR DESCRIPTION
Delivers the two Core changes that let R run a mixed list of individual and population simulations.

- **#2896** — `OSPSuite.R.Domain.Simulation` now carries `IndividualValuesCache`, `AgingData`, and an `IsPopulation` flag.
- **#2897** — stateless `SimulationRunner.RunSimulations(options, params Simulation[])`: individual simulations run concurrently (a fresh runner per item), population simulations run sequentially; returns `ConcurrencyManagerResult<SimulationResults>[]`.

Fixes #2896
Fixes #2897


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulations can now represent population runs with additional population-related data.
  * Added support for running multiple simulations in one call, including mixed individual and population simulations.
  * Population-specific settings such as aging data are now handled during batch execution.

* **Bug Fixes**
  * Improved result handling so one failed population run does not stop other simulations from completing.
  * Added clearer success and failure reporting for batch simulation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->