### PR TITLE
Fixes #2720 "Link data to simulations" wrong behavior - apply the color of the mapped output

### DIFF
--- a/src/OSPSuite.Core/Domain/Data/DataColumn.cs
+++ b/src/OSPSuite.Core/Domain/Data/DataColumn.cs
@@ -28,7 +28,6 @@ namespace OSPSuite.Core.Domain.Data
       private WeakRef<DataRepository> _repository;
       protected List<float> _values;
       public IDimension Dimension { get; set; }
-      public string BottomCompartment { get; set; }
 
       internal Cache<AuxiliaryType, DataColumn> RelatedColumnsCache { get; } = new Cache<AuxiliaryType, DataColumn>(x => x.DataInfo.AuxiliaryType);
 

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -112,11 +112,13 @@ namespace OSPSuite.Presentation.Presenters.Charts
       /// <summary>
       ///    Adds a new curve to a the chart for the <paramref name="dataColumn" /> if one does not already exist.
       ///    Curve options will be applied if they are specified and a new curve is created.
+      ///    When <paramref name="linkedOutputPath" /> is specified, the curve takes the color of the simulation curve
+      ///    with this path if one exists in the chart.
       /// </summary>
       /// <returns>
       ///    The new curve or existing if chart already contains a curve for the specified <paramref name="dataColumn" />
       /// </returns>
-      Curve AddCurveForColumn(DataColumn dataColumn, CurveOptions defaultCurveOptions = null, bool isLinkedDataToSimulation = false);
+      Curve AddCurveForColumn(DataColumn dataColumn, CurveOptions defaultCurveOptions = null, string linkedOutputPath = null);
 
       /// <summary>
       ///    Adds a curves to the chart for all dataColumns in <paramref name="dataColumnList" /> if they do not already exist.
@@ -404,17 +406,17 @@ namespace OSPSuite.Presentation.Presenters.Charts
       {
          using (_chartUpdater.UpdateTransaction(Chart, e.Used ? CurveChartUpdateModes.Add : CurveChartUpdateModes.Remove))
          {
-            updateColumnUsedProperty(e.Columns, e.Used, e.IsLinkedDataToSimulation);
+            updateColumnUsedProperty(e.Columns, e.Used, e.LinkedOutputPath);
          }
       }
 
