### PR TITLE
Fixes #2918 Remove a neighborhood redefined with invalid neighbors when merging modules

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -1733,6 +1733,9 @@ namespace OSPSuite.Assets
 
       public static string SecondNeighborNotDefinedFor(string neighborhoodName) => $"Second neighbor is undefined for neighborhood '{neighborhoodName}'";
 
+      public static string NeighborhoodNeighborsNotFoundInModel(string neighborhoodName, string firstNeighborPath, string secondNeighborPath, string buildingBlockName) =>
+         $"Cannot create the neighborhood '{neighborhoodName}' from building block '{buildingBlockName}': at least one neighbor cannot be found in the simulation (first neighbor: '{firstNeighborPath}', second neighbor: '{secondNeighborPath}').\nTo remove the neighborhood from the simulation, redefine it without neighbors instead.";
+
       public const string InParentTagCanOnlyBeUsedWithAndOperator = "IN PARENT tag can only be used with AND operator";
 
       public static string KeywordCannotBeInFirstPosition(string keyword, string path) => $"Keyword '{keyword}' cannot be used in first position in '{path}'";
@@ -1757,8 +1760,6 @@ namespace OSPSuite.Assets
 
       public static string SimulationUsedInPlotsAreNotExported(IReadOnlyList<string> simulationNames, string project)
          => $"{ObjectTypes.Simulation.PluralizeIf(simulationNames)} {simulationNames.ToString(", ", "'")} used in plots {"is".PluralizeIf(simulationNames)} not found in the list of exported simulations for {ObjectTypes.Project} {project}";
