### PR TITLE
Fixes #2913 Rename the stored parameter path in ParameterValuesCache.RenamePath

### DIFF
--- a/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
+++ b/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
@@ -87,7 +87,10 @@ namespace OSPSuite.Core.Domain.Populations
 
          var values = _parameterValuesCache[possibleKey];
          Remove(possibleKey);
-         _parameterValuesCache.Add(newPath, values);
+         //the cache is keyed by the path stored in the entry. Renaming only the key would be undone as soon as
+         //the cache is cloned, since the clone is built from the entries
+         values.ParameterPath = newPath;
+         _parameterValuesCache.Add(values);
       }
 
       private int numberOfValuesPerPath => !_parameterValuesCache.Any() ? 0 : _parameterValuesCache.First().Count;

--- a/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
+++ b/src/OSPSuite.Core/Domain/Populations/ParameterValuesCache.cs
@@ -87,8 +87,6 @@ namespace OSPSuite.Core.Domain.Populations
 
          var values = _parameterValuesCache[possibleKey];
          Remove(possibleKey);
-         //the cache is keyed by the path stored in the entry. Renaming only the key would be undone as soon as
-         //the cache is cloned, since the clone is built from the entries
          values.ParameterPath = newPath;
          _parameterValuesCache.Add(values);
       }

--- a/src/OSPSuite.Infrastructure.Import/Services/IndividualValuesCacheImporter.cs
+++ b/src/OSPSuite.Infrastructure.Import/Services/IndividualValuesCacheImporter.cs
@@ -94,7 +94,6 @@ namespace OSPSuite.Infrastructure.Import.Services
             if (allParameters.Contains(pathWithUnitsRemoved))
             {
                individualValuesCache.RenamePath(parameterPath, pathWithUnitsRemoved);
-               parameterValue.ParameterPath = pathWithUnitsRemoved;
                continue;
             }
 

--- a/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCacheSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/ParameterValuesCacheSpecs.cs
@@ -238,6 +238,19 @@ namespace OSPSuite.Core.Domain
       {
          sut.Has("PATH1").ShouldBeFalse();
       }
+
+      [Observation]
+      public void should_have_renamed_the_path_stored_in_the_entry()
+      {
+         sut.ParameterValuesFor("PATH2").ParameterPath.ShouldBeEqualTo("PATH2");
+      }
+
+      [Observation]
+      public void should_keep_the_renamed_path_when_the_cache_is_cloned()
+      {
+         //the clone is keyed from the path stored in each entry
+         sut.Clone().AllParameterPaths().ShouldOnlyContain("PATH2");
+      }
    }
 
    public class When_renaming_a_parameter_path_that_does_exist_containing_unit : concern_for_ParameterValuesCache
@@ -265,6 +278,12 @@ namespace OSPSuite.Core.Domain
       {
          sut.Has("PATH1").ShouldBeFalse();
          sut.Has("PATH1 [mg]").ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_have_renamed_the_path_stored_in_the_entry()
+      {
+         sut.ParameterValuesFor("PATH2").ParameterPath.ShouldBeEqualTo("PATH2");
       }
    }
 


### PR DESCRIPTION
Fixes #2913

`RenamePath` re-keyed the cache but left `ParameterValues.ParameterPath` at the old value. Since the cache is keyed by that field and `Clone` rebuilds from the entries, the rename was undone on clone.

- `RenamePath` now renames the stored path as well.
- `IndividualValuesCacheImporter` no longer has to set the path itself after calling it.

Tests: three observations added to `ParameterValuesCacheSpecs`, covering the stored path and a clone round trip. All failed before the change.

Core 2051, Infrastructure 158, Integration 513 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)