-      private void updateColumnUsedProperty(IReadOnlyList<DataColumn> columns, bool used, bool isLinkedDataToSimulations)
+      private void updateColumnUsedProperty(IReadOnlyList<DataColumn> columns, bool used, string linkedOutputPath)
       {
          columns.Each(column =>
          {
             if (used)
             {
-               var curve = AddCurveForColumn(column, isLinkedDataToSimulation: isLinkedDataToSimulations);
+               var curve = AddCurveForColumn(column, linkedOutputPath: linkedOutputPath);
                updateCurveProperty(curve);
             }
             else
@@ -662,23 +664,23 @@ namespace OSPSuite.Presentation.Presenters.Charts
          }
       }
 
-      public Curve AddCurveForColumn(DataColumn dataColumn, CurveOptions defaultCurveOptions = null, bool isLinkedDataToSimulation = false)
+      public Curve AddCurveForColumn(DataColumn dataColumn, CurveOptions defaultCurveOptions = null, string linkedOutputPath = null)
       {
          var (exists, curve) = createAndConfigureCurve(dataColumn);
 
          if (exists)
          {
             // An existing curve that is linked to a simulation curve might need a color update to match the simulation curve
-            if (isLinkedDataToSimulation)
-               updateCurveColorForLinkedData(curve);
+            if (!string.IsNullOrEmpty(linkedOutputPath))
+               updateCurveColorForLinkedData(curve, linkedOutputPath);
             return curve;
          }
 
          Chart.UpdateCurveColorAndStyle(curve, dataColumn, AllDataColumns);
 
          // override new curve coloring when the curve is linked to a simulation curve
-         if (isLinkedDataToSimulation)
-            updateCurveColorForLinkedData(curve);
+         if (!string.IsNullOrEmpty(linkedOutputPath))
+            updateCurveColorForLinkedData(curve, linkedOutputPath);
 
          if (defaultCurveOptions != null)
             curve.CurveOptions.UpdateFrom(defaultCurveOptions);
@@ -687,24 +689,19 @@ namespace OSPSuite.Presentation.Presenters.Charts
          return curve;
       }
 
-      private void updateCurveColorForLinkedData(Curve curve)
+      private void updateCurveColorForLinkedData(Curve curve, string linkedOutputPath)
       {
-         var matchedColor = colorForLinkedCurve(Chart, curve);
+         var matchedColor = colorForLinkedCurve(Chart, linkedOutputPath);
          if (matchedColor.HasValue)
          {
             curve.Color = matchedColor.Value;
          }
       }
 
-      private static Color? colorForLinkedCurve(CurveChart chart, Curve newCurve)
+      private static Color? colorForLinkedCurve(CurveChart chart, string linkedOutputPath)
       {
-         var compartment = newCurve.yData.BottomCompartment;
-
-         if (string.IsNullOrEmpty(compartment))
-            return null;
-
          var match = chart.Curves.Where(c => c.yData.IsCalculation())
-            .FirstOrDefault(c => c.yData.BottomCompartment?.Equals(compartment, StringComparison.OrdinalIgnoreCase) == true);
+            .FirstOrDefault(c => string.Equals(c.yData.PathAsString, linkedOutputPath));
 
          return match?.Color;
       }

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -700,7 +700,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       private static Color? colorForLinkedCurve(CurveChart chart, string linkedOutputPath)
       {
-         var match = chart.Curves.Where(c => c.yData.IsCalculation())
+         var match = chart.Curves.Where(c => c.yData != null && c.yData.IsCalculation())
             .FirstOrDefault(c => string.Equals(c.yData.PathAsString, linkedOutputPath));
 
          return match?.Color;

--- a/src/OSPSuite.Presentation/Presenters/Charts/DataBrowserPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/DataBrowserPresenter.cs
@@ -53,11 +53,11 @@ namespace OSPSuite.Presentation.Presenters.Charts
       /// </summary>
       /// <param name="dataColumnDTOs">The list of columns</param>
       /// <param name="used">true if the columns should be used, otherwise false</param>
-      /// <param name="isLinkedDataToSimulations">
-      ///    true if the columns should be linked to the simulation, so same color should be
-      ///    applied
+      /// <param name="linkedOutputPath">
+      ///    Full path of the simulation output the columns are linked to, so the same color as the output curve
+      ///    can be applied, otherwise null
       /// </param>
-      void SetUsedState(IReadOnlyList<DataColumnDTO> dataColumnDTOs, bool used, bool isLinkedDataToSimulations = false);
+      void SetUsedState(IReadOnlyList<DataColumnDTO> dataColumnDTOs, bool used, string linkedOutputPath = null);
 
       /// <summary>
       ///    Returns all <see cref="DataColumn" /> currently selected by the user
@@ -181,7 +181,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public void UsedChangedFor(DataColumnDTO dataColumnDTO, bool used)
       {
-         raiseUsedChanged(dataColumnDTO.DataColumn, used, isLinkedDataToSimulations: false);
+         raiseUsedChanged(dataColumnDTO.DataColumn, used, linkedOutputPath: null);
          updateDataSelection(_view.SelectedColumns);
          updateLinkedObservedData(dataColumnDTO.DataColumn, used);
       }
@@ -191,7 +191,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          if (!_isLinkedMappedOutputs) return;
 
          var linkedObservedData = getLinkedObservedDataFromOutputPath(dataColumn.PathAsString);
-         SetUsedState(linkedObservedData, used);
+         SetUsedState(linkedObservedData, used, dataColumn.PathAsString);
       }
 
       private IReadOnlyList<DataColumnDTO> getLinkedObservedDataFromOutputPath(string outputPath)
@@ -242,12 +242,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          {
             var outputColumnUsed = dataColumnDTO.Used;
             var linkedObservedData = getLinkedObservedDataFromOutputPath(dataColumnDTO.DataColumn.PathAsString);
-            //The bottom compartment also needs to be updated since it will take the value from the output data column
-            foreach (var columnDTO in linkedObservedData)
-            {
-               columnDTO.DataColumn.BottomCompartment = dataColumnDTO.BottomCompartment;
-            }
-            SetUsedState(linkedObservedData, outputColumnUsed,  isLinkedDataToSimulations: true);
+            SetUsedState(linkedObservedData, outputColumnUsed, dataColumnDTO.DataColumn.PathAsString);
          }
       }
 