-
-      public static string NeighborIsLogical(string neighborName, string neighborhoodName) => $"Container {neighborName} is defined as logical for neighborhood '{neighborhoodName}'";
 
       public static class SensitivityAnalysis
       {
@@ -2066,7 +2067,9 @@ namespace OSPSuite.Assets
       public static string LargeNumberOfOutputPoints(int numberOfPoints) =>
          $"The selected output resolution will generate {numberOfPoints} points and may severely impact the software performance.\nAre you sure you want to run with these setting? If not, consider changing output resolution in simulations settings";
 
-      public static string NeighborhoodWasNotFoundInModel(string neighborhoodName, string buildingBlockName) => $"The neighborhood '{neighborhoodName}' from building block '{buildingBlockName}' was not added to the simulation because it is not defined or at least one of the containers is logical";
+      public static string NeighborhoodRemovedFromModel(string neighborhoodName, string buildingBlockName) => $"The neighborhood '{neighborhoodName}' was removed from the simulation because it is defined without neighbors in building block '{buildingBlockName}'";
+
+      public static string NeighborIsLogical(string neighborName, string neighborhoodName) => $"Container {neighborName} is defined as logical for neighborhood '{neighborhoodName}'";
 
       public static string UnitNotFoundInDimensionForParameter(string unit, string dimension, string parameterName)
       {

--- a/src/OSPSuite.Core/Domain/Builder/NeighborhoodBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/NeighborhoodBuilder.cs
@@ -26,22 +26,30 @@ namespace OSPSuite.Core.Domain.Builder
 
       public IContainer SecondNeighbor { get; private set; }
 
+      /// <summary>
+      ///    Path of the first neighbor in the spatial structure. Never <c>null</c>: an empty path indicates that the neighbor
+      ///    is not defined
+      /// </summary>
       public ObjectPath FirstNeighborPath
       {
          get => _firstNeighborPath;
          set
          {
-            _firstNeighborPath = value;
+            _firstNeighborPath = value ?? new ObjectPath();
             FirstNeighbor = null;
          }
       }
 
+      /// <summary>
+      ///    Path of the second neighbor in the spatial structure. Never <c>null</c>: an empty path indicates that the neighbor
+      ///    is not defined
+      /// </summary>
       public ObjectPath SecondNeighborPath
       {
          get => _secondNeighborPath;
          set
          {
-            _secondNeighborPath = value;
+            _secondNeighborPath = value ?? new ObjectPath();
             SecondNeighbor = null;
          }
       }
@@ -49,7 +57,27 @@ namespace OSPSuite.Core.Domain.Builder
       public NeighborhoodBuilder()
       {
          ContainerType = ContainerType.Neighborhood;
+         _firstNeighborPath = new ObjectPath();
+         _secondNeighborPath = new ObjectPath();
       }
+
+      /// <summary>
+      ///    Returns <c>true</c> if neither the first nor the second neighbor path is defined otherwise <c>false</c>.
+      ///    A neighborhood without neighbors removes the neighborhood with the same name from the simulation when merging
+      ///    modules.
+      /// </summary>
+      public bool HasNoNeighbors => !firstNeighborPathIsDefined && !secondNeighborPathIsDefined;
+
+      /// <summary>
+      ///    Returns <c>true</c> if both the first and the second neighbor path are defined otherwise <c>false</c>.
+      /// </summary>
+      public bool HasDefinedNeighborPaths => firstNeighborPathIsDefined && secondNeighborPathIsDefined;
+
+      private bool firstNeighborPathIsDefined => pathIsDefined(FirstNeighborPath);
+
+      private bool secondNeighborPathIsDefined => pathIsDefined(SecondNeighborPath);
+
+      private static bool pathIsDefined(ObjectPath path) => !string.IsNullOrEmpty(path.PathAsString);
 
       public IContainer MoleculeProperties => this.Container(Constants.MOLECULE_PROPERTIES);
 
@@ -76,9 +104,12 @@ namespace OSPSuite.Core.Domain.Builder
       /// </summary>
       private void resolveReferenceIfRequired(IContainer container)
       {
-         //only update if undefined
-         FirstNeighbor = FirstNeighbor ?? FirstNeighborPath.TryResolve<IContainer>(container);
-         SecondNeighbor = SecondNeighbor ?? SecondNeighborPath.TryResolve<IContainer>(container);
+         //only update if undefined. An undefined path cannot be resolved
+         if (firstNeighborPathIsDefined)
+            FirstNeighbor = FirstNeighbor ?? FirstNeighborPath.TryResolve<IContainer>(container);
+
+         if (secondNeighborPathIsDefined)
+            SecondNeighbor = SecondNeighbor ?? SecondNeighborPath.TryResolve<IContainer>(container);
       }
 
       /// <summary>

--- a/src/OSPSuite.Core/Domain/Mappers/NeighborhoodBuilderToNeighborhoodMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/NeighborhoodBuilderToNeighborhoodMapper.cs
@@ -53,6 +53,10 @@ namespace OSPSuite.Core.Domain.Mappers
       public Neighborhood MapFrom(NeighborhoodBuilder neighborhoodBuilder, IReadOnlyList<string> moleculeNames,
          IEnumerable<string> moleculeNamesWithCopyPropertiesRequired, ModelConfiguration modelConfiguration)
       {
+         //At least one neighbor path is undefined. The neighborhood cannot be created
+         if (!neighborhoodBuilder.HasDefinedNeighborPaths)
+            return null;
+
          var (model, simulationBuilder, replacementContext) = modelConfiguration;
 
          var neighborhood = _objectBaseFactory.Create<Neighborhood>();

--- a/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
@@ -10,9 +10,10 @@ using OSPSuite.Utility.Extensions;
 namespace OSPSuite.Core.Domain.Mappers
 {
    /// <summary>
-   ///    Returns a result that includes a top container named "NEIGHBORHOODS" with all mapped neighborhoods
-   ///    and a list of all neighborhoods that were not included because one or both neighbors were not found in the
-   ///    simulation spatial structure
+   ///    Returns a result that includes a top container named "NEIGHBORHOODS" with all mapped neighborhoods,
+   ///    a list of all invalid neighborhoods that could not be created because one or both neighbors were not found in the
+   ///    simulation spatial structure, and a list of all neighborhoods that were removed because a module redefines them
+   ///    without neighbors
    /// </summary>
    internal interface INeighborhoodCollectionToContainerMapper : IMapper<ModelConfiguration, NeighborhoodMapResult>
    {
@@ -49,21 +50,29 @@ namespace OSPSuite.Core.Domain.Mappers
 
          var mapToNeighborhood = mapToNeighborhoodDef(modelConfiguration);
 
+         //neighborhoods defined without neighbors represent a removal and are not mapped into the model
          IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborHoodsFrom(SpatialStructure spatialStructure) =>
-            spatialStructure.Neighborhoods.Select(x => (builder: x, neighborhood: mapToNeighborhood(x))).ToList();
+            spatialStructure.Neighborhoods.Where(x => !x.HasNoNeighbors).Select(x => (builder: x, neighborhood: mapToNeighborhood(x))).ToList();
 
-         IReadOnlyList<Neighborhood> definedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => allNeighborhoods.Where(x => x.neighborhood != null).Select(x => x.neighborhood).ToList();
-         IReadOnlyList<NeighborhoodBuilder> notDefinedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => allNeighborhoods.Where(x => x.neighborhood == null).Select(x => x.builder).ToList();
+         IReadOnlyList<Neighborhood> definedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => 
+            allNeighborhoods.Where(x => x.neighborhood != null).Select(x => x.neighborhood).ToList();
+         
+         IReadOnlyList<NeighborhoodBuilder> invalidNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, Neighborhood neighborhood)> allNeighborhoods) => 
+            allNeighborhoods.Where(x => x.neighborhood == null).Select(x => x.builder).ToList();
+         
+         IReadOnlyList<NeighborhoodBuilder> neighborhoodsWithoutNeighbors(SpatialStructure spatialStructure) => 
+            spatialStructure.Neighborhoods.Where(x => x.HasNoNeighbors).ToList();
 
          //we use a cache to ensure that we are replacing neighborhoods defined in multiple structures
          var firstSpatialStructure = allSpatialStructureAndMergeBehaviors[0].spatialStructure;
          var allOtherSpatialStructuresWithMergeBehavior = allSpatialStructureAndMergeBehaviors.Skip(1).ToList();
 
          //first step: Add the neighborhoods from the first structure
+         //a neighborhood without neighbors in the first structure has nothing to remove and is simply ignored
          var allNeighbors = allNeighborHoodsFrom(firstSpatialStructure);
          neighborhoodsParentContainer.AddChildren(definedNeighborhoods(allNeighbors));
 
-         notDefinedNeighborhoods(allNeighbors).Each(x => neighborhoodMapResult.Add(x, firstSpatialStructure));
+         invalidNeighborhoods(allNeighbors).Each(x => neighborhoodMapResult.AddInvalid(x, firstSpatialStructure));
 
          //now merge all other neighborhoods
          allOtherSpatialStructuresWithMergeBehavior
@@ -71,27 +80,27 @@ namespace OSPSuite.Core.Domain.Mappers
             .Each(x =>
             {
                mergeNeighborhoodsInStructure(neighborhoodsParentContainer, definedNeighborhoods(x.neighborhoods), x.mergeBehavior);
-               notDefinedNeighborhoods(x.neighborhoods).Each(n =>
-               {
-                  removeNeighborhoodRedefinedWithInvalidNeighbors(neighborhoodsParentContainer, n);
-                  neighborhoodMapResult.Add(n, x.spatialStructure);
-               });
+               invalidNeighborhoods(x.neighborhoods).Each(n => neighborhoodMapResult.AddInvalid(n, x.spatialStructure));
+               neighborhoodsWithoutNeighbors(x.spatialStructure).Each(n => removeNeighborhood(neighborhoodsParentContainer, n, x.spatialStructure, neighborhoodMapResult));
             });
 
          return neighborhoodMapResult;
       }
 
       /// <summary>
-      ///    Removes the neighborhood named after <paramref name="invalidNeighborhoodBuilder" /> from
-      ///    <paramref name="neighborhoods" /> if it was created by a previously merged spatial structure. A module redefining
-      ///    a neighborhood with neighbors that cannot be resolved discards it, whatever the merge behavior. This is the only
-      ///    way for a module to remove a neighborhood defined in another module.
+      ///    Removes the neighborhood named after <paramref name="neighborhoodWithoutNeighbors" /> from
+      ///    <paramref name="neighborhoods" /> if it was created by a previously merged spatial structure. Redefining a
+      ///    neighborhood without neighbors is the only way for a module to remove a neighborhood defined in another module.
+      ///    This applies whatever the merge behavior of the module.
       /// </summary>
-      private void removeNeighborhoodRedefinedWithInvalidNeighbors(IContainer neighborhoods, NeighborhoodBuilder invalidNeighborhoodBuilder)
+      private void removeNeighborhood(IContainer neighborhoods, NeighborhoodBuilder neighborhoodWithoutNeighbors, SpatialStructure spatialStructure, NeighborhoodMapResult neighborhoodMapResult)
       {
-         var existingNeighborhood = neighborhoods.GetSingleChildByName(invalidNeighborhoodBuilder.Name);
-         if (existingNeighborhood != null)
-            neighborhoods.RemoveChild(existingNeighborhood);
+         var existingNeighborhood = neighborhoods.GetSingleChildByName(neighborhoodWithoutNeighbors.Name);
+         if (existingNeighborhood == null)
+            return;
+
+         neighborhoods.RemoveChild(existingNeighborhood);
+         neighborhoodMapResult.AddRemoved(neighborhoodWithoutNeighbors, spatialStructure);
       }
 
       private void mergeNeighborhoodsInStructure(IContainer neighborhoods, IReadOnlyList<Neighborhood> neighborhoodsToMerge, MergeBehavior mergeBehavior)
@@ -159,6 +168,10 @@ namespace OSPSuite.Core.Domain.Mappers
       /// </summary>
       private IReadOnlyList<string> moleculeNamesFor(NeighborhoodBuilder neighborhoodBuilder, ICache<string, List<string>> moleculesStartValuesForFloatingMolecules)
       {
+         // undefined neighbor paths cannot contain any molecule
+         if (!neighborhoodBuilder.HasDefinedNeighborPaths)
+            return new List<string>();
+
          var pathToFirstNeighbor = neighborhoodBuilder.FirstNeighborPath.PathAsString;
          var pathToSecondNeighbor = neighborhoodBuilder.SecondNeighborPath.PathAsString;
 
@@ -174,28 +187,44 @@ namespace OSPSuite.Core.Domain.Mappers
 
    internal class NeighborhoodMapResult
    {
-      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _ignoredNeighborhoods;
+      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _invalidNeighborhoods;
+      private readonly List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> _removedNeighborhoods;
       private readonly IContainer _container;
 
       public NeighborhoodMapResult(IContainer container)
       {
          _container = container;
-         _ignoredNeighborhoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
+         _invalidNeighborhoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
+         _removedNeighborhoods = new List<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)>();
       }
 
       /// <summary>
-      ///    Adds the ignored <paramref name="builder" /> and the source <paramref name="buildingBlock" /> to the list of ignored
-      ///    neighborhoods
+      ///    Adds the <paramref name="builder" /> and the source <paramref name="buildingBlock" /> to the list of invalid
+      ///    neighborhoods (at least one neighbor could not be found in the simulation)
       /// </summary>
-      public void Add(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
+      public void AddInvalid(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
       {
-         _ignoredNeighborhoods.Add((builder, buildingBlock));
+         _invalidNeighborhoods.Add((builder, buildingBlock));
       }
 
-      internal void Deconstruct(out IContainer container, out IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> ignoredNeighborhoods)
+      /// <summary>
+      ///    Adds the <paramref name="builder" /> and the source <paramref name="buildingBlock" /> to the list of removed
+      ///    neighborhoods (the neighborhood was removed from the simulation because <paramref name="builder" /> defines no
+      ///    neighbors)
+      /// </summary>
+      public void AddRemoved(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
+      {
+         _removedNeighborhoods.Add((builder, buildingBlock));
+      }
+
+      internal void Deconstruct(
+         out IContainer container,
+         out IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> invalidNeighborhoods,
+         out IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> removedNeighborhoods)
       {
          container = _container;
-         ignoredNeighborhoods = _ignoredNeighborhoods;
+         invalidNeighborhoods = _invalidNeighborhoods;
+         removedNeighborhoods = _removedNeighborhoods;
       }
    }
 }

--- a/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
+++ b/src/OSPSuite.Core/Domain/Mappers/NeighborhoodCollectionToContainerMapper.cs
@@ -71,10 +71,27 @@ namespace OSPSuite.Core.Domain.Mappers
             .Each(x =>
             {
                mergeNeighborhoodsInStructure(neighborhoodsParentContainer, definedNeighborhoods(x.neighborhoods), x.mergeBehavior);
-               notDefinedNeighborhoods(x.neighborhoods).Each(n => neighborhoodMapResult.Add(n, x.spatialStructure));
+               notDefinedNeighborhoods(x.neighborhoods).Each(n =>
+               {
+                  removeNeighborhoodRedefinedWithInvalidNeighbors(neighborhoodsParentContainer, n);
+                  neighborhoodMapResult.Add(n, x.spatialStructure);
+               });
             });
 
          return neighborhoodMapResult;
+      }
+
+      /// <summary>
+      ///    Removes the neighborhood named after <paramref name="invalidNeighborhoodBuilder" /> from
+      ///    <paramref name="neighborhoods" /> if it was created by a previously merged spatial structure. A module redefining
+      ///    a neighborhood with neighbors that cannot be resolved discards it, whatever the merge behavior. This is the only
+      ///    way for a module to remove a neighborhood defined in another module.
+      /// </summary>
+      private void removeNeighborhoodRedefinedWithInvalidNeighbors(IContainer neighborhoods, NeighborhoodBuilder invalidNeighborhoodBuilder)
+      {
+         var existingNeighborhood = neighborhoods.GetSingleChildByName(invalidNeighborhoodBuilder.Name);
+         if (existingNeighborhood != null)
+            neighborhoods.RemoveChild(existingNeighborhood);
       }
 
       private void mergeNeighborhoodsInStructure(IContainer neighborhoods, IReadOnlyList<Neighborhood> neighborhoodsToMerge, MergeBehavior mergeBehavior)

--- a/src/OSPSuite.Core/Domain/Services/ModelConstructor.cs
+++ b/src/OSPSuite.Core/Domain/Services/ModelConstructor.cs
@@ -288,25 +288,38 @@ namespace OSPSuite.Core.Domain.Services
          //we update the replacement context first when the root container is created so that we can replace keywords from the root container
          modelConfiguration.UpdateReplacementContext();
 
-         IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> ignoredNeighborhoods;
-         (model.Neighborhoods, ignoredNeighborhoods) = _spatialStructureMerger.MergeNeighborhoods(modelConfiguration);
-
+         IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> invalidNeighborhoods;
+         IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> removedNeighborhoods;
+         (model.Neighborhoods, invalidNeighborhoods, removedNeighborhoods) = _spatialStructureMerger.MergeNeighborhoods(modelConfiguration);
 
          var validationResult = validate<SpatialStructureValidator>(modelConfiguration);
          if (modelConfiguration.ShouldValidate)
-            validationResult.AddMessagesFrom(warnMissingNeighborhoods(ignoredNeighborhoods));
+         {
+            validationResult.AddMessagesFrom(errorsForInvalidNeighborhoods(invalidNeighborhoods));
+            validationResult.AddMessagesFrom(warningsForRemovedNeighborhoods(removedNeighborhoods));
+         }
 
          return validationResult;
       }
 
-      private ValidationResult warnMissingNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> ignoredNeighborhoods)
+      private ValidationResult errorsForInvalidNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> invalidNeighborhoods)
       {
-         return new ValidationResult(ignoredNeighborhoods.Select(x => messageForMissingNeighborhood(x.builder, x.buildingBlock)));
+         return new ValidationResult(invalidNeighborhoods.Select(x => messageForInvalidNeighborhood(x.builder, x.buildingBlock)));
       }
 
