### PR TITLE
Fixes #2903 Log scale 0 representation is not clear

### DIFF
--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
@@ -170,6 +170,12 @@ namespace OSPSuite.Presentation.Presenters.Charts
       bool IsPointBelowLLOQ(double[] values, string seriesId);
       int GetSourceIndexFromDataRow(string seriesId, DataRow row);
 
+      /// <summary>
+      ///    Returns the y value of the underlying data for the given <paramref name="row" /> in the unit of the y axis.
+      ///    This is also available for rows representing empty points (e.g. a value of 0 on a logarithmic scale)
+      /// </summary>
+      double GetYValueFromDataRow(string seriesId, DataRow row);
+
       void Edit(CurveChart chart);
 
       /// <summary>
@@ -378,6 +384,12 @@ namespace OSPSuite.Presentation.Presenters.Charts
       {
          var curveBinder = curveBinderFromSeriesId(seriesId);
          return curveBinder?.OriginalCurveIndexForRow(row) ?? 0;
+      }
+
+      public double GetYValueFromDataRow(string seriesId, DataRow row)
+      {
+         var curveBinder = curveBinderFromSeriesId(seriesId);
+         return curveBinder?.YValueForRow(row) ?? double.NaN;
       }
 
       public Curve CurveFromSeriesId(string seriesId) => curveBinderFromSeriesId(seriesId)?.Curve;

--- a/src/OSPSuite.Presentation/Presenters/Charts/ICurveBinder.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ICurveBinder.cs
@@ -29,6 +29,12 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       int OriginalCurveIndexForRow(DataRow row);
 
+      /// <summary>
+      ///    Returns the y value of the underlying data for the given <paramref name="row" /> in the unit of the y axis.
+      ///    This is also available for rows representing empty points (e.g. a value of 0 on a logarithmic scale)
+      /// </summary>
+      double YValueForRow(DataRow row);
+
       bool IsValidFor(DataMode dataMode, AxisTypes curveAxisType);
       
    }

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -317,18 +317,23 @@ namespace OSPSuite.UI.Binders
                double x = xDimension.BaseUnitValueToUnitValue(xUnit, ValueInBaseUnit(xData, baseGrid, baseIndex));
                double y = yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(yData, baseGrid, baseIndex));
 
-               if (!isValidXValue(x) || !IsValidYValue(y))
+               if (!isValidXValue(x))
                   return;
 
                var row = _dataTable.NewRow();
                row[X] = x;
-               row[Y] = y;
                row[INDEX_OF_VALUE_IN_CURVE] = baseIndex;
 
                if (HasLLOQ)
                   row[LLOQ_SUFFIX] = LLOQ;
 
-               AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseGrid, baseIndex);
+               //A y value that cannot be plotted on the axis (e.g. 0 on a log scale) is kept as an empty point
+               //so that the curve shows a gap instead of a line connecting the neighboring valid points
+               if (IsValidYValue(y))
+               {
+                  row[Y] = y;
+                  AddRelatedValuesToRow(row, yData, yDimension, yUnit, y, baseGrid, baseIndex);
+               }
 
                _dataTable.Rows.Add(row);
             }

--- a/src/OSPSuite.UI/Binders/CurveBinder.cs
+++ b/src/OSPSuite.UI/Binders/CurveBinder.cs
@@ -461,6 +461,14 @@ namespace OSPSuite.UI.Binders
 
       public int OriginalCurveIndexForRow(DataRow row) => (int)row[INDEX_OF_VALUE_IN_CURVE];
 
+      public double YValueForRow(DataRow row)
+      {
+         var yData = ActiveYData;
+         var baseGrid = activeBaseGrid(Curve.xData, yData);
+         var yUnit = Curve.yDimension.Unit(_yAxis.UnitName);
+         return Curve.yDimension.BaseUnitValueToUnitValue(yUnit, ValueInBaseUnit(yData, baseGrid, OriginalCurveIndexForRow(row)));
+      }
+
       public bool IsValidFor(DataMode dataMode, AxisTypes yAxisType) =>
          _dataMode == dataMode &&
          _yAxisType == yAxisType;

