### PR TITLE
Fixes #2917 Take the administered molecule from the last module when extending

### DIFF
--- a/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
+++ b/src/OSPSuite.Core/Domain/Builder/SimulationBuilder.cs
@@ -167,6 +167,50 @@ namespace OSPSuite.Core.Domain.Builder
          targetBuilder.EventGroupType = sourceBuilder.EventGroupType;
 
          mergeDescriptorCriteria(targetBuilder.SourceCriteria, sourceBuilder.SourceCriteria);
+
+         mergeApplications(targetBuilder, sourceBuilder);
+      }
+
+      /// <summary>
+      ///    Merges the given event group builders, and all equally named event group builders defined under them, as
+      ///    applications. This is required because <see cref="ApplicationBuilder.MoleculeName" /> is a property and not a
+      ///    child entity and is therefore not covered by the generic container merge
+      /// </summary>
+      private void mergeApplications(EventGroupBuilder targetBuilder, EventGroupBuilder sourceBuilder)
+      {
+         if (targetBuilder is ApplicationBuilder targetApplication && sourceBuilder is ApplicationBuilder sourceApplication)
+            mergeApplication(targetApplication, sourceApplication);
+
+         var targetEventGroups = targetBuilder.GetChildren<EventGroupBuilder>().ToList();
+         foreach (var sourceEventGroup in sourceBuilder.GetChildren<EventGroupBuilder>().ToList())
+         {
+            //The container merge already placed every source event group in the target, so this is only null when the
+            //target uses that name for something that is not an event group. For a group that was added as is, target
+            //and source are the same instance and merging them is a no-op
+            var targetEventGroup = targetEventGroups.FirstOrDefault(x => string.Equals(x.Name, sourceEventGroup.Name));
+            if (targetEventGroup != null)
+               mergeApplications(targetEventGroup, sourceEventGroup);
+         }
+      }
+
+      private void mergeApplication(ApplicationBuilder targetApplication, ApplicationBuilder sourceApplication)
+      {
+         //Application molecules only define where the administered molecule is applied. They are meaningless for another
+         //molecule, so the ones inherited from the base builder are dropped when the administered molecule changes
+         if (!string.Equals(targetApplication.MoleculeName, sourceApplication.MoleculeName))
+            removeApplicationMoleculesNotDefinedIn(targetApplication, sourceApplication);
+
+         targetApplication.MoleculeName = sourceApplication.MoleculeName;
+      }
+
+      private void removeApplicationMoleculesNotDefinedIn(ApplicationBuilder targetApplication, ApplicationBuilder sourceApplication)
+      {
+         //the container merge added the application molecules of the source to the target by name
+         var sourceMoleculeNames = sourceApplication.Molecules.Select(x => x.Name).ToList();
+         targetApplication.Molecules
+            .Where(x => !sourceMoleculeNames.Contains(x.Name))
+            .ToList()
+            .Each(targetApplication.RemoveMolecule);
       }
 
       private void mergeReactions(ReactionBuilder targetReaction, BuilderSource<ReactionBuilder> sourceReaction)

--- a/tests/OSPSuite.Core.IntegrationTests/SimulationBuilderSpecs.cs
+++ b/tests/OSPSuite.Core.IntegrationTests/SimulationBuilderSpecs.cs
@@ -22,6 +22,19 @@ internal class concern_for_SimulationBuilder : ContextForIntegration<SimulationB
       _simulationConfiguration = IoC.Resolve<ModelHelperForSpecs>().CreateSimulationConfiguration();
       _modelHelper = IoC.Resolve<ModelHelperForSpecs>();
    }
+
+   protected ApplicationBuilder CreateApplicationBuilder(string name, string moleculeName, string applicationMoleculeName, string containerName)
+   {
+      var applicationBuilder = new ApplicationBuilder().WithName(name);
+      applicationBuilder.MoleculeName = moleculeName;
+
+      var applicationMoleculeBuilder = new ApplicationMoleculeBuilder().WithName(applicationMoleculeName).WithParentContainer(applicationBuilder);
+      applicationMoleculeBuilder.RelativeContainerPath = new ObjectPath("..", containerName);
+
+      return applicationBuilder;
+   }
+
+   protected ApplicationBuilder ApplicationBuilderFor(string name) => sut.EventGroups.OfType<ApplicationBuilder>().Single(x => x.Name == name);
 }
 
 
@@ -546,4 +559,102 @@ internal class When_extending_event_group_builder_with_source_criteria : concern
       var eventGroup = sut.EventGroups.Single(x => x.Name == "EG1");
       eventGroup.SourceCriteria.Operator.ShouldBeEqualTo(CriteriaOperator.And);
    }