-      private ValidationMessage messageForMissingNeighborhood(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
+      private ValidationMessage messageForInvalidNeighborhood(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
       {
-         return new ValidationMessage(NotificationType.Warning, Warning.NeighborhoodWasNotFoundInModel(builder.Name, buildingBlock.DisplayName), builder, buildingBlock);
+         return new ValidationMessage(NotificationType.Error, Error.NeighborhoodNeighborsNotFoundInModel(builder.Name, builder.FirstNeighborPath.PathAsString, builder.SecondNeighborPath.PathAsString, buildingBlock.DisplayName), builder, buildingBlock);
+      }
+
+      private ValidationResult warningsForRemovedNeighborhoods(IReadOnlyList<(NeighborhoodBuilder builder, SpatialStructure buildingBlock)> removedNeighborhoods)
+      {
+         return new ValidationResult(removedNeighborhoods.Select(x => messageForRemovedNeighborhood(x.builder, x.buildingBlock)));
+      }
+
+      private ValidationMessage messageForRemovedNeighborhood(NeighborhoodBuilder builder, SpatialStructure buildingBlock)
+      {
+         return new ValidationMessage(NotificationType.Warning, Warning.NeighborhoodRemovedFromModel(builder.Name, buildingBlock.DisplayName), builder, buildingBlock);
       }
 
       private ValidationResult checkCircularReferences(ModelConfiguration modelConfiguration)

--- a/src/OSPSuite.Core/Domain/Services/SimulationConfigurationValidator.cs
+++ b/src/OSPSuite.Core/Domain/Services/SimulationConfigurationValidator.cs
@@ -63,6 +63,10 @@ namespace OSPSuite.Core.Domain.Services
 
       private bool isEquivalentButNotExtensionNeighborhood(NeighborhoodBuilder neighborhood1, NeighborhoodBuilder neighborhood2)
       {
+         // a neighborhood with undefined neighbors does not define a location and cannot be equivalent to another neighborhood
+         if (!neighborhood1.HasDefinedNeighborPaths || !neighborhood2.HasDefinedNeighborPaths)
+            return false;
+
          // shared name means that one extends the other, or they are actually the same instance
          if (Equals(neighborhood1.Name, neighborhood2.Name))
             return false;

--- a/src/OSPSuite.Core/Domain/Services/SpatialStructureValidator.cs
+++ b/src/OSPSuite.Core/Domain/Services/SpatialStructureValidator.cs
@@ -39,10 +39,10 @@ namespace OSPSuite.Core.Domain.Services
             _result.AddMessage(NotificationType.Error, neighborhood, Error.SecondNeighborNotDefinedFor(neighborhood.Name));
 
          if (neighborhood.FirstNeighbor?.Mode == ContainerMode.Logical)
-            _result.AddMessage(NotificationType.Warning, neighborhood, Error.NeighborIsLogical(neighborhood.FirstNeighbor.Name, neighborhood.Name));
+            _result.AddMessage(NotificationType.Warning, neighborhood, Warning.NeighborIsLogical(neighborhood.FirstNeighbor.Name, neighborhood.Name));
 
          if (neighborhood.SecondNeighbor?.Mode == ContainerMode.Logical)
-            _result.AddMessage(NotificationType.Warning, neighborhood, Error.NeighborIsLogical(neighborhood.SecondNeighbor.Name, neighborhood.Name));
+            _result.AddMessage(NotificationType.Warning, neighborhood, Warning.NeighborIsLogical(neighborhood.SecondNeighbor.Name, neighborhood.Name));
       }
    }
 }

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -43,8 +43,7 @@ namespace OSPSuite.Core
       public void should_return_a_successful_validation_with_warning()
       {
          _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.ValidWithWarnings, _result.ValidationResult.Messages.Select(m => m.Text).ToString("\n"));
