### PR TITLE
Fixes #2924 Scrollbars in HeavyWorkView progress popup at 125% scaling

### DIFF
--- a/src/OSPSuite.UI/Views/HeavyWorkView.Designer.cs
+++ b/src/OSPSuite.UI/Views/HeavyWorkView.Designer.cs
@@ -140,7 +140,6 @@
          this.Controls.Add(this.uxLayoutControl);
          this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
          this.Margin = new System.Windows.Forms.Padding(5);
-         this.MaximumSize = new System.Drawing.Size(250, 155);
          this.Name = "HeavyWorkView";
          this.Text = "Processing...";
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();

--- a/src/OSPSuite.UI/Views/HeavyWorkView.cs
+++ b/src/OSPSuite.UI/Views/HeavyWorkView.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System.Drawing;
+using System.Windows.Forms;
 using DevExpress.XtraEditors;
 using OSPSuite.Assets;
 using OSPSuite.Presentation.Presenters;
@@ -9,6 +10,10 @@ namespace OSPSuite.UI.Views
 {
    public partial class HeavyWorkView : BaseView, IHeavyWorkView
    {
+      private const int VIEW_WIDTH = 172;
+      private const int VIEW_HEIGHT = 110;
+      private const int VIEW_HEIGHT_WITH_CANCEL = 155;
+
       private IHeavyWorkPresenter _presenter;
 
       public HeavyWorkView()
@@ -16,6 +21,8 @@ namespace OSPSuite.UI.Views
          InitializeComponent();
          FormBorderStyle = FormBorderStyle.None;
          StartPosition = FormStartPosition.CenterParent;
+         //scrollbars should never appear in the progress popup, whatever the screen scaling
+         uxLayoutControl.AutoScroll = false;
          btnCancel.InitWithImage(ApplicationIcons.Cancel, Captions.CancelButton, ImageLocation.MiddleRight);
          btnCancel.Text = Captions.CancelButton;
          btnCancel.Click += (o, e) => OnEvent(cancelButtonClick);
@@ -31,11 +38,13 @@ namespace OSPSuite.UI.Views
       private void setLayout()
       {
          ShowInTaskbar = false;
+         //sizes defined in the designer are not scaled with screen DPI and need to be set explicitly
+         ClientSize = new Size(UIConstants.Size.ScaleForScreenDPI(VIEW_WIDTH), UIConstants.Size.ScaleForScreenDPI(VIEW_HEIGHT));
          if (CancelVisible)
          {
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             MaximizeBox = false;
-            Height = MaximumSize.Height;
+            Height = UIConstants.Size.ScaleForScreenDPI(VIEW_HEIGHT_WITH_CANCEL);
             Opacity = 1.0;
          }
          else


### PR DESCRIPTION
Fixes #2924

## Problem

At 125% Windows font scaling, the `HeavyWorkView` progress popup ("Loading project...", observed-data import, etc.) shows scrollbars around the progress bar (reported in Open-Systems-Pharmacology/PK-Sim#3641). The view was rewritten in #2459 to host the progress bar in a `UxLayoutControl`, but the form keeps fixed designer sizes (`ClientSize` 172×110, `MaximumSize` 250×155) that are not scaled with screen DPI — at 125% the scaled layout content overflows the capped form and the layout control shows its built-in scrollbars.

## Changes

- `uxLayoutControl.AutoScroll = false` so scrollbars can never appear in the popup
- Removed the unscaled `MaximumSize` from the designer
- `setLayout()` now sets the form size explicitly using the existing `UIConstants.Size.ScaleForScreenDPI` helper (same values as before at 100%: 172×110 borderless, height 155 with cancel button visible)

Pure UI change, no tests added per repo convention.

## Verification

Needs a visual check at 100% and 125% scaling: open a project in PK-Sim (popup without cancel) and import a large observed-data file in MoBi (popup with cancel) — no scrollbars, progress bar and cancel button fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