--- a/src/OSPSuite.UI/Views/Charts/ChartDisplayView.cs
+++ b/src/OSPSuite.UI/Views/Charts/ChartDisplayView.cs
@@ -565,9 +565,22 @@ namespace OSPSuite.UI.Views.Charts
             xAxisTitle,
             yAxisTitle,
             _doubleFormatter.Format(nextPoint.NumericalArgument),
-            _doubleFormatter.Format(nextPoint.Values[0]), nextPoint.Values.Length > 1
+            _doubleFormatter.Format(yValueFor(series, nextPoint)), nextPoint.Values.Length > 1 && !nextPoint.IsEmpty
                ? _doubleFormatter.Format(nextPoint.Values[1])
                : null, editable: _curveEditEnabled, description: curveDescription);
+      }
+
+      private double yValueFor(Series series, SeriesPoint seriesPoint)
+      {
+         if (!seriesPoint.IsEmpty)
+            return seriesPoint.Values[0];
+
+         //An empty point has no rendered value (e.g. 0 on a logarithmic scale) so the value is retrieved from the underlying data
+         var dataRowView = seriesPoint.Tag as DataRowView;
+         if (dataRowView == null)
+            return double.NaN;
+
+         return _presenter.GetYValueFromDataRow(series.Name, dataRowView.Row);
       }
 
       private SeriesPoint findPointInSeries(ChartHitInfo hitInfo, Series series) =>

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
@@ -15,6 +15,8 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views.Charts;
 using OSPSuite.Utility.Exceptions;
+using DataRow = System.Data.DataRow;
+using DataTable = System.Data.DataTable;
 
 namespace OSPSuite.Presentation.Presentation
 {
@@ -66,6 +68,7 @@ namespace OSPSuite.Presentation.Presentation
             var curveBinder = A.Fake<ICurveBinder>();
             A.CallTo(() => curveBinder.SeriesIds).Returns(SeriesIdsFor(curve));
             A.CallTo(() => curveBinder.LLOQ).Returns(LLOQFor(curve));
+            A.CallTo(() => curveBinder.YValueForRow(A<DataRow>._)).ReturnsLazily(() => YValueForRowFor(curve));
             A.CallTo(() => curveBinder.ContainsSeries(curve.Id)).Returns(true);
             A.CallTo(() => curveBinder.Id).Returns(curve.Id);
             A.CallTo(() => curveBinder.Curve).Returns(curve);
@@ -89,6 +92,11 @@ namespace OSPSuite.Presentation.Presentation
       protected virtual double? LLOQFor(Curve curve)
       {
          return null;
+      }
+
+      protected virtual double YValueForRowFor(Curve curve)
+      {
+         return double.NaN;
       }
 
       protected virtual string[] SeriesIdsFor(Curve curve)
@@ -396,6 +404,51 @@ namespace OSPSuite.Presentation.Presentation
       public void should_use_the_chart_export_task_to_export_the_char_to_png()
       {
          A.CallTo(() => _chartDisplayView.ExportToPng(A<string>.Ignored, A<string>.Ignored)).MustHaveHappened();
+      }
+   }
+
+   public class When_retrieving_the_y_value_from_a_data_row_of_a_known_series : concern_for_ChartDisplayPresenter
+   {
+      private DataRow _row;
+
+      protected override void SetupChart()
+      {
+         base.SetupChart();
+         _curveChart.AddCurve(_curve);
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         _row = new DataTable().NewRow();
+      }
+
+      protected override double YValueForRowFor(Curve curve)
+      {
+         return 5.0;
+      }
+
+      [Observation]
+      public void should_return_the_value_provided_by_the_curve_binder()
+      {
+         sut.GetYValueFromDataRow(_curve.Id, _row).ShouldBeEqualTo(5.0);
+      }
+   }
+
+   public class When_retrieving_the_y_value_from_a_data_row_of_an_unknown_series : concern_for_ChartDisplayPresenter
+   {
+      private DataRow _row;
+
+      protected override void Context()
+      {
+         base.Context();
+         _row = new DataTable().NewRow();
+      }
+
+      [Observation]
+      public void should_return_nan()
+      {
+         double.IsNaN(sut.GetYValueFromDataRow("unknown series", _row)).ShouldBeTrue();
       }
    }
 }