-         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel("does_not_match_existing", "Module1 - SPATIAL STRUCTURE MODULE 1"))).ShouldNotBeNull();
-         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel("not_physical", "Module1 - SPATIAL STRUCTURE MODULE 1"))).ShouldNotBeNull();
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborIsLogical(Bone, "not_physical"))).ShouldNotBeNull();
       }
 
       [Observation]
@@ -67,9 +66,9 @@ namespace OSPSuite.Core
       }
 
       [Observation]
-      public void should_have_removed_neighborhoods_pointing_to_invalid_neighbors()
+      public void should_have_created_the_neighborhood_between_a_physical_and_a_logical_container()
       {
-         _model.Neighborhoods.FindByName("does_not_match_existing").ShouldBeNull();
+         _model.Neighborhoods.FindByName("not_physical").ShouldNotBeNull();
       }
 
       [Observation]
@@ -461,6 +460,8 @@ namespace OSPSuite.Core
    internal class When_extending_a_neighborhood_with_neighbors_that_cannot_be_resolved : concern_for_ModuleIntegration
    {
       private const string NEIGHBORHOOD_NAME = "art_pls_to_bon_pls";
+      private readonly ObjectPath _invalidNeighborPath = new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST");
+      private readonly ObjectPath _validNeighborPath = new ObjectPath(Constants.ORGANISM, Bone, Plasma);
       private INeighborhoodBuilderFactory _neighborhoodFactory;
       private Module _module2;
 
@@ -476,7 +477,7 @@ namespace OSPSuite.Core
          _module2 = configuration.ModuleConfigurations[1].Module;
 
          //redefine a neighborhood of the first module with a neighbor that cannot be resolved in the merged structure
-         var neighborhood = _neighborhoodFactory.CreateBetween(new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST"), new ObjectPath(Constants.ORGANISM, Bone, Plasma));
+         var neighborhood = _neighborhoodFactory.CreateBetween(_invalidNeighborPath, _validNeighborPath);
          neighborhood.Name = NEIGHBORHOOD_NAME;
          _module2.SpatialStructure.AddNeighborhood(neighborhood);
 
@@ -484,21 +485,24 @@ namespace OSPSuite.Core
       };
 
       [Observation]
-      public void the_neighborhood_created_by_the_first_module_should_have_been_removed_from_the_model()
+      public void should_fail_the_simulation_construction_with_an_error()
       {
-         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Error.NeighborhoodNeighborsNotFoundInModel(NEIGHBORHOOD_NAME, _invalidNeighborPath.PathAsString, _validNeighborPath.PathAsString, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
       }
 
       [Observation]
-      public void should_warn_that_the_neighborhood_was_not_added_to_the_simulation()
+      public void should_not_have_removed_the_neighborhood_defined_in_the_first_module()
       {
-         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldNotBeNull();
       }
    }
 
    internal class When_overwriting_a_neighborhood_with_neighbors_that_cannot_be_resolved : concern_for_ModuleIntegration
    {
       private const string NEIGHBORHOOD_NAME = "art_pls_to_bon_pls";
+      private readonly ObjectPath _invalidNeighborPath = new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST");
+      private readonly ObjectPath _validNeighborPath = new ObjectPath(Constants.ORGANISM, Bone, Plasma);
       private INeighborhoodBuilderFactory _neighborhoodFactory;
       private Module _module2;
 
@@ -514,7 +518,7 @@ namespace OSPSuite.Core
          _module2 = configuration.ModuleConfigurations[1].Module;
 
          //redefine a neighborhood of the first module with a neighbor that cannot be resolved in the merged structure
-         var neighborhood = _neighborhoodFactory.CreateBetween(new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST"), new ObjectPath(Constants.ORGANISM, Bone, Plasma));
+         var neighborhood = _neighborhoodFactory.CreateBetween(_invalidNeighborPath, _validNeighborPath);
          neighborhood.Name = NEIGHBORHOOD_NAME;
          _module2.SpatialStructure.AddNeighborhood(neighborhood);
 
@@ -522,15 +526,220 @@ namespace OSPSuite.Core
       };
 
       [Observation]
-      public void the_neighborhood_created_by_the_first_module_should_have_been_removed_from_the_model()
+      public void should_fail_the_simulation_construction_with_an_error()
+      {
+         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Error.NeighborhoodNeighborsNotFoundInModel(NEIGHBORHOOD_NAME, _invalidNeighborPath.PathAsString, _validNeighborPath.PathAsString, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_not_have_removed_the_neighborhood_defined_in_the_first_module()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldNotBeNull();
+      }
+   }
+
+   internal class When_creating_a_new_neighborhood_with_neighbors_that_cannot_be_resolved : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "neighborhood_with_invalid_neighbors";
+      private readonly ObjectPath _invalidNeighborPath = new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST");
+      private readonly ObjectPath _validNeighborPath = new ObjectPath(Constants.ORGANISM, Bone, Plasma);
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForExtendMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //add a new neighborhood with a neighbor that cannot be resolved in the merged structure
+         var neighborhood = _neighborhoodFactory.CreateBetween(_invalidNeighborPath, _validNeighborPath);
+         neighborhood.Name = NEIGHBORHOOD_NAME;
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void should_fail_the_simulation_construction_with_an_error()
+      {
+         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.Invalid);
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Error.NeighborhoodNeighborsNotFoundInModel(NEIGHBORHOOD_NAME, _invalidNeighborPath.PathAsString, _validNeighborPath.PathAsString, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_not_have_created_the_neighborhood()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+   }
+
+   internal class When_extending_a_neighborhood_with_a_neighborhood_without_neighbors : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "bon_pls_to_ven_pls";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForExtendMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //redefine the neighborhood without neighbors to remove it from the simulation
+         var neighborhood = _neighborhoodFactory.Create().WithName(NEIGHBORHOOD_NAME);
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void should_have_removed_the_neighborhood_defined_in_the_first_module()
       {
          _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
       }
 
       [Observation]
-      public void should_warn_that_the_neighborhood_was_not_added_to_the_simulation()
+      public void should_warn_that_the_neighborhood_was_removed_from_the_simulation()
       {
-         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+         _result.ValidationResult.ValidationState.ShouldBeEqualTo(ValidationState.ValidWithWarnings, _result.ValidationResult.Messages.Select(m => m.Text).ToString("\n"));
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodRemovedFromModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+   }
+
+   internal class When_overwriting_a_neighborhood_with_a_neighborhood_without_neighbors : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "bon_pls_to_ven_pls";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForOverrideMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //redefine the neighborhood without neighbors to remove it from the simulation
+         var neighborhood = _neighborhoodFactory.Create().WithName(NEIGHBORHOOD_NAME);
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void should_have_removed_the_neighborhood_defined_in_the_first_module()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_warn_that_the_neighborhood_was_removed_from_the_simulation()
+      {
+         //the validation state is not asserted here because the underlying simulation configuration
+         //contains a pre-existing event error ('StartTime' reference) that is unrelated to the removal
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodRemovedFromModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+   }
+
+   internal class When_the_first_module_defines_a_neighborhood_without_neighbors : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "neighborhood_without_neighbors";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForExtendMergeBehavior();
+         _module1 = configuration.ModuleConfigurations[0].Module;
+
+         //there is no neighborhood to remove in the first module. The neighborhood is simply ignored
+         var neighborhood = _neighborhoodFactory.Create().WithName(NEIGHBORHOOD_NAME);
+         _module1.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void should_not_fail_the_simulation_construction()
+      {
+         _result.ValidationResult.ValidationState.ShouldNotBeEqualTo(ValidationState.Invalid);
+      }
+
+      [Observation]
+      public void should_not_have_created_the_neighborhood()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_not_warn_that_a_neighborhood_was_removed()
+      {
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodRemovedFromModel(NEIGHBORHOOD_NAME, _module1.SpatialStructure.DisplayName))).ShouldBeNull();
+      }
+   }
+
+   internal class When_a_module_defines_a_neighborhood_without_neighbors_matching_no_existing_neighborhood : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "neighborhood_without_neighbors";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForExtendMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //no neighborhood with this name exists in the previously merged modules. The neighborhood is simply ignored
+         var neighborhood = _neighborhoodFactory.Create().WithName(NEIGHBORHOOD_NAME);
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void should_not_fail_the_simulation_construction()
+      {
+         _result.ValidationResult.ValidationState.ShouldNotBeEqualTo(ValidationState.Invalid);
+      }
+
+      [Observation]
+      public void should_not_have_created_the_neighborhood()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_not_warn_that_a_neighborhood_was_removed()
+      {
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodRemovedFromModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldBeNull();
       }
    }
 