@@ -256,10 +251,10 @@ namespace OSPSuite.Presentation.Presenters.Charts
          _view.SetGroupRowFormat(format);
       }
 
-      public void SetUsedState(IReadOnlyList<DataColumnDTO> dataColumnDTOs, bool used, bool isLinkedDataToSimulations = false)
+      public void SetUsedState(IReadOnlyList<DataColumnDTO> dataColumnDTOs, bool used, string linkedOutputPath = null)
       {
          updateUsedStateForColumns(dataColumnDTOs, used);
-         raiseUsedChanged(columnsFrom(dataColumnDTOs), used, isLinkedDataToSimulations);
+         raiseUsedChanged(columnsFrom(dataColumnDTOs), used, linkedOutputPath);
          updateDataSelection(_view.SelectedColumns);
       }
 
@@ -280,14 +275,14 @@ namespace OSPSuite.Presentation.Presenters.Charts
          dataColumnDTOs.Each(dto => dto.Used = used);
       }
 
-      private void raiseUsedChanged(IReadOnlyList<DataColumn> dataColumns, bool used, bool isLinkedDataToSimulations)
+      private void raiseUsedChanged(IReadOnlyList<DataColumn> dataColumns, bool used, string linkedOutputPath)
       {
-         UsedChanged(this, new UsedColumnsEventArgs(dataColumns, used, isLinkedDataToSimulations));
+         UsedChanged(this, new UsedColumnsEventArgs(dataColumns, used, linkedOutputPath));
       }
 
-      private void raiseUsedChanged(DataColumn dataColumn, bool used, bool isLinkedDataToSimulations)
+      private void raiseUsedChanged(DataColumn dataColumn, bool used, string linkedOutputPath)
       {
-         raiseUsedChanged(new[] { dataColumn }, used, isLinkedDataToSimulations);
+         raiseUsedChanged(new[] { dataColumn }, used, linkedOutputPath);
       }
 
       private void updateDataSelection(IReadOnlyList<DataColumnDTO> selectedDataColumnDTOs)

--- a/src/OSPSuite.Presentation/Presenters/Charts/DataColumnDTO.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/DataColumnDTO.cs
@@ -85,7 +85,6 @@ namespace OSPSuite.Presentation.Presenters.Charts
          DataColumn = dataColumn;
          Used = false;
          _pathElements = displayQuantityPathFunc(dataColumn);
-         DataColumn.BottomCompartment = BottomCompartment;
       }
 
       private string displayNameFor(PathElementId pathElementId) => _pathElements[pathElementId].DisplayName;

