### PR TITLE
Fixes #2928 Share the simulation analysis tab context menu across apps

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -2120,6 +2120,8 @@ namespace OSPSuite.Assets
       public static readonly string Remove = "Remove...";
       public static readonly string DeleteSubMenu = "Delete";
       public static readonly string Rename = "Rename...";
+      public static readonly string RemoveAnalysis = "Remove";
+      public static readonly string RemoveAllAnalyses = "Remove All";
       public static readonly string GroupBy = "Create Subfolders By...";
       public static readonly string DeleteSubFoldersAndKeepData = "All Subfolders and Keep Data";
       public static readonly string DeleteSubFoldersAndData = "All Subfolders and Data";

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
@@ -59,9 +60,25 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public virtual void InitializeAnalysis(TChart chart)
       {
+         unbindChart();
          Chart = chart;
+         Chart.PropertyChanged += chartPropertyChanged;
          BindChartToEditors();
          InitEditorLayout();
+      }
+
+      private void unbindChart()
+      {
+         if (Chart == null)
+            return;
+
+         Chart.PropertyChanged -= chartPropertyChanged;
+      }
+
+      private void chartPropertyChanged(object sender, PropertyChangedEventArgs e)
+      {
+         if (string.Equals(e.PropertyName, nameof(Chart.Name)))
+            updateViewCaptionFromChart();
       }
 
       protected Action PostEditorLayout
@@ -168,6 +185,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public virtual void Clear()
       {
+         unbindChart();
          _chartPresenterContext.Clear();
          ChartEditorPresenter.ColumnSettingsChanged -= columnSettingsChanged;
          ChartEditorPresenter.ChartChanged -= ChartChanged;

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartPresenter.cs
@@ -78,7 +78,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       private void chartPropertyChanged(object sender, PropertyChangedEventArgs e)
       {
          if (string.Equals(e.PropertyName, nameof(Chart.Name)))
-            updateViewCaptionFromChart();
+            ChartChanged();
       }
 
       protected Action PostEditorLayout

--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/SimulationAnalysisPresenterContextMenu.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/SimulationAnalysisPresenterContextMenu.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.UICommands;
+using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Utility.Container.IContainer;
+
+namespace OSPSuite.Presentation.Presenters.ContextMenus
+{
+   public class SimulationAnalysisPresenterContextMenu : ContextMenu<ISimulationAnalysisPresenter, IPresenterWithAnalyses>
+   {
+      public SimulationAnalysisPresenterContextMenu(ISimulationAnalysisPresenter simulationAnalysisPresenter, IPresenterWithAnalyses presenterWithAnalyses, IContainer container)
+         : base(simulationAnalysisPresenter, presenterWithAnalyses, container)
+      {
+      }
+
+      protected override IEnumerable<IMenuBarItem> AllMenuItemsFor(ISimulationAnalysisPresenter simulationAnalysisPresenter, IPresenterWithAnalyses presenterWithAnalyses)
+      {
+         yield return CreateMenuButton.WithCaption(MenuNames.Clone)
+            .WithActionCommand(() => presenterWithAnalyses.CloneAnalysis(simulationAnalysisPresenter.Analysis))
+            .WithIcon(ApplicationIcons.Clone);
+
+         yield return CreateMenuButton.WithCaption(MenuNames.RemoveAnalysis)
+            .WithActionCommand(() => presenterWithAnalyses.RemoveAnalysis(simulationAnalysisPresenter))
+            .WithIcon(ApplicationIcons.Close);
+
+         yield return CreateMenuButton.WithCaption(MenuNames.RemoveAllAnalyses)
+            .WithActionCommand(presenterWithAnalyses.RemoveAllAnalyses);
+
+         yield return CreateMenuButton.WithCaption(MenuNames.Rename)
+            .WithCommandFor<RenameSimulationAnalysisUICommand, ISimulationAnalysis>(simulationAnalysisPresenter.Analysis, _container)
+            .WithIcon(ApplicationIcons.Rename)
+            .AsGroupStarter();
+      }
+   }
+
+   public class SimulationAnalysisPresenterContextMenuSpecificationFactory : IContextMenuSpecificationFactory<ISimulationAnalysisPresenter>
+   {
+      private readonly IContainer _container;
+
+      public SimulationAnalysisPresenterContextMenuSpecificationFactory(IContainer container)
+      {
+         _container = container;
+      }
+
+      public IContextMenu CreateFor(ISimulationAnalysisPresenter simulationAnalysisPresenter, IPresenterWithContextMenu<ISimulationAnalysisPresenter> presenter)
+      {
+         return new SimulationAnalysisPresenterContextMenu(simulationAnalysisPresenter, presenter.DowncastTo<IPresenterWithAnalyses>(), _container);
+      }
+
+      public bool IsSatisfiedBy(ISimulationAnalysisPresenter simulationAnalysisPresenter, IPresenterWithContextMenu<ISimulationAnalysisPresenter> presenter)
+      {
+         return presenter.IsAnImplementationOf<IPresenterWithAnalyses>();
+      }
+   }
+}

--- a/src/OSPSuite.Presentation/Presenters/EditAnalyzablePresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/EditAnalyzablePresenter.cs
@@ -14,17 +14,21 @@ using OSPSuite.Presentation.Views;
 
 namespace OSPSuite.Presentation.Presenters
 {
+   public interface IPresenterWithAnalyses : IPresenterWithContextMenu<ISimulationAnalysisPresenter>
+   {
+      void RemoveAnalysis(ISimulationAnalysisPresenter simulationAnalysisPresenter);
+      void RemoveAllAnalyses();
+      void CloneAnalysis(ISimulationAnalysis analysis);
+   }
+
    public interface IEditAnalyzablePresenter :
       IListener<SimulationAnalysisCreatedEvent>,
       IListener<SimulationResultsUpdatedEvent>,
       IListener<SimulationStatusChangedEvent>,
-      IPresenterWithContextMenu<ISimulationAnalysisPresenter>, IPresenterWithSettings
+      IPresenterWithAnalyses, IPresenterWithSettings
 
    {
-      void RemoveAnalysis(ISimulationAnalysisPresenter simulationAnalysisPresenter);
-      void RemoveAllAnalyses();
       void SetSelectedTabIndex(int tabIndex);
-      void CloneAnalysis(ISimulationAnalysis analysis);
    }
 
    public interface IEditAnalyzablePresenter<TAnalyzable> : ISingleStartPresenter<TAnalyzable>, IEditAnalyzablePresenter where TAnalyzable : IAnalysable

--- a/src/OSPSuite.Presentation/UICommands/RenameSimulationAnalysisUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RenameSimulationAnalysisUICommand.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Utility.Events;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public class RenameSimulationAnalysisUICommand : RenameObjectBaseUICommand<ISimulationAnalysis>
+   {
+      public RenameSimulationAnalysisUICommand(IOSPSuiteExecutionContext context, IEventPublisher eventPublisher, IApplicationController applicationController)
+         : base(context, eventPublisher, applicationController)
+      {
+      }
+
+      protected override IEnumerable<string> ForbiddenNamesFor(ISimulationAnalysis analysis)
+      {
+         return analysis.Analysable?.Analyses.AllNames() ?? Enumerable.Empty<string>();
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/RenameSimulationAnalysisUICommandSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/RenameSimulationAnalysisUICommandSpecs.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Events;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.UICommands;
+using OSPSuite.Utility.Events;
+
+namespace OSPSuite.Presentation.Presentation
+{
+   public abstract class concern_for_RenameSimulationAnalysisUICommand : ContextSpecification<RenameSimulationAnalysisUICommand>
+   {
+      protected IOSPSuiteExecutionContext _executionContext;
+      protected IEventPublisher _eventPublisher;
+      protected IApplicationController _applicationController;
+      protected IRenameObjectPresenter _renameObjectPresenter;
+      protected ISimulationAnalysis _analysis;
+      protected ISimulationAnalysis _siblingAnalysis;
+      protected IAnalysable _analysable;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IOSPSuiteExecutionContext>();
+         _eventPublisher = A.Fake<IEventPublisher>();
+         _applicationController = A.Fake<IApplicationController>();
+         _renameObjectPresenter = A.Fake<IRenameObjectPresenter>();
+         A.CallTo(() => _applicationController.Start<IRenameObjectPresenter>()).Returns(_renameObjectPresenter);
+
+         _analysis = A.Fake<ISimulationAnalysis>();
+         _analysis.Name = "Time Profile";
+         _siblingAnalysis = A.Fake<ISimulationAnalysis>();
+         _siblingAnalysis.Name = "Sibling Analysis";
+         _analysable = A.Fake<IAnalysable>();
+         A.CallTo(() => _analysable.Analyses).Returns(new[] {_analysis, _siblingAnalysis});
+         A.CallTo(() => _analysis.Analysable).Returns(_analysable);
+
+         sut = new RenameSimulationAnalysisUICommand(_executionContext, _eventPublisher, _applicationController);
+         sut.For(_analysis);
+      }
+   }
+
+   public class When_renaming_a_simulation_analysis : concern_for_RenameSimulationAnalysisUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _renameObjectPresenter.NewNameFrom(_analysis, A<IEnumerable<string>>._, null)).Returns("New Name");
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_forbid_the_names_of_all_analyses_of_the_analysable()
+      {
+         A.CallTo(() => _renameObjectPresenter.NewNameFrom(_analysis, A<IEnumerable<string>>.That.Matches(x => x.Contains(_siblingAnalysis.Name)), null)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_rename_the_analysis()
+      {
+         _analysis.Name.ShouldBeEqualTo("New Name");
+      }
+
+      [Observation]
+      public void should_publish_a_renamed_event_for_the_analysis()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<RenamedEvent>.That.Matches(x => Equals(x.RenamedObject, _analysis)))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_notify_a_project_change()
+      {
+         A.CallTo(() => _executionContext.ProjectChanged()).MustHaveHappened();
+      }
+   }
+
+   public class When_the_rename_of_a_simulation_analysis_is_canceled : concern_for_RenameSimulationAnalysisUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _renameObjectPresenter.NewNameFrom(_analysis, A<IEnumerable<string>>._, null)).Returns(string.Empty);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_not_rename_the_analysis()
+      {
+         _analysis.Name.ShouldBeEqualTo("Time Profile");
+      }
+
+      [Observation]
+      public void should_not_publish_any_renamed_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<RenamedEvent>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_renaming_a_simulation_analysis_that_does_not_belong_to_an_analysable : concern_for_RenameSimulationAnalysisUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _analysis.Analysable).Returns(null);
+         A.CallTo(() => _renameObjectPresenter.NewNameFrom(_analysis, A<IEnumerable<string>>._, null)).Returns("New Name");
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_not_forbid_any_name()
+      {
+         A.CallTo(() => _renameObjectPresenter.NewNameFrom(_analysis, A<IEnumerable<string>>.That.Matches(x => !x.Any()), null)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimulationAnalysisPresenterContextMenuSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimulationAnalysisPresenterContextMenuSpecs.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.UICommands;
+using OSPSuite.Presentation.Views.ContextMenus;
+using OSPSuite.Utility.Events;
+using IContainer = OSPSuite.Utility.Container.IContainer;
+
+namespace OSPSuite.Presentation.Presentation
+{
+   public abstract class concern_for_SimulationAnalysisPresenterContextMenuSpecificationFactory : ContextSpecification<SimulationAnalysisPresenterContextMenuSpecificationFactory>
+   {
+      protected IContainer _container;
+      protected IContextMenuView _contextMenuView;
+      protected ISimulationAnalysisPresenter _simulationAnalysisPresenter;
+      protected IPresenterWithAnalyses _presenterWithAnalyses;
+
+      protected override void Context()
+      {
+         _container = A.Fake<IContainer>();
+         _contextMenuView = A.Fake<IContextMenuView>();
+         _simulationAnalysisPresenter = A.Fake<ISimulationAnalysisPresenter>();
+         _presenterWithAnalyses = A.Fake<IPresenterWithAnalyses>();
+
+         A.CallTo(() => _container.Resolve<IContextMenuView>()).Returns(_contextMenuView);
+         A.CallTo(() => _container.Resolve<RenameSimulationAnalysisUICommand>()).Returns(
+            new RenameSimulationAnalysisUICommand(A.Fake<IOSPSuiteExecutionContext>(), A.Fake<IEventPublisher>(), A.Fake<IApplicationController>()));
+
+         sut = new SimulationAnalysisPresenterContextMenuSpecificationFactory(_container);
+      }
+   }
+
+   public class When_checking_if_a_context_menu_can_be_created_for_a_presenter_managing_analyses : concern_for_SimulationAnalysisPresenterContextMenuSpecificationFactory
+   {
+      [Observation]
+      public void should_return_true_for_a_presenter_implementing_the_presenter_with_analyses_interface()
+      {
+         sut.IsSatisfiedBy(_simulationAnalysisPresenter, _presenterWithAnalyses).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_true_for_an_edit_analyzable_presenter()
+      {
+         sut.IsSatisfiedBy(_simulationAnalysisPresenter, A.Fake<IEditAnalyzablePresenter>()).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_false_for_any_other_presenter()
+      {
+         sut.IsSatisfiedBy(_simulationAnalysisPresenter, A.Fake<IPresenterWithContextMenu<ISimulationAnalysisPresenter>>()).ShouldBeFalse();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_a_simulation_analysis_presenter : concern_for_SimulationAnalysisPresenterContextMenuSpecificationFactory
+   {
+      private List<IMenuBarItem> _allMenuItems;
+      private ISimulationAnalysis _analysis;
+
+      protected override void Context()
+      {
+         base.Context();
+         _allMenuItems = new List<IMenuBarItem>();
+         _analysis = A.Fake<ISimulationAnalysis>();
+         A.CallTo(() => _simulationAnalysisPresenter.Analysis).Returns(_analysis);
+         A.CallTo(() => _contextMenuView.AddMenuItem(A<IMenuBarItem>._))
+            .Invokes(x => _allMenuItems.Add(x.GetArgument<IMenuBarItem>(0)));
+      }
+
+      protected override void Because()
+      {
+         sut.CreateFor(_simulationAnalysisPresenter, _presenterWithAnalyses);
+      }
+
+      [Observation]
+      public void should_create_a_menu_containing_clone_remove_remove_all_and_rename()
+      {
+         _allMenuItems.Select(x => x.Caption).ShouldOnlyContainInOrder(MenuNames.Clone, MenuNames.RemoveAnalysis, MenuNames.RemoveAllAnalyses, MenuNames.Rename);
+      }
+
+      [Observation]
+      public void clicking_the_clone_menu_should_clone_the_analysis()
+      {
+         menuButtonWithCaption(MenuNames.Clone).Command.Execute();
+         A.CallTo(() => _presenterWithAnalyses.CloneAnalysis(_analysis)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void clicking_the_remove_menu_should_remove_the_analysis()
+      {
+         menuButtonWithCaption(MenuNames.RemoveAnalysis).Command.Execute();
+         A.CallTo(() => _presenterWithAnalyses.RemoveAnalysis(_simulationAnalysisPresenter)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void clicking_the_remove_all_menu_should_remove_all_analyses()
+      {
+         menuButtonWithCaption(MenuNames.RemoveAllAnalyses).Command.Execute();
+         A.CallTo(() => _presenterWithAnalyses.RemoveAllAnalyses()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_rename_menu_should_start_a_new_group()
+      {
+         menuButtonWithCaption(MenuNames.Rename).BeginGroup.ShouldBeTrue();
+      }
+
+      private IMenuBarButton menuButtonWithCaption(string caption)
+      {
+         return _allMenuItems.OfType<IMenuBarButton>().First(x => string.Equals(x.Caption, caption));
+      }
+   }
+}

--- a/tests/OSPSuite.Presentation.Tests/Presentation/SimulationPredictedVsObservedChartPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/SimulationPredictedVsObservedChartPresenterSpecs.cs
@@ -26,7 +26,7 @@ namespace OSPSuite.Presentation.Presentation
 {
    public abstract class concern_for_SimulationPredictedVsObservedChartPresenter : ContextSpecification<SimulationPredictedVsObservedChartPresenter>
    {
-      private ISimulationVsObservedDataView _view;
+      protected ISimulationVsObservedDataView _view;
       private IChartEditorAndDisplayPresenter _chartEditorAndDisplayPresenter;
       private ICurveNamer _curveNamer;
       protected ISimulation _simulation;
@@ -150,6 +150,41 @@ namespace OSPSuite.Presentation.Presentation
          A.CallTo(() => _observedDataRepository.AllObservedDataUsedBy(A<ISimulation>._)).Returns(new List<DataRepository>() { _calculationData });
 
          sut.InitializeAnalysis(_predictedVsObservedChart);
+      }
+   }
+
+   public class When_the_chart_of_an_initialized_analysis_is_renamed : concern_for_SimulationPredictedVsObservedChartPresenter
+   {
+      protected override void Because()
+      {
+         _predictedVsObservedChart.Name = "New chart name";
+      }
+
+      [Observation]
+      public void should_update_the_view_caption()
+      {
+         _view.Caption.ShouldBeEqualTo("New chart name");
+      }
+   }
+
+   public class When_the_chart_presenter_has_been_cleared : concern_for_SimulationPredictedVsObservedChartPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Clear();
+         _view.Caption = "Caption before rename";
+      }
+
+      protected override void Because()
+      {
+         _predictedVsObservedChart.Name = "New chart name";
+      }
+
+      [Observation]
+      public void should_not_update_the_view_caption_when_the_chart_is_renamed()
+      {
+         _view.Caption.ShouldBeEqualTo("Caption before rename");
       }
    }
 


### PR DESCRIPTION
Fixes #2928

PK-Sim implements the plot-tab context menu (Clone / Remove / Remove All / Rename...) privately in `PKSim.Presentation`, while the hosting infrastructure already lives in this repo. MoBi consequently shows no context menu at all on its parameter identification / sensitivity analysis plot tabs (Open-Systems-Pharmacology/MoBi#516).

## Changes

- **`IPresenterWithAnalyses`** extracted from `IEditAnalyzablePresenter` (`RemoveAnalysis`, `RemoveAllAnalyses`, `CloneAnalysis` + context menu support). `IEditAnalyzablePresenter` extends it, so existing implementations are unaffected. MoBi's `EditSimulationPresenter` (which does not derive from `EditAnalyzablePresenter`) can implement the small interface to host the same menu on its simulation plot tabs.
- **`SimulationAnalysisPresenterContextMenu`** + specification factory added to `OSPSuite.Presentation.Presenters.ContextMenus` (picked up by the existing context menu scanner): Clone, Remove, Remove All, Rename... — same entries as PK-Sim's menu.
- **`RenameSimulationAnalysisUICommand`**: renames an `ISimulationAnalysis` via `IRenameObjectPresenter`, forbidding the names of sibling analyses (PK-Sim's own rename command does not validate against siblings).
- **`ChartPresenter`** now reacts to a change of the chart's `Name` property with `ChartChanged()` — the view caption updates and the project is marked as changed, with the existing application overrides (`NotifyProjectChanged`/`ChartChanged`) applying as usual. Renaming a PI/SA plot tab currently leaves the tab caption stale until the editor rebinds; the PropertyChanged subscription follows the pattern already used by `ParameterIdentificationResidualHistogramPresenter` and `SensitivityAnalysisPKParameterAnalysisPresenter`.

## Notes for PK-Sim

Once PK-Sim updates to a Core version containing this change (planned as a regular core update PR):
- its own `SimulationAnalysisPresenterContextMenu`/factory in `PKSim.Presentation` becomes a duplicate registration and can be deleted
- `SimulationTimeProfileChartPresenter` no longer needs its `RenamedEvent` listener: the caption update comes from `ChartPresenter`, and marking the owning simulation as changed flows through its existing `NotifyProjectChanged` override
- `EditPopulationAnalysisChartPresenter` keeps its `RenamedEvent` handling (population analysis charts are not `CurveChart`-based)

## Tests

- new specs for the context menu specification factory and menu actions
- new specs for `RenameSimulationAnalysisUICommand`
- new specs for the caption update (and unsubscription on `Clear`) in `SimulationPredictedVsObservedChartPresenterSpecs`
- full `OSPSuite.Presentation.Tests` suite passes (1325 tests); MoBi (2602) and PK-Sim (5599) suites pass locally against a build of this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-menu actions for cloning, renaming, removing, and removing all simulation analyses.
  * Added validation to prevent duplicate analysis names.
  * Added captions for analysis removal actions.

* **Bug Fixes**
  * Chart captions now update when an initialized chart is renamed, while cleared charts remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->