### PR TITLE
Fixes #2921 Make ModelCoreSimulation.Model virtual

### DIFF
--- a/src/OSPSuite.Core/Domain/ModelCoreSimulation.cs
+++ b/src/OSPSuite.Core/Domain/ModelCoreSimulation.cs
@@ -54,7 +54,7 @@ namespace OSPSuite.Core.Domain
 
    public class ModelCoreSimulation : ObjectBase, IModelCoreSimulation
    {
-      public IModel Model { get; set; }
+      public virtual IModel Model { get; set; }
 
       public SimulationConfiguration Configuration { get; set; }
 


### PR DESCRIPTION
Makes `ModelCoreSimulation.Model` `virtual` so MoBi can override the getter and construct a simulation's model lazily on first access instead of eagerly when a project is opened.

One-line, behaviorally inert change for existing consumers.

Enables lazy simulation loading in Open-Systems-Pharmacology/MoBi#1908 (draft PR Open-Systems-Pharmacology/MoBi#2452), which pins to a local build of this change until it is released.

Fixes #2921

🤖 Generated with [Claude Code](https://claude.com/claude-code)