--- a/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/ModuleIntegrationTests.cs
@@ -458,6 +458,82 @@ namespace OSPSuite.Core
       }
    }
 
+   internal class When_extending_a_neighborhood_with_neighbors_that_cannot_be_resolved : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "art_pls_to_bon_pls";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForExtendMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //redefine a neighborhood of the first module with a neighbor that cannot be resolved in the merged structure
+         var neighborhood = _neighborhoodFactory.CreateBetween(new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST"), new ObjectPath(Constants.ORGANISM, Bone, Plasma));
+         neighborhood.Name = NEIGHBORHOOD_NAME;
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void the_neighborhood_created_by_the_first_module_should_have_been_removed_from_the_model()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_warn_that_the_neighborhood_was_not_added_to_the_simulation()
+      {
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+   }
+
+   internal class When_overwriting_a_neighborhood_with_neighbors_that_cannot_be_resolved : concern_for_ModuleIntegration
+   {
+      private const string NEIGHBORHOOD_NAME = "art_pls_to_bon_pls";
+      private INeighborhoodBuilderFactory _neighborhoodFactory;
+      private Module _module2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodFactory = IoC.Resolve<INeighborhoodBuilderFactory>();
+      }
+
+      protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x =>
+      {
+         var configuration = x.CreateSimulationConfigurationForOverrideMergeBehavior();
+         _module2 = configuration.ModuleConfigurations[1].Module;
+
+         //redefine a neighborhood of the first module with a neighbor that cannot be resolved in the merged structure
+         var neighborhood = _neighborhoodFactory.CreateBetween(new ObjectPath(Constants.ORGANISM, "DOES_NOT_EXIST"), new ObjectPath(Constants.ORGANISM, Bone, Plasma));
+         neighborhood.Name = NEIGHBORHOOD_NAME;
+         _module2.SpatialStructure.AddNeighborhood(neighborhood);
+
+         return configuration;
+      };
+
+      [Observation]
+      public void the_neighborhood_created_by_the_first_module_should_have_been_removed_from_the_model()
+      {
+         _model.Neighborhoods.FindByName(NEIGHBORHOOD_NAME).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_warn_that_the_neighborhood_was_not_added_to_the_simulation()
+      {
+         _result.ValidationResult.Messages.FirstOrDefault(x => x.Text.Equals(Warning.NeighborhoodWasNotFoundInModel(NEIGHBORHOOD_NAME, _module2.SpatialStructure.DisplayName))).ShouldNotBeNull();
+      }
+   }
+
    internal class When_running_the_case_study_for_module_integration_with_merge_behavior_overwrite_for_eventGroup : concern_for_ModuleIntegration
    {
       protected override Func<ModuleHelperForSpecs, SimulationConfiguration> SimulationConfigurationBuilder() => x => x.CreateSimulationConfigurationForOverrideMergeBehavior();

--- a/tests/OSPSuite.Core.IntegrationTests/Serializers/NeighborhoodBuilderXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/Serializers/NeighborhoodBuilderXmlSerializerSpecs.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
@@ -27,6 +28,19 @@ namespace OSPSuite.Core.Serializers
          var cont2 = SerializeAndDeserialize(cont1);
          var x2 = cont2.FindByName(x1.Name).DowncastTo<NeighborhoodBuilder>();
          AssertForSpecs.AreEqualNeighborhoodBuilder(x1, x2);
+      }
+
+      [Test]
+      public void TestSerializationWithoutNeighbors()
+      {
+         //a neighborhood builder without neighbors removes the neighborhood with the same name when merging modules
+         var x1 = CreateObject<NeighborhoodBuilder>().WithName("Nena.Builder.WithoutNeighbors")
+            .WithMode(ContainerMode.Logical);
+
+         var cont1 = new Container {C1, x1}.WithId("titi");
+         var cont2 = SerializeAndDeserialize(cont1);
+         var x2 = cont2.FindByName(x1.Name).DowncastTo<NeighborhoodBuilder>();
+         x2.HasNoNeighbors.ShouldBeTrue();
       }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Domain/NeighborhoodBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Domain/NeighborhoodBuilderSpecs.cs
@@ -12,6 +12,185 @@ namespace OSPSuite.Core.Domain
       }
    }
 