--- a/src/OSPSuite.Presentation/Presenters/Charts/UsedColumnsEventArgs.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/UsedColumnsEventArgs.cs
@@ -14,12 +14,17 @@ namespace OSPSuite.Presentation.Presenters.Charts
    public class UsedColumnsEventArgs : ColumnsEventArgs
    {
       public bool Used { get; }
-      public bool IsLinkedDataToSimulation { get; }
 
-      public UsedColumnsEventArgs(IReadOnlyList<DataColumn> columns, bool used, bool isLinkedDataToSimulation) : base(columns)
+      /// <summary>
+      ///    Full path of the simulation output the columns are linked to so that the same color can be applied,
+      ///    or null when the columns are not linked to an output
+      /// </summary>
+      public string LinkedOutputPath { get; }
+
+      public UsedColumnsEventArgs(IReadOnlyList<DataColumn> columns, bool used, string linkedOutputPath = null) : base(columns)
       {
          Used = used;
-         IsLinkedDataToSimulation = isLinkedDataToSimulation;
+         LinkedOutputPath = linkedOutputPath;
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
@@ -41,7 +41,6 @@ namespace OSPSuite.Presentation.Presentation
       protected List<DataRepository> _dataRepositoryList;
       protected BaseGrid _baseGrid2;
       protected BaseGrid _baseGrid3;
-      protected readonly string _bottomCompartment = "Plasma";
 
       protected override void Context()
       {
@@ -79,8 +78,6 @@ namespace OSPSuite.Presentation.Presentation
          {
             DataInfo = new DataInfo(ColumnOrigins.Observation),
          };
-         _standardColumn.BottomCompartment = _bottomCompartment;
-         _standardColumn2.BottomCompartment = _bottomCompartment;
          A.CallTo(() => _dimensionFactory.MergedDimensionFor(_baseGrid)).Returns(_baseGrid.Dimension);
          A.CallTo(() => _dimensionFactory.MergedDimensionFor(_standardColumn)).Returns(_standardColumn.Dimension);
       }
@@ -417,7 +414,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       protected override void Because()
       {
-         _dataBrowserPresenter.UsedChanged += Raise.With(new UsedColumnsEventArgs(new[] { _standardColumn, }, true, false));
+         _dataBrowserPresenter.UsedChanged += Raise.With(new UsedColumnsEventArgs(new[] { _standardColumn, }, true));
       }
 
       [Observation]
@@ -506,7 +503,7 @@ namespace OSPSuite.Presentation.Presentation
 
       protected override void Because()
       {
-         _dataBrowserPresenter.UsedChanged += Raise.With(new UsedColumnsEventArgs(new[] { _standardColumn, }, false, false));
+         _dataBrowserPresenter.UsedChanged += Raise.With(new UsedColumnsEventArgs(new[] { _standardColumn, }, false));
       }
 
       [Observation]
@@ -524,34 +521,6 @@ namespace OSPSuite.Presentation.Presentation
 
    public class When_the_chart_editor_presenter_is_updating_curves_that_are_linked_to_simulation : concern_for_ChartEditorPresenter
    {
-      protected override void Context()
-      {
-         base.Context();
-         var calculationColumn = new DataColumn("Standard", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
-         {
-            DataInfo = new DataInfo(ColumnOrigins.Calculation),
-            BottomCompartment = _bottomCompartment
-         };
-
-         sut.AddCurveForColumn(calculationColumn, isLinkedDataToSimulation: false);
-         sut.AddCurveForColumn(_standardColumn2, isLinkedDataToSimulation: false);
-      }
-
-      protected override void Because()
-      {
-         sut.AddCurveForColumn(_standardColumn2, isLinkedDataToSimulation: true);
-      }
-
-      [Observation]
-      public void should_update_the_curve_with_same_color()
-      {
-         sut.Chart.Curves.Count.ShouldBeEqualTo(2);
-         sut.Chart.Curves.All(x => x.Color == sut.Chart.Curves.First().Color).ShouldBeTrue();
-      }
-   }
-
-   public class When_adding_curves_that_are_linked_to_simulation_curves : concern_for_ChartEditorPresenter
-   {
       private DataColumn _calculationColumn;
 
       protected override void Context()
@@ -560,22 +529,113 @@ namespace OSPSuite.Presentation.Presentation
          _calculationColumn = new DataColumn("Standard", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
          {
             DataInfo = new DataInfo(ColumnOrigins.Calculation),
-            BottomCompartment = _bottomCompartment
+            QuantityInfo = new QuantityInfo(new[] {"Sim", "Organism", "PeripheralVenousBlood", "Plasma", "Drug"}, QuantityType.Drug)
          };
 
-         sut.AddCurveForColumn(_calculationColumn, isLinkedDataToSimulation: false);
+         sut.AddCurveForColumn(_calculationColumn).Color = Color.Red;
+         sut.AddCurveForColumn(_standardColumn2).Color = Color.Green;
       }
 
       protected override void Because()
       {
-         sut.AddCurveForColumn(_standardColumn2, isLinkedDataToSimulation: true);
+         sut.AddCurveForColumn(_standardColumn2, linkedOutputPath: _calculationColumn.PathAsString);
       }
 
       [Observation]
-      public void should_add_curve_with_same_color()
+      public void should_update_the_existing_curve_with_the_color_of_the_linked_output_curve()
       {
          sut.Chart.Curves.Count.ShouldBeEqualTo(2);
-         sut.Chart.Curves.All(x => x.Color == sut.Chart.Curves.First().Color).ShouldBeTrue();
+         sut.Chart.Curves.All(x => x.Color == Color.Red).ShouldBeTrue();
+      }
+   }
+
+   public class When_adding_curves_that_are_linked_to_simulation_curves : concern_for_ChartEditorPresenter
+   {
+      private DataColumn _calculationColumn;
+      private Curve _curve;
+
+      protected override void Context()
+      {
+         base.Context();
+         _calculationColumn = new DataColumn("Standard", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            QuantityInfo = new QuantityInfo(new[] {"Sim", "Organism", "PeripheralVenousBlood", "Plasma", "Drug"}, QuantityType.Drug)
+         };
+
+         sut.AddCurveForColumn(_calculationColumn).Color = Color.Red;
+      }
+
+      protected override void Because()
+      {
+         _curve = sut.AddCurveForColumn(_standardColumn2, linkedOutputPath: _calculationColumn.PathAsString);
+      }
+
+      [Observation]
+      public void should_add_the_curve_with_the_color_of_the_linked_output_curve()
+      {
+         sut.Chart.Curves.Count.ShouldBeEqualTo(2);
+         _curve.Color.ShouldBeEqualTo(Color.Red);
+      }
+   }
+
+   public class When_adding_a_curve_linked_to_an_output_when_multiple_outputs_share_the_same_compartment : concern_for_ChartEditorPresenter
+   {
+      private DataColumn _calculationColumn1;
+      private DataColumn _calculationColumn2;
+      private Curve _curve;
+
+      protected override void Context()
+      {
+         base.Context();
+         _calculationColumn1 = new DataColumn("Venous", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            QuantityInfo = new QuantityInfo(new[] {"Sim", "Organism", "PeripheralVenousBlood", "Plasma", "Drug"}, QuantityType.Drug)
+         };
+         _calculationColumn2 = new DataColumn("Arterial", DomainHelperForSpecs.ConcentrationDimensionForSpecs(), _baseGrid)
+         {
+            DataInfo = new DataInfo(ColumnOrigins.Calculation),
+            QuantityInfo = new QuantityInfo(new[] {"Sim", "Organism", "ArterialBlood", "Plasma", "Drug"}, QuantityType.Drug)
+         };
+
+         sut.AddCurveForColumn(_calculationColumn1).Color = Color.Red;
+         sut.AddCurveForColumn(_calculationColumn2).Color = Color.Blue;
+      }
+
+      protected override void Because()
+      {
+         _curve = sut.AddCurveForColumn(_standardColumn2, linkedOutputPath: _calculationColumn2.PathAsString);
+      }
+
+      [Observation]
+      public void should_apply_the_color_of_the_output_the_data_is_mapped_to_and_not_the_color_of_the_first_output()
+      {
+         _curve.Color.ShouldBeEqualTo(Color.Blue);
+      }
+   }
+
+   public class When_adding_a_curve_linked_to_an_output_that_has_no_curve_in_the_chart : concern_for_ChartEditorPresenter
+   {
+      private Curve _curve;
+      private Color _defaultColor;
+
+      protected override void Context()
+      {
+         base.Context();
+         _defaultColor = sut.AddCurveForColumn(_standardColumn2).Color;
+         _chart.RemoveCurvesForColumn(_standardColumn2);
+      }
+
+      protected override void Because()
+      {
+         _curve = sut.AddCurveForColumn(_standardColumn2, linkedOutputPath: "Sim|Organism|Liver|Cell|Drug");
+      }
+
+      [Observation]
+      public void should_keep_the_default_color_of_the_curve()
+      {
+         _curve.Color.ShouldBeEqualTo(_defaultColor);
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/DataBrowserPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/DataBrowserPresenterSpecs.cs
@@ -318,6 +318,7 @@ namespace OSPSuite.Presentation.Presentation
    {
       private OutputMappings _fakeOutputMappings;
       private readonly List<DataRepository> _linkedDataRepositories = new List<DataRepository>();
+      private readonly List<UsedColumnsEventArgs> _usedChangedEvents = new List<UsedColumnsEventArgs>();
 
       protected override void Context()
       {
@@ -330,6 +331,7 @@ namespace OSPSuite.Presentation.Presentation
          _allDataColumnDTOs[0].Used = true;
          _allDataColumnDTOs[1].Used = false;
          sut.AddOutputMappings(_fakeOutputMappings);
+         sut.UsedChanged += (o, e) => _usedChangedEvents.Add(e);
       }
 
       protected override void Because()
@@ -342,6 +344,51 @@ namespace OSPSuite.Presentation.Presentation
       {
          _allDataColumnDTOs[0].Used.ShouldBeTrue();
          _allDataColumnDTOs[1].Used.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_notify_the_used_changed_event_for_the_linked_data_with_the_path_of_the_output()
+      {
+         var eventForLinkedData = _usedChangedEvents.Single(x => x.Columns.Contains(_column2));
+         eventForLinkedData.LinkedOutputPath.ShouldBeEqualTo(_column1.PathAsString);
+      }
+   }
+
+   public class When_the_used_state_of_an_output_column_is_changed_while_linking_is_enabled : concern_for_DataBrowserPresenter
+   {
+      private OutputMappings _fakeOutputMappings;
+      private readonly List<DataRepository> _linkedDataRepositories = new List<DataRepository>();
+      private readonly List<UsedColumnsEventArgs> _usedChangedEvents = new List<UsedColumnsEventArgs>();
+
+      protected override void Context()
+      {
+         base.Context();
+         _column1.DataInfo.Origin = ColumnOrigins.CalculationAuxiliary;
+         sut.AddDataColumns(new[] { _column1, _column2 });
+         _linkedDataRepositories.Add(_column2.Repository);
+         _fakeOutputMappings = A.Fake<OutputMappings>();
+         A.CallTo(() => _fakeOutputMappings.AllDataRepositoryMappedTo(_column1.PathAsString)).Returns(_linkedDataRepositories);
+         sut.AddOutputMappings(_fakeOutputMappings);
+         sut.OutputObservedDataLinkingChanged(true);
+         sut.UsedChanged += (o, e) => _usedChangedEvents.Add(e);
+      }
+
+      protected override void Because()
+      {
+         sut.UsedChangedFor(_allDataColumnDTOs[0], true);
+      }
+
+      [Observation]
+      public void should_update_the_used_state_of_the_linked_observed_data()
+      {
+         _allDataColumnDTOs[1].Used.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_notify_the_used_changed_event_for_the_linked_observed_data_with_the_path_of_the_output()
+      {
+         var eventForLinkedData = _usedChangedEvents.Single(x => x.Columns.Contains(_column2));
+         eventForLinkedData.LinkedOutputPath.ShouldBeEqualTo(_column1.PathAsString);
       }
    }
 


### PR DESCRIPTION
Fixes #2720
Fixes #2120

# Description

"Link Data to Simulations" colored all linked observed data with the color of the **first** simulation curve: the matching curve was guessed by bottom compartment name, which collapses when multiple outputs share a compartment (e.g. `PeripheralVenousBlood/Plasma` and `ArterialBlood/Plasma`).

The data browser already resolves exactly which observed data are mapped to which output via `OutputMappings`, so the output path is now carried through the `UsedChanged` event and the simulation curve is matched by its actual path (`yData.PathAsString`). This also fixes ticking an output column while linking is already enabled, which previously applied no color sync at all. The now-unused `DataColumn.BottomCompartment` plumbing was removed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Regression spec for the multi-output scenario from #2720, plus specs for the event carrying the output path. Manually verified with the Alfentanil project attached to #2720.

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart color synchronization for curves linked to simulation outputs.
  * Linked curves now match the correct simulation output even when multiple outputs share the same compartment.
  * Preserved default curve colors when no matching simulation output is available.
  * Improved propagation of output-link information when observed data is linked or its used state changes.

* **Refactor**
  * Replaced compartment-based linking with full simulation output paths for more reliable chart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->