+}
+
+internal class When_extending_an_application_builder_with_another_administered_molecule : concern_for_SimulationBuilder
+{
+   protected override void Context()
+   {
+      base.Context();
+
+      var application1 = CreateApplicationBuilder("App1", "MoleculeX", "AppMoleculeX", "C1");
+      var module1 = new Module { new EventGroupBuildingBlock { application1 } };
+
+      var application2 = CreateApplicationBuilder("App1", "MoleculeY", "AppMoleculeY", "C2");
+      var module2 = new Module { new EventGroupBuildingBlock { application2 } };
+      module2.MergeBehavior = MergeBehavior.Extend;
+
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2));
+      sut = new SimulationBuilderForSpecs(_simulationConfiguration);
+   }
+
+   [Observation]
+   public void the_administered_molecule_should_be_from_module_2()
+   {
+      ApplicationBuilderFor("App1").MoleculeName.ShouldBeEqualTo("MoleculeY");
+   }
+
+   [Observation]
+   public void the_application_molecules_should_only_be_the_ones_from_module_2()
+   {
+      ApplicationBuilderFor("App1").Molecules.Select(x => x.Name).ShouldOnlyContain("AppMoleculeY");
+   }
+}
+
+internal class When_extending_an_application_builder_with_the_same_administered_molecule : concern_for_SimulationBuilder
+{
+   protected override void Context()
+   {
+      base.Context();
+
+      var application1 = CreateApplicationBuilder("App1", "MoleculeX", "AppMolecule1", "C1");
+      var module1 = new Module { new EventGroupBuildingBlock { application1 } };
+
+      var application2 = CreateApplicationBuilder("App1", "MoleculeX", "AppMolecule2", "C2");
+      var module2 = new Module { new EventGroupBuildingBlock { application2 } };
+      module2.MergeBehavior = MergeBehavior.Extend;
+
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2));
+      sut = new SimulationBuilderForSpecs(_simulationConfiguration);
+   }
+
+   [Observation]
+   public void the_administered_molecule_should_be_unchanged()
+   {
+      ApplicationBuilderFor("App1").MoleculeName.ShouldBeEqualTo("MoleculeX");
+   }
+
+   [Observation]
+   public void the_application_molecules_should_be_the_ones_from_both_modules()
+   {
+      ApplicationBuilderFor("App1").Molecules.Select(x => x.Name).ShouldOnlyContain("AppMolecule1", "AppMolecule2");
+   }
+}
+
+internal class When_extending_an_event_group_builder_containing_an_application_with_another_administered_molecule : concern_for_SimulationBuilder
+{
+   protected override void Context()
+   {
+      base.Context();
+
+      var eventGroup1 = new EventGroupBuilder().WithName("EG1");
+      CreateApplicationBuilder("App1", "MoleculeX", "AppMoleculeX", "C1").WithParentContainer(eventGroup1);
+      var module1 = new Module { new EventGroupBuildingBlock { eventGroup1 } };
+
+      var eventGroup2 = new EventGroupBuilder().WithName("EG1");
+      CreateApplicationBuilder("App1", "MoleculeY", "AppMoleculeY", "C2").WithParentContainer(eventGroup2);
+      var module2 = new Module { new EventGroupBuildingBlock { eventGroup2 } };
+      module2.MergeBehavior = MergeBehavior.Extend;
+
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module1));
+      _simulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(module2));
+      sut = new SimulationBuilderForSpecs(_simulationConfiguration);
+   }
+
+   [Observation]
+   public void the_administered_molecule_should_be_from_module_2()
+   {
+      nestedApplicationBuilder().MoleculeName.ShouldBeEqualTo("MoleculeY");
+   }
+
+   [Observation]
+   public void the_application_molecules_should_only_be_the_ones_from_module_2()
+   {
+      nestedApplicationBuilder().Molecules.Select(x => x.Name).ShouldOnlyContain("AppMoleculeY");
+   }
+
+   private ApplicationBuilder nestedApplicationBuilder() =>
+      sut.EventGroups.Single(x => x.Name == "EG1").GetChildren<ApplicationBuilder>().Single(x => x.Name == "App1");
 }


### PR DESCRIPTION
Fixes #2917

Under merge behavior "Extend", an equally named application kept the **first** module's administered molecule and the extending module had no effect. `mergeEvents` copied only `EventGroupType` and merged `SourceCriteria`; `ApplicationBuilder.MoleculeName` is a property rather than a child entity, so the generic container merge never touched it either.

`mergeApplications` now walks the target and source event group trees in lockstep, pairing children by name, and transfers the administered molecule for every matched application pair. The walk is recursive because applications can sit at the root of the Events building block *or* nested inside event groups — MoBi offers both — and `mergeEvents` is only ever handed the top-level builder. The nested case was verified broken before the fix, so handling only the builder passed to `mergeEvents` would have left the bug reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation extension handling for application molecules.
  * When the administered molecule changes, outdated application molecules are removed.
  * Applications nested within event groups now merge correctly.
  * Applications with the same administered molecule retain and combine molecules from both modules.

* **Tests**
  * Added coverage for application and nested event-group merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->