+   public class When_checking_the_neighbor_paths_of_a_neighborhood_builder_without_neighbors : concern_for_NeighborhoodBuilder
+   {
+      [Observation]
+      public void should_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_have_defined_neighbor_paths()
+      {
+         sut.HasDefinedNeighborPaths.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void the_neighbor_paths_should_never_be_null()
+      {
+         sut.FirstNeighborPath.ShouldNotBeNull();
+         sut.SecondNeighborPath.ShouldNotBeNull();
+      }
+   }
+
+   public class When_setting_a_neighbor_path_to_null : concern_for_NeighborhoodBuilder
+   {
+      protected override void Because()
+      {
+         sut.FirstNeighborPath = null;
+         sut.SecondNeighborPath = null;
+      }
+
+      [Observation]
+      public void the_neighbor_paths_should_be_replaced_by_empty_paths()
+      {
+         sut.FirstNeighborPath.ShouldNotBeNull();
+         sut.SecondNeighborPath.ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void the_neighborhood_builder_should_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeTrue();
+      }
+   }
+
+   public class When_checking_the_neighbor_paths_of_a_neighborhood_builder_with_empty_neighbor_paths : concern_for_NeighborhoodBuilder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.FirstNeighborPath = new ObjectPath();
+         sut.SecondNeighborPath = new ObjectPath();
+      }
+
+      [Observation]
+      public void should_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_have_defined_neighbor_paths()
+      {
+         sut.HasDefinedNeighborPaths.ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_the_neighbor_paths_of_a_neighborhood_builder_with_only_one_neighbor : concern_for_NeighborhoodBuilder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.FirstNeighborPath = new ObjectPath("root", "first");
+      }
+
+      [Observation]
+      public void should_not_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_not_have_defined_neighbor_paths()
+      {
+         sut.HasDefinedNeighborPaths.ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_the_neighbor_paths_of_a_neighborhood_builder_with_two_neighbors : concern_for_NeighborhoodBuilder
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.FirstNeighborPath = new ObjectPath("root", "first");
+         sut.SecondNeighborPath = new ObjectPath("root", "second");
+      }
+
+      [Observation]
+      public void should_not_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_have_defined_neighbor_paths()
+      {
+         sut.HasDefinedNeighborPaths.ShouldBeTrue();
+      }
+   }
+
+   public class When_resolving_the_references_of_a_neighborhood_builder_without_neighbors : concern_for_NeighborhoodBuilder
+   {
+      private Container _root;
+
+      protected override void Context()
+      {
+         base.Context();
+         _root = new Container {Name = "root"};
+      }
+
+      protected override void Because()
+      {
+         sut.ResolveReference(new[] {_root});
+      }
+
+      [Observation]
+      public void should_not_resolve_any_neighbor()
+      {
+         sut.FirstNeighbor.ShouldBeNull();
+         sut.SecondNeighbor.ShouldBeNull();
+      }
+   }
+
+   public class When_resolving_the_references_of_a_neighborhood_builder_with_empty_neighbor_paths : concern_for_NeighborhoodBuilder
+   {
+      private Container _root;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.FirstNeighborPath = new ObjectPath();
+         sut.SecondNeighborPath = new ObjectPath();
+         _root = new Container {Name = "root"};
+      }
+
+      protected override void Because()
+      {
+         sut.ResolveReference(new[] {_root});
+      }
+
+      [Observation]
+      public void should_not_resolve_the_neighbors_to_the_container_itself()
+      {
+         sut.FirstNeighbor.ShouldBeNull();
+         sut.SecondNeighbor.ShouldBeNull();
+      }
+   }
+
+   public class When_updating_a_neighborhood_builder_from_a_neighborhood_builder_without_neighbors : concern_for_NeighborhoodBuilder
+   {
+      private NeighborhoodBuilder _sourceNeighborhoodBuilder;
+
+      protected override void Context()
+      {
+         base.Context();
+         _sourceNeighborhoodBuilder = new NeighborhoodBuilder();
+      }
+
+      protected override void Because()
+      {
+         sut.UpdatePropertiesFrom(_sourceNeighborhoodBuilder, null);
+      }
+
+      [Observation]
+      public void should_also_have_no_neighbors()
+      {
+         sut.HasNoNeighbors.ShouldBeTrue();
+      }
+   }
+
    public class When_setting_the_first_neighbor_and_second_neighbor_path : concern_for_NeighborhoodBuilder
    {
       protected override void Context()

--- a/tests/OSPSuite.Core.Tests/Mappers/NeighborhoodBuilderToNeighborhoodMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/NeighborhoodBuilderToNeighborhoodMapperSpecs.cs
@@ -31,6 +31,33 @@ namespace OSPSuite.Core.Mappers
       }
    }
 
