### PR TITLE
Fixes #2911 Add building block ClassificationType values and make ClassificationTypeToRootNodeTypeMapper.MapFrom virtual

### DIFF
--- a/src/OSPSuite.Core/Domain/ClassificationType.cs
+++ b/src/OSPSuite.Core/Domain/ClassificationType.cs
@@ -9,6 +9,14 @@ namespace OSPSuite.Core.Domain
       ParameterIdentification,
       SensitiviyAnalysis,
       QualificationPlan,
-      Module
+      Module,
+      Compound,
+      Formulation,
+      Individual,
+      Population,
+      Protocol,
+      Event,
+      ObserverSet,
+      ExpressionProfile
    }
 }

--- a/src/OSPSuite.Presentation/Mappers/ClassificationTypeToRootNodeTypeMapper.cs
+++ b/src/OSPSuite.Presentation/Mappers/ClassificationTypeToRootNodeTypeMapper.cs
@@ -11,7 +11,7 @@ namespace OSPSuite.Presentation.Mappers
 
    public class ClassificationTypeToRootNodeTypeMapper : IClassificationTypeToRootNodeTypeMapper
    {
-      public RootNodeType MapFrom(ClassificationType classificationType)
+      public virtual RootNodeType MapFrom(ClassificationType classificationType)
       {
          switch (classificationType)
          {


### PR DESCRIPTION
Supports PK-Sim building block subfolders (Open-Systems-Pharmacology/PK-Sim#1435).

Two small, additive changes so PK-Sim can reuse the OSP `Classification` / `Classifiable<T>` mechanism for building block subfolders:

- **`ClassificationType`**: add one value per PK-Sim building block type — `Compound`, `Formulation`, `Individual`, `Population`, `Protocol`, `Event`, `ObserverSet`, `ExpressionProfile`. Distinct values keep subfolders separate per building block type and gate drag/drop correctly (the classification machinery keys the root-folder mapping and the drop/move checks on `ClassificationType`). The enum is serialized by name, so the additions are backward compatible.
- **`ClassificationTypeToRootNodeTypeMapper.MapFrom`**: made `virtual`, so PK-Sim can subclass the mapper to route the new building block classification types to its own `PKSimRootNodeTypes.*Folder` root nodes and delegate all other types to the base implementation.

No behavior change for Core or MoBi.

Fixes #2911