--- a/tests/OSPSuite.Starter/Presenters/ChartTestPresenter.cs
+++ b/tests/OSPSuite.Starter/Presenters/ChartTestPresenter.cs
@@ -39,6 +39,7 @@ namespace OSPSuite.Starter.Presenters
       void AddObservationsWithGeometricDeviation(int numberOfObservations, int pointsPerObservation, double? lloq);
       void AddCalculationsWithGeometricMean(int numberOfCalculations, int pointsPerCalculation);
       void AddCalculationsWithArithmeticMean(int numberOfCalculations, int pointsPerCalculation);
+      void AddCalculationWithZeroValues();
    }
 
    public class ChartTestPresenter : AbstractCommandCollectorPresenter<IChartTestView, IChartTestPresenter>, IChartTestPresenter
@@ -115,6 +116,11 @@ namespace OSPSuite.Starter.Presenters
       public void AddCalculationsWithArithmeticMean(int numberOfCalculations, int pointsPerCalculation)
       {
          addRepositoryToChart(_dataRepositoryCreator.CreateCalculationsWithArithmeticMean(numberOfCalculations, _model, _dataRepositories.Count, pointsPerCalculation));
+      }
+
+      public void AddCalculationWithZeroValues()
+      {
+         addRepositoryToChart(_dataRepositoryCreator.CreateCalculationWithZeroValues(_model, _dataRepositories.Count));
       }
 
       public void AddObservationsWithGeometricDeviation(int numberOfObservations, int pointsPerObservation, double? lloq)

--- a/tests/OSPSuite.Starter/Tasks/DataRepositoryCreator.cs
+++ b/tests/OSPSuite.Starter/Tasks/DataRepositoryCreator.cs
@@ -17,6 +17,7 @@ namespace OSPSuite.Starter.Tasks
       DataRepository CreateObservationWithGeometricDeviation(int numberOfObservations, IContainer model, int index, int pointsPerObservation, double? lloq);
       DataRepository CreateCalculationsWithGeometricMean(int numberOfCalculations, IContainer model, int index, int pointsPerCalculation);
       DataRepository CreateCalculationsWithArithmeticMean(int numberOfCalculations, IContainer model, int index, int pointsPerCalculation);
+      DataRepository CreateCalculationWithZeroValues(IContainer model, int index);
    }
 
    public class DataRepositoryCreator : IDataRepositoryCreator
@@ -165,6 +166,47 @@ namespace OSPSuite.Starter.Tasks
             });
 
          return dataRepository;
+      }
+
+      /// <summary>
+      ///    Creates a calculation curve that decays, stays at exactly 0 between 50h and 100h and then decays again.
+      ///    Used to verify that values equal to 0 are shown as a gap on a logarithmic y axis (see issue 2903).
+      /// </summary>
+      public DataRepository CreateCalculationWithZeroValues(IContainer model, int index)
+      {
+         var dataRepository = new DataRepository().WithName($"Zero Values Repository {index}");
+         var baseGrid = new BaseGrid("ZeroValuesGrid", _dimensionFactory.Dimension("Time"));
+         var baseGridPath = new List<string> {dataRepository.Name, baseGrid.Name};
+         baseGrid.QuantityInfo = new QuantityInfo(baseGridPath, QuantityType.Time);
+
+         //150 hours in minutes, one point every 15 minutes
+         const float totalTimeInMinutes = 150 * 60;
+         const float intervalInMinutes = 15;
+         var numberOfPoints = (int) (totalTimeInMinutes / intervalInMinutes) + 1;
+         baseGrid.Values = Enumerable.Range(0, numberOfPoints).Select(i => i * intervalInMinutes).ToArray();
+
+         var quantity = getOrganismFromModel(model).EntityAt<IQuantity>("VenousBlood", "Plasma", "A", "Concentration");
+         var column = new DataColumn("Values dropping to zero", quantity.Dimension, baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            QuantityInfo = Helper.CreateQuantityInfo(quantity),
+            Values = baseGrid.Values.Select(zeroValuesPointFor).ToArray()
+         };
+
+         dataRepository.Add(column);
+         return dataRepository;
+      }
+
+      private static float zeroValuesPointFor(float timeInMinutes)
+      {
+         var timeInHours = timeInMinutes / 60;
+         if (timeInHours < 50)
+            return (float) (10 * Math.Exp(-timeInHours / 10));
+
+         if (timeInHours <= 100)
+            return 0;
+
+         return (float) (10 * Math.Exp(-(timeInHours - 100) / 10));
       }
 
       public DataRepository CreateObservationWithArithmenticDeviation(int numberOfObservations, IContainer model, int index, int pointsPerObservation, double? lloq)