+   internal class When_mapping_a_neighborhood_builder_with_an_undefined_neighbor_path : concern_for_NeighborhoodBuilderToNeighborhoodMapper
+   {
+      private NeighborhoodBuilder _neighborhoodBuilder;
+      private Neighborhood _neighborhood;
+      private ModelConfiguration _modelConfiguration;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodBuilder = new NeighborhoodBuilder().WithName("tralala");
+         //only the first neighbor path is defined
+         _neighborhoodBuilder.FirstNeighborPath = new ObjectPath("First");
+         _modelConfiguration = new ModelConfiguration(A.Fake<IModel>(), new SimulationConfiguration(), A.Fake<SimulationBuilder>());
+      }
+
+      protected override void Because()
+      {
+         _neighborhood = sut.MapFrom(_neighborhoodBuilder, new List<string>(), new List<string>(), _modelConfiguration);
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _neighborhood.ShouldBeNull();
+      }
+   }
+
    internal class When_mapping_a_neighborhood_builder_to_a_neighborhood : concern_for_NeighborhoodBuilderToNeighborhoodMapper
    {
       private NeighborhoodBuilder _neighborhoodBuilder;

--- a/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/SimulationConfigurationValidatorSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Core.Services
 {
@@ -52,6 +53,39 @@ namespace OSPSuite.Core.Services
       public void the_error_should_only_be_reported_once_instead_of_for_both_neighborhoods()
       {
          _result.Messages.Count().ShouldBeEqualTo(1);
+      }
+   }
+
+   internal class When_validating_a_simulation_configuration_with_multiple_neighborhoods_without_neighbors : concern_for_SimulationConfigurationValidator
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private ValidationResult _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(moduleWithNeighborhoodWithoutNeighbors("name1")));
+         _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(moduleWithNeighborhoodWithoutNeighbors("name2")));
+      }
+
+      private Module moduleWithNeighborhoodWithoutNeighbors(string neighborhoodName)
+      {
+         var spatialStructure = new SpatialStructure { NeighborhoodsContainer = new Container() };
+         spatialStructure.AddNeighborhood(new NeighborhoodBuilder().WithName(neighborhoodName));
+
+         return new Module { spatialStructure };
+      }
+
+      protected override void Because()
+      {
+         _result = sut.Validate(_simulationConfiguration);
+      }
+
+      [Observation]
+      public void should_not_report_the_neighborhoods_as_equivalent()
+      {
+         _result.ValidationState.ShouldBeEqualTo(ValidationState.Valid, _result.Messages.Select(x => x.Text).ToString("\n"));
       }
    }
 

