### PR TITLE
Populate the skin gallery on demand to reduce startup time

### DIFF
--- a/src/OSPSuite.UI/Mappers/SkinManagerToSkinGalleryMapper.cs
+++ b/src/OSPSuite.UI/Mappers/SkinManagerToSkinGalleryMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Linq;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
 using DevExpress.Utils;
@@ -30,13 +31,39 @@ namespace OSPSuite.UI.Mappers
       public RibbonGalleryBarItem MapFrom(RibbonBarManager barManager, ISkinManager skinManager)
       {
          var rgbiSkins = createSkinGallery(barManager);
-         foreach (var skin in skinManager.All())
+
+         //Populate skins on demand instead of during startup
+         void populateGallery()
          {
-            var command = _container.Resolve<ActivateSkinCommand>();
-            command.SkinName = skin;
-            addSkinToGallery(rgbiSkins, CreateMenuButton.WithCaption(skin).WithCommand(command));
+            if (rgbiSkins.Gallery.Groups[0].Items.Count > 0)
+               return;
+
+            foreach (var skin in skinManager.All())
+            {
+               var command = _container.Resolve<ActivateSkinCommand>();
+               command.SkinName = skin;
+               addSkinToGallery(rgbiSkins, CreateMenuButton.WithCaption(skin).WithCommand(command));
+            }
          }
+
+         rgbiSkins.Gallery.InitDropDownGallery += (o, e) =>
+         {
+            populateGallery();
+            rgbiSkins_Gallery_InitDropDownGallery(rgbiSkins, e);
+         };
+
+         barManager.Ribbon.SelectedPageChanged += (o, e) =>
+         {
+            if (pageContains(barManager.Ribbon.SelectedPage, rgbiSkins))
+               populateGallery();
+         };
+
          return rgbiSkins;
+      }
+
+      private static bool pageContains(RibbonPage page, BarItem barItem)
+      {
+         return page != null && page.Groups.Any(group => group.ItemLinks.Any(link => Equals(link.Item, barItem)));
       }
 
       private RibbonGalleryBarItem createSkinGallery(RibbonBarManager barManager)
@@ -53,7 +80,6 @@ namespace OSPSuite.UI.Mappers
          rgbiSkins.Gallery.ImageSize = new Size(32, 17);
          rgbiSkins.Gallery.ItemImageLocation = Locations.Top;
          rgbiSkins.Gallery.RowCount = 4;
-         rgbiSkins.Gallery.InitDropDownGallery += (o, e) => rgbiSkins_Gallery_InitDropDownGallery(rgbiSkins, e);
          rgbiSkins.Gallery.ItemClick += (o, e) => e.Item.Tag.DowncastTo<IMenuBarButton>().Click();
          return rgbiSkins;
       }


### PR DESCRIPTION
Fixes #2901

Part of a broader effort to cut PK-Sim / MoBi startup time (Open-Systems-Pharmacology/PK-Sim#1472) — ~5 s combined across the fixes below. The ribbon skin gallery was built entirely at startup (one command + two skin-styled bitmaps per skin, ~50 skins). It is now populated on first use — when the drop-down is opened or its ribbon page is selected. Startup skin restore is unaffected. MoBi gets the same win via the shared OSPSuite.UI code.

Approximate startup savings across the investigation:

| Fix | Repository | Saving |
|---|---|---|
| `ValueOriginRepository` re-mapping bug (guard `Start()`) | PK-Sim | ~1.0 s |
| Background (parallel) repository warm-up | PK-Sim | ~1.0 s |
| Journal editor built on demand | PK-Sim | ~1.9 s |
| Skin gallery populated on demand (this PR) | OSPSuite.Core | ~1.4 s |

So, when you click the Utilities tab, there is a small delay because that's when the gallery is built. We could move this gallery if it feels weird, the other tabs are instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
