### PR TITLE
Fixes #2908 Scheduled coverage workflow broken after .NET 10 retarget

### DIFF
--- a/dotcover.xml
+++ b/dotcover.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
   <TargetArguments>
-  Tests\OSPSuite.Core.Tests\bin\Debug\net8.0\OSPSuite.Core.Tests.dll
-  Tests\OSPSuite.Core.IntegrationTests\bin\Debug\net8.0\OSPSuite.Core.IntegrationTests.dll
-  Tests\OSPSuite.Presentation.Tests\bin\Debug\net8.0\OSPSuite.Presentation.Tests.dll
-  Tests\OSPSuite.Infrastructure.Tests\bin\Debug\net8.0\OSPSuite.Infrastructure.Tests.dll
-  Tests\OSPSuite.R.Tests\bin\Debug\net8.0\OSPSuite.R.Tests.dll
-  Tests\OSPSuite.UI.Tests\bin\Debug\net8.0-windows\OSPSuite.UI.Tests.dll
+  Tests\OSPSuite.Core.Tests\bin\Debug\net10.0\OSPSuite.Core.Tests.dll
+  Tests\OSPSuite.Core.IntegrationTests\bin\Debug\net10.0-windows\OSPSuite.Core.IntegrationTests.dll
+  Tests\OSPSuite.Presentation.Tests\bin\Debug\net10.0-windows\OSPSuite.Presentation.Tests.dll
+  Tests\OSPSuite.Infrastructure.Tests\bin\Debug\net10.0\OSPSuite.Infrastructure.Tests.dll
+  Tests\OSPSuite.R.Tests\bin\Debug\net10.0\OSPSuite.R.Tests.dll
+  Tests\OSPSuite.UI.Tests\bin\Debug\net10.0-windows\OSPSuite.UI.Tests.dll
   </TargetArguments>
   <TargetWorkingDir>./</TargetWorkingDir>
  


### PR DESCRIPTION
Fixes #2908

The scheduled **Code Coverage V13** workflow fails because `dotcover.xml` still lists the pre-.NET-10 test output paths (`net8.0` / `net8.0-windows`), so NUnit finds zero test assemblies ([failing run](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/actions/runs/29978780424/job/89116103909)).

This updates the six `<TargetArguments>` entries to the current TFM output folders:

- `OSPSuite.Core.Tests`, `OSPSuite.Infrastructure.Tests`, `OSPSuite.R.Tests` → `net10.0`
- `OSPSuite.Core.IntegrationTests`, `OSPSuite.Presentation.Tests`, `OSPSuite.UI.Tests` → `net10.0-windows` (the first two also changed from plain `net8.0` to a `-windows` TFM during the retarget)

Note: full repair also requires bumping `NUnit.ConsoleRunner` (3.19.2 has no .NET 10 agent; added in 3.21.0) and `JetBrains.dotCover.CommandLineTools` in the shared `dotCover` composite action — companion PR in Open-Systems-Pharmacology/Workflows.