--- a/tests/OSPSuite.Starter/Tasks/DataRepositoryCreator.cs
+++ b/tests/OSPSuite.Starter/Tasks/DataRepositoryCreator.cs
@@ -168,10 +168,6 @@ namespace OSPSuite.Starter.Tasks
          return dataRepository;
       }
 
-      /// <summary>
-      ///    Creates a calculation curve that decays, stays at exactly 0 between 50h and 100h and then decays again.
-      ///    Used to verify that values equal to 0 are shown as a gap on a logarithmic y axis (see issue 2903).
-      /// </summary>
       public DataRepository CreateCalculationWithZeroValues(IContainer model, int index)
       {
          var dataRepository = new DataRepository().WithName($"Zero Values Repository {index}");

--- a/tests/OSPSuite.Starter/Views/ChartTestView.cs
+++ b/tests/OSPSuite.Starter/Views/ChartTestView.cs
@@ -34,6 +34,7 @@ namespace OSPSuite.Starter.Views
 
          _calculationsDropDownControl.Items.Add(new DXMenuItem("With Arithmetic Population Mean", (o, e) => OnEvent(createCalculationsWithArithmeticMean)));
          _calculationsDropDownControl.Items.Add(new DXMenuItem("With Geometric Population Mean", (o, e) => OnEvent(createCalculationsWithGeometricMean)));
+         _calculationsDropDownControl.Items.Add(new DXMenuItem("With Values Dropping To Zero", (o, e) => OnEvent(createCalculationWithZeroValues)));
       }
 
       public override void InitializeBinding()
@@ -91,6 +92,11 @@ namespace OSPSuite.Starter.Views
       private void createCalculationsWithArithmeticMean()
       {
          _presenter.AddCalculationsWithArithmeticMean(NumberOfCalculations, PointsPerCalculation);
+      }
+
+      private void createCalculationWithZeroValues()
+      {
+         _presenter.AddCalculationWithZeroValues();
       }
 
       private void createObservationsWithArithmeticDeviation()

--- a/tests/OSPSuite.UI.Tests/Binders/CurveBinderSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Binders/CurveBinderSpecs.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Data;
+using System.Linq;
+using DevExpress.XtraCharts;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Chart.Mappers;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Helpers;
+using OSPSuite.Presentation.Presenters.Charts;
+using OSPSuite.UI.Controls;
+using OSPSuite.UI.Services;
+using OSPSuite.Utility.Extensions;
+using OSPSuite.Utility.Format;
+using Axis = OSPSuite.Core.Chart.Axis;
+using DataColumn = OSPSuite.Core.Domain.Data.DataColumn;
+
+namespace OSPSuite.UI.Binders
+{
+   public abstract class concern_for_CurveBinder : ContextSpecification<ICurveBinder>
+   {
+      protected UxChartControl _chartControl;
+      protected CurveChart _chart;
+      protected Curve _curve;
+      protected IDimensionFactory _dimensionFactory;
+      protected BaseGrid _baseGrid;
+      protected DataColumn _dataColumn;
+      protected Axis _xAxis;
+      protected Axis _yAxis;
+
+      private const string X = "X";
+      private const string Y = "Y";
+      private const string INDEX_OF_VALUE_IN_CURVE = "INDEX_OF_VALUE_IN_CURVE";
+
+      protected override void Context()
+      {
+         base.Context();
+         _chartControl = new UxChartControl();
+         //an initial series is required so that the diagram of the chart control is available
+         _chartControl.Series.Add(new Series("dummySeries", ViewType.ScatterLine));
+
+         _dimensionFactory = A.Fake<IDimensionFactory>();
+         A.CallTo(() => _dimensionFactory.MergedDimensionFor(A<DataColumn>._)).ReturnsLazily(x => x.GetArgument<DataColumn>(0).Dimension);
+
+         _baseGrid = new BaseGrid("Time", DomainHelperForSpecs.TimeDimensionForSpecs()) {Values = TimeValues};
+         _dataColumn = new DataColumn("Col", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            Values = ColumnValues,
+            DataInfo = {Origin = ColumnOrigins.Observation}
+         };
+
+         _xAxis = new Axis(AxisTypes.X) {Dimension = _baseGrid.Dimension, UnitName = _baseGrid.Dimension.BaseUnit.Name, Scaling = XScaling};
+         _yAxis = new Axis(AxisTypes.Y) {Dimension = _dataColumn.Dimension, UnitName = _dataColumn.Dimension.BaseUnit.Name, Scaling = YScaling};
+
+         _chart = new CurveChart();
+         _chart.AddAxis(_xAxis);
+         _chart.AddAxis(_yAxis);
+
+         _curve = new Curve();
+         _curve.SetxData(_baseGrid, _dimensionFactory);
+         _curve.SetyData(_dataColumn, _dimensionFactory);
+
+         var yAxisBinder = new AxisBinder(_yAxis, _chartControl, new NumericFormatterOptions());
+         sut = new CurveBinderFactory(new CurveToDataModeMapper()).CreateFor(_curve, _chartControl, _chart, yAxisBinder);
+      }
+
+      protected virtual float[] TimeValues { get; } = {1f, 2f, 3f, 4f};
+      protected abstract float[] ColumnValues { get; }
+      protected virtual Scalings XScaling { get; } = Scalings.Linear;
+      protected virtual Scalings YScaling { get; } = Scalings.Linear;
+
+      protected Series CurveSeries => _chartControl.Series.Cast<Series>().First(series => string.Equals(series.Name, _curve.Id));
+
+      protected DataTable DataTableForCurveSeries => CurveSeries.DataSource.DowncastTo<DataTable>();
+
+      protected object YValueAt(int rowIndex) => DataTableForCurveSeries.Rows[rowIndex][Y];
+
+      protected float XValueAt(int rowIndex) => (float) DataTableForCurveSeries.Rows[rowIndex][X];
+
+      protected int OriginalIndexAt(int rowIndex) => (int) DataTableForCurveSeries.Rows[rowIndex][INDEX_OF_VALUE_IN_CURVE];
+   }
+
+   public class When_binding_a_curve_containing_zero_values_to_a_logarithmic_y_axis : concern_for_CurveBinder
+   {
+      protected override float[] ColumnValues { get; } = {10f, 0f, 0f, 30f};
+      protected override Scalings YScaling { get; } = Scalings.Log;
+
+      [Observation]
+      public void should_add_a_row_for_each_point()
+      {
+         DataTableForCurveSeries.Rows.Count.ShouldBeEqualTo(4);
+      }
+
+      [Observation]
+      public void should_leave_the_y_value_empty_for_values_that_cannot_be_plotted_so_that_the_curve_shows_a_gap()
+      {
+         YValueAt(0).ShouldBeEqualTo(10f);
+         YValueAt(1).ShouldBeEqualTo(DBNull.Value);
+         YValueAt(2).ShouldBeEqualTo(DBNull.Value);
+         YValueAt(3).ShouldBeEqualTo(30f);
+      }
+
+      [Observation]
+      public void should_keep_the_x_value_and_the_original_curve_index_for_empty_points()
+      {
+         XValueAt(1).ShouldBeEqualTo(2f);
+         OriginalIndexAt(1).ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_keep_the_default_empty_point_handling_which_renders_empty_points_as_breaks_in_the_line()
+      {
+         //Despite its name, the default InsertZero mode renders empty points of a line series as breaks.
+         //Ignore or Interpolate would connect the neighboring points across the gap.
+         CurveSeries.View.DowncastTo<XYDiagramSeriesViewBase>().EmptyPointOptions.ProcessPoints.ShouldBeEqualTo(ProcessEmptyPointsMode.InsertZero);
+      }
+   }
+
+   public class When_binding_a_curve_containing_zero_values_to_a_linear_y_axis : concern_for_CurveBinder
+   {
+      protected override float[] ColumnValues { get; } = {10f, 0f, 0f, 30f};
+
+      [Observation]
+      public void should_plot_all_values_including_zero()
+      {
+         DataTableForCurveSeries.Rows.Count.ShouldBeEqualTo(4);
+         YValueAt(0).ShouldBeEqualTo(10f);
+         YValueAt(1).ShouldBeEqualTo(0f);
+         YValueAt(2).ShouldBeEqualTo(0f);
+         YValueAt(3).ShouldBeEqualTo(30f);
+      }
+   }
+
+   public class When_binding_a_curve_containing_nan_values : concern_for_CurveBinder
+   {
+      protected override float[] ColumnValues { get; } = {10f, float.NaN, 30f, 40f};
+
+      [Observation]
+      public void should_leave_the_y_value_empty_for_the_nan_value_so_that_the_curve_shows_a_gap()
+      {
+         DataTableForCurveSeries.Rows.Count.ShouldBeEqualTo(4);
+         YValueAt(0).ShouldBeEqualTo(10f);
+         YValueAt(1).ShouldBeEqualTo(DBNull.Value);
+         YValueAt(2).ShouldBeEqualTo(30f);
+         YValueAt(3).ShouldBeEqualTo(40f);
+      }
+   }
+
+   public class When_binding_a_curve_with_x_values_that_cannot_be_plotted_on_a_logarithmic_x_axis : concern_for_CurveBinder
+   {
+      protected override float[] TimeValues { get; } = {0f, 2f, 3f, 4f};
+      protected override float[] ColumnValues { get; } = {10f, 20f, 30f, 40f};
+      protected override Scalings XScaling { get; } = Scalings.Log;
+
+      [Observation]
+      public void should_not_add_a_row_for_points_without_a_valid_x_value()
+      {
+         DataTableForCurveSeries.Rows.Count.ShouldBeEqualTo(3);
+         OriginalIndexAt(0).ShouldBeEqualTo(1);
+      }
+   }
+}

--- a/tests/OSPSuite.UI.Tests/Binders/CurveBinderSpecs.cs
+++ b/tests/OSPSuite.UI.Tests/Binders/CurveBinderSpecs.cs
@@ -118,6 +118,13 @@ namespace OSPSuite.UI.Binders
          //Ignore or Interpolate would connect the neighboring points across the gap.
          CurveSeries.View.DowncastTo<XYDiagramSeriesViewBase>().EmptyPointOptions.ProcessPoints.ShouldBeEqualTo(ProcessEmptyPointsMode.InsertZero);
       }
+
+      [Observation]
+      public void should_return_the_underlying_y_value_for_empty_rows_as_well_as_for_regular_rows()
+      {
+         sut.YValueForRow(DataTableForCurveSeries.Rows[0]).ShouldBeEqualTo(10.0);
+         sut.YValueForRow(DataTableForCurveSeries.Rows[1]).ShouldBeEqualTo(0.0);
+      }
    }
 
    public class When_binding_a_curve_containing_zero_values_to_a_linear_y_axis : concern_for_CurveBinder


### PR DESCRIPTION
Fixes #2903

Values that cannot be plotted on a log-scaled axis (e.g. 0) were silently dropped from the bound chart data, so DevExpress drew a straight line connecting the neighboring valid points. Such values are now kept as empty points, which DevExpress renders as a gap in the curve.

Hovering near a gap now shows the underlying data value (e.g. 0) in the tooltip instead of NaN.

Also adds a 'With Values Dropping To Zero' test data set to OSPSuite.Starter for visual verification.

Linear view
<img width="665" height="746" alt="image" src="https://github.com/user-attachments/assets/bc801488-d86f-4303-b3ab-f55798007741" />

Before
<img width="676" height="754" alt="image" src="https://github.com/user-attachments/assets/dde618ab-1fc7-464f-9ac8-8102c15babaf" />

After - it's a single series, but has a gap
<img width="680" height="759" alt="image" src="https://github.com/user-attachments/assets/e0a86792-e4c5-4864-81f6-48e23a036eb3" />

There is a little bit of code to deal with the actual NaN that would be in the tooltip, replacing it with the data from the data set instead of the curve.
<img width="625" height="722" alt="image" src="https://github.com/user-attachments/assets/3c38337a-6cd1-48da-adcb-a105a8851a77" />