--- a/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
+++ b/tests/OSPSuite.HelpersForTests/ModuleHelperForSpecs.cs
@@ -71,13 +71,9 @@ namespace OSPSuite.Helpers
          };
 
          var module1 = createModule1();
-         var bonePlasma = module1.SpatialStructure.TopContainers
-            .FindByName(ORGANISM)
-            .FindByName(Bone)
-            .WithName(Plasma);
-
-         var logicalContainer = createContainerWithName(Plasma, ContainerMode.Logical);
-         addLogicalNeighborhood(module1.SpatialStructure,(IContainer)bonePlasma, logicalContainer);
+         //Bone is a logical container in the spatial structure of module1
+         var bone = module1.SpatialStructure.TopContainers.FindByName(ORGANISM).Container(Bone);
+         addLogicalNeighborhood(module1.SpatialStructure, bone);
          var module2 = createModule2();
          var module3 = createModule3();
 
@@ -450,18 +446,15 @@ namespace OSPSuite.Helpers
          neighborhood6.AddTag("Cell2Plasma");
          neighborhood6.AddParameter(NewConstantParameter("SA", 22));
 
-         var neighborhood7 = _neighborhoodFactory.CreateBetween(bonePlasma, boneCell).WithName("does_not_match_existing");
-         neighborhood7.FirstNeighborPath = new ObjectPath("Organism", "NOPE");
-         spatialStructure.AddNeighborhood(neighborhood7);
-
          spatialStructure.ResolveReferencesInNeighborhoods();
          return spatialStructure;
       }
 
-      private void addLogicalNeighborhood(SpatialStructure spatialStructure, IContainer bonePlasma, IContainer logicalContainer)
+      private void addLogicalNeighborhood(SpatialStructure spatialStructure, IContainer bone)
       {
-         var neighborhood8 = _neighborhoodFactory.CreateBetween(bonePlasma, logicalContainer).WithName("not_physical");
-         neighborhood8.FirstNeighborPath = new ObjectPath("Organism", "NOPE");
+         //neighborhood between a physical container (bone plasma) and a logical container (bone)
+         var bonePlasma = bone.Container(Plasma);
+         var neighborhood8 = _neighborhoodFactory.CreateBetween(bonePlasma, bone).WithName("not_physical");
          spatialStructure.AddNeighborhood(neighborhood8);
       }
 


### PR DESCRIPTION
Fixes #2918

When merging modules, only the neighborhoods whose neighbors resolved were passed to the merge step. A module redefining a neighborhood with unresolvable neighbors therefore had its definition dropped, silently leaving the version created by an earlier module in the model.

Such a redefinition now removes the existing neighborhood, for both `Extend` and `Overwrite`. This makes it possible to remove a neighborhood from another module, and makes the existing "was not added to the simulation" warning accurate.

Covered by two new fixtures in `ModuleIntegrationTests`, one per merge behavior; both fail without the fix. Verified manually in MoBi.

We are implementing this with UI in MoBi to support

Blank neighborhoods are valid
<img width="699" height="213" alt="image" src="https://github.com/user-attachments/assets/39546c47-578b-4973-9e7c-fdb80f9f1b5a" />

Removed neighborhoods are listed. They also have notification messages
<img width="860" height="179" alt="image" src="https://github.com/user-attachments/assets/bda06dd6-013c-4989-b1ef-993a365a5df6" />

If you specify an invalid neighbor in any module, the simulation will not build and you will see this error
<img width="1034" height="163" alt="image" src="https://github.com/user-attachments/assets/eb4f3344-4e3d-46dc-b587-356d8655e46a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved neighborhood handling when referenced neighbors are missing or unresolved.
  * Neighborless definitions no longer attempt invalid path access.
  * Invalid neighborhoods now produce clear errors, while removed neighborhoods generate warnings.
  * Logical neighbors are reported as warnings and remain in the merged model where applicable.
  * Improved handling of neighborhoods that extend or overwrite existing definitions.

* **Tests**
  * Added coverage for missing, logical, neighborless, extended, and overwritten neighborhoods, including serialization and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->