### PR TITLE
Fixes #2915 Open exported files and hyperlinks again

### DIFF
--- a/src/OSPSuite.Assets.Images/OSPSuite.Assets.Images.csproj
+++ b/src/OSPSuite.Assets.Images/OSPSuite.Assets.Images.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/OSPSuite.Assets/OSPSuite.Assets.csproj
+++ b/src/OSPSuite.Assets/OSPSuite.Assets.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/OSPSuite.CLI.Core/OSPSuite.CLI.Core.csproj
+++ b/src/OSPSuite.CLI.Core/OSPSuite.CLI.Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+		<PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSPSuite.Core/OSPSuite.Core.csproj
+++ b/src/OSPSuite.Core/OSPSuite.Core.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="OSPSuite.Serializer" Version="4.0.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/OSPSuite.Infrastructure.Autofac/OSPSuite.Infrastructure.Autofac.csproj
+++ b/src/OSPSuite.Infrastructure.Autofac/OSPSuite.Infrastructure.Autofac.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OSPSuite.Infrastructure.Castle/OSPSuite.Infrastructure.Castle.csproj
+++ b/src/OSPSuite.Infrastructure.Castle/OSPSuite.Infrastructure.Castle.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Windsor" Version="6.0.0" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OSPSuite.Infrastructure.Export/OSPSuite.Infrastructure.Export.csproj
+++ b/src/OSPSuite.Infrastructure.Export/OSPSuite.Infrastructure.Export.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="NPOI" Version="2.8.0" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
   </ItemGroup>

--- a/src/OSPSuite.Infrastructure.Import/OSPSuite.Infrastructure.Import.csproj
+++ b/src/OSPSuite.Infrastructure.Import/OSPSuite.Infrastructure.Import.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="NPOI" Version="2.8.0" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="LumenWorksCsvReader" Version="4.0.0" />
     <!-- Override NPOI's transitive System.Security.Cryptography.Xml 8.0.2, which has CVE-2026-33116 (GHSA-37gx-xxp4-5rgx). Patched in 10.0.6+. -->
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />

--- a/src/OSPSuite.Infrastructure/OSPSuite.Infrastructure.csproj
+++ b/src/OSPSuite.Infrastructure/OSPSuite.Infrastructure.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ospsuite.serializer" Version="4.0.1.5" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />

--- a/src/OSPSuite.Presentation/OSPSuite.Presentation.csproj
+++ b/src/OSPSuite.Presentation/OSPSuite.Presentation.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <!-- DevExpress.Data brings IDXDataErrorInfo / ErrorInfo used by DxValidatableDTO. -->
     <PackageReference Include="DevExpress.Data" Version="25.2.7" />
     <!-- DevExpress.Utils brings SvgImage / DefaultBoolean used by Extensions/ApplicationIconExtensions. -->

--- a/src/OSPSuite.R/OSPSuite.R.csproj
+++ b/src/OSPSuite.R/OSPSuite.R.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OSPSuite.UI/OSPSuite.UI.csproj
+++ b/src/OSPSuite.UI/OSPSuite.UI.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="WindowsAPICodePack.Shell.CommonFileDialogs" Version="1.1.5" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OSPSuite.UI/Services/DialogCreator.cs
+++ b/src/OSPSuite.UI/Services/DialogCreator.cs
@@ -62,7 +62,7 @@ namespace OSPSuite.UI.Services
          };
 
          if (containsHyperlink(message))
-            args.HyperlinkClick += (o, e) => { Process.Start(e.Link); };
+            args.HyperlinkClick += (o, e) => { Process.Start(new ProcessStartInfo(e.Link) {UseShellExecute = true}); };
 
          return args;
       }

--- a/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
+++ b/tests/OSPSuite.Core.IntegrationTests/OSPSuite.Core.IntegrationTests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/OSPSuite.Presentation.Tests/OSPSuite.Presentation.Tests.csproj
+++ b/tests/OSPSuite.Presentation.Tests/OSPSuite.Presentation.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OSPSuite.Assets.Images\OSPSuite.Assets.Images.csproj" />

--- a/tests/OSPSuite.R.Tests/OSPSuite.R.Tests.csproj
+++ b/tests/OSPSuite.R.Tests/OSPSuite.R.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />


### PR DESCRIPTION
Fixes #2915

- `OSPSuite.Utility` 5.0.0.10 -> 5.0.0.11, which carries the `FileHelper.TryOpenFile` fix (Open-Systems-Pharmacology/OSPSuite.Utility#58). Since .NET Core, `Process.Start(path)` no longer shell-executes, so `TryOpenFile` threw `Win32Exception` and swallowed it. That restores `ExportToExcelTask`, `JournalExportTask` and the `BaseShell` help links.
- `DialogCreator` opens message box hyperlinks with its own `Process.Start` call, which the Utility fix does not cover. It now passes an explicit `ProcessStartInfo` with `UseShellExecute = true`.

Solution builds with no new warnings. OSPSuite.Core.Tests, OSPSuite.Infrastructure.Tests, OSPSuite.Presentation.Tests and OSPSuite.UI.Tests all pass (3592 tests).

Unblocks Open-Systems-Pharmacology/MoBi#2459 and Open-Systems-Pharmacology/PK-Sim#3397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
