### PR TITLE
Fixes #2930 Share the observed data usage tracking infrastructure with MoBi

### DIFF
--- a/src/OSPSuite.Core/Domain/ISimulation.cs
+++ b/src/OSPSuite.Core/Domain/ISimulation.cs
@@ -12,8 +12,11 @@ namespace OSPSuite.Core.Domain
 
       //ResultsDataRepository will be null for Population Simulations and should never be called for them
       DataRepository ResultsDataRepository { get; set; }
-      void RemoveUsedObservedData(DataRepository dataRepository);
 
+      IEnumerable<UsedObservedData> UsedObservedData { get; }
+      void AddUsedObservedData(DataRepository dataRepository);
+      void AddUsedObservedData(UsedObservedData usedObservedData);
+      void RemoveUsedObservedData(DataRepository dataRepository);
 
       /// <summary>
       ///    Remove the output mappings mapped to the dataRepository

--- a/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
@@ -58,6 +58,17 @@ namespace OSPSuite.Core.Domain.Services
       ///    in Parameter Identifications and also requiring confirmation by the user.
       /// </summary>
       void RemoveUsedObservedDataFromSimulation(IReadOnlyList<UsedObservedData> usedObservedDataList);
+
+      /// <summary>
+      ///    Adds the given observed data to the analysable. Curves will not be shown
+      /// </summary>
+      void AddObservedDataToAnalysable(IReadOnlyList<DataRepository> observedDataList, IAnalysable analysable);
+
+      /// <summary>
+      ///    Adds the given observed data to the analysable. Curves will be shown if the <paramref name="showData" /> flag is
+      ///    set to <c>true</c>
+      /// </summary>
+      void AddObservedDataToAnalysable(IReadOnlyList<DataRepository> observedDataList, IAnalysable analysable, bool showData);
    }
 
    public abstract class ObservedDataTask : IObservedDataTask
@@ -68,16 +79,19 @@ namespace OSPSuite.Core.Domain.Services
       private readonly IContainerTask _containerTask;
       private readonly IObjectTypeResolver _objectTypeResolver;
       private readonly IConfirmationManager _confirmationManager;
+      private readonly IOutputMappingMatchingTask _outputMappingMatchingTask;
 
       protected ObservedDataTask(IDialogCreator dialogCreator, IOSPSuiteExecutionContext executionContext,
          IDataRepositoryExportTask dataRepositoryExportTask, IContainerTask containerTask,
-         IObjectTypeResolver objectTypeResolver, IConfirmationManager confirmationManager)
+         IObjectTypeResolver objectTypeResolver, IConfirmationManager confirmationManager,
+         IOutputMappingMatchingTask outputMappingMatchingTask)
       {
          _dialogCreator = dialogCreator;
          _executionContext = executionContext;
          _dataRepositoryExportTask = dataRepositoryExportTask;
          _containerTask = containerTask;
          _objectTypeResolver = objectTypeResolver;
+         _outputMappingMatchingTask = outputMappingMatchingTask;
          _confirmationManager = confirmationManager;
       }
 
@@ -195,6 +209,29 @@ namespace OSPSuite.Core.Domain.Services
       public void SuppressWarningOnRemovingObservedDataEntryFromSimulation()
       {
          _confirmationManager.SuppressConfirmation(ConfirmationFlags.ObservedDataEntryRemoved);
+      }
+
+      public void AddObservedDataToAnalysable(IReadOnlyList<DataRepository> observedDataList, IAnalysable analysable)
+      {
+         AddObservedDataToAnalysable(observedDataList, analysable, showData: false);
+      }
+
+      public void AddObservedDataToAnalysable(IReadOnlyList<DataRepository> observedDataList, IAnalysable analysable, bool showData)
+      {
+         var simulation = analysable as ISimulation;
+         if (simulation == null)
+            return;
+
+         var observedDataToAdd = observedDataList.Where(x => !simulation.UsesObservedData(x)).ToList();
+         if (!observedDataToAdd.Any())
+            return;
+
+         observedDataToAdd.Each(simulation.AddUsedObservedData);
+         observedDataList.Each(observedData => _outputMappingMatchingTask.AddMatchingOutputMapping(observedData, simulation));
+         simulation.HasChanged = true;
+
+         _executionContext.PublishEvent(new ObservedDataAddedToAnalysableEvent(simulation, observedDataToAdd, showData));
+         _executionContext.PublishEvent(new SimulationStatusChangedEvent(simulation));
       }
 
       public void RemoveUsedObservedDataFromSimulation(IReadOnlyList<UsedObservedData> usedObservedDataList)

--- a/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
+++ b/src/OSPSuite.Core/Domain/Services/ObservedDataTask.cs
@@ -227,7 +227,7 @@ namespace OSPSuite.Core.Domain.Services
             return;
 
          observedDataToAdd.Each(simulation.AddUsedObservedData);
-         observedDataList.Each(observedData => _outputMappingMatchingTask.AddMatchingOutputMapping(observedData, simulation));
+         observedDataToAdd.Each(observedData => _outputMappingMatchingTask.AddMatchingOutputMapping(observedData, simulation));
          simulation.HasChanged = true;
 
          _executionContext.PublishEvent(new ObservedDataAddedToAnalysableEvent(simulation, observedDataToAdd, showData));

--- a/src/OSPSuite.Core/Serialization/Xml/UsedObservedDataXmlSerializer.cs
+++ b/src/OSPSuite.Core/Serialization/Xml/UsedObservedDataXmlSerializer.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace OSPSuite.Core.Serialization.Xml
+{
+   public class UsedObservedDataXmlSerializer : OSPSuiteXmlSerializer<UsedObservedData>
+   {
+      public override void PerformMapping()
+      {
+         Map(x => x.Id);
+      }
+   }
+}

--- a/src/OSPSuite.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/OSPSuite.Presentation/Nodes/TreeNodeFactory.cs
@@ -15,6 +15,7 @@ namespace OSPSuite.Presentation.Nodes
       ITreeNode CreateFor(ClassifiableParameterIdentification classifiableParameterIdentification);
       ITreeNode CreateFor(ClassifiableSensitivityAnalysis classifiableSensitivityAnalysis);
       ITreeNode CreateFor(ClassifiableObservedData observedData);
+      ITreeNode CreateFor(UsedObservedData usedObservedData);
       ITreeNode<TObjectBase> CreateFor<TObjectBase>(TObjectBase entity) where TObjectBase : class, IObjectBase;
       ITreeNode CreateFor(string nodeText, string id, string iconName);
       ITreeNode CreateFor(string nodeText, string id);

--- a/src/OSPSuite.Presentation/UICommands/RemoveUsedObservedDataUICommand.cs
+++ b/src/OSPSuite.Presentation/UICommands/RemoveUsedObservedDataUICommand.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+
+namespace OSPSuite.Presentation.UICommands
+{
+   public class RemoveUsedObservedDataUICommand : ObjectUICommand<IReadOnlyList<UsedObservedData>>
+   {
+      private readonly IObservedDataTask _observedDataTask;
+
+      public RemoveUsedObservedDataUICommand(IObservedDataTask observedDataTask)
+      {
+         _observedDataTask = observedDataTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         _observedDataTask.RemoveUsedObservedDataFromSimulation(Subject);
+      }
+
+      public RemoveUsedObservedDataUICommand For(UsedObservedData usedObservedData)
+      {
+         For(new[] {usedObservedData});
+         return this;
+      }
+   }
+}

--- a/src/OSPSuite.R/Domain/Simulation.cs
+++ b/src/OSPSuite.R/Domain/Simulation.cs
@@ -23,6 +23,7 @@ namespace OSPSuite.R.Domain
       public bool ComesFromPKSim { get; } = false;
       public bool UsesObservedData(DataRepository observedData) => false;
       public IEnumerable<CurveChart> Charts { get; } = new List<CurveChart>();
+      public IEnumerable<UsedObservedData> UsedObservedData { get; } = new List<UsedObservedData>();
       public SimulationEntitySources EntitySources { get; set; } = new SimulationEntitySources();
       public OutputMappings OutputMappings { get; set; }
       public DataRepository ResultsDataRepository { get; set; }
@@ -32,6 +33,16 @@ namespace OSPSuite.R.Domain
       public AgingData AgingData { get; set; }
 
       public bool IsPopulation => IndividualValuesCache != null;
+
+      public void AddUsedObservedData(DataRepository dataRepository)
+      {
+         // nothing to do in R
+      }
+
+      public void AddUsedObservedData(UsedObservedData usedObservedData)
+      {
+         // nothing to do in R
+      }
 
       public void RemoveUsedObservedData(DataRepository dataRepository)
       {

--- a/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
@@ -213,6 +213,13 @@ namespace OSPSuite.Core.Services
       }
 
       [Observation]
+      public void should_add_matching_output_mappings_only_for_the_newly_used_observed_data()
+      {
+         A.CallTo(() => _outputMappingMatchingTask.AddMatchingOutputMapping(_obsData1, _simulation)).MustHaveHappened();
+         A.CallTo(() => _outputMappingMatchingTask.AddMatchingOutputMapping(_alreadyUsedObservedData, _simulation)).MustNotHaveHappened();
+      }
+
+      [Observation]
       public void should_mark_the_simulation_as_changed()
       {
          A.CallToSet(() => _simulation.HasChanged).To(true).MustHaveHappened();

--- a/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Services/ObservedDataTaskSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.Core.Commands;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Events;
 using OSPSuite.Helpers;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +20,7 @@ namespace OSPSuite.Core.Services
       protected IContainerTask _containerTask;
       protected IObjectTypeResolver _objectTypeResolver;
       protected IConfirmationManager _confirmationManager;
+      protected IOutputMappingMatchingTask _outputMappingMatchingTask;
       protected DataRepository _obsData1;
       protected DataRepository _obsData2;
       protected List<IUsesObservedData> _allUserOfObservedData = new List<IUsesObservedData>();
@@ -31,8 +33,9 @@ namespace OSPSuite.Core.Services
          _containerTask = A.Fake<IContainerTask>();
          _objectTypeResolver = A.Fake<IObjectTypeResolver>();
          _confirmationManager = A.Fake<IConfirmationManager>();
+         _outputMappingMatchingTask = A.Fake<IOutputMappingMatchingTask>();
 
-         sut = new ObservedDataTaskForSpecs(_dialogCreator, _context, _dataRepositoryTask, _containerTask, _objectTypeResolver, _confirmationManager);
+         sut = new ObservedDataTaskForSpecs(_dialogCreator, _context, _dataRepositoryTask, _containerTask, _objectTypeResolver, _confirmationManager, _outputMappingMatchingTask);
 
          _obsData1 = DomainHelperForSpecs.ObservedData("OBS1");
          _obsData2 = DomainHelperForSpecs.ObservedData("OBS2");
@@ -183,10 +186,78 @@ namespace OSPSuite.Core.Services
       }
    }
 
+   public class When_adding_observed_data_to_a_simulation : concern_for_ObservedDataTask
+   {
+      private ISimulation _simulation;
+      private DataRepository _alreadyUsedObservedData;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<ISimulation>();
+         _alreadyUsedObservedData = _obsData2;
+         A.CallTo(() => _simulation.UsesObservedData(_obsData1)).Returns(false);
+         A.CallTo(() => _simulation.UsesObservedData(_alreadyUsedObservedData)).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.AddObservedDataToAnalysable(new[] {_obsData1, _alreadyUsedObservedData}, _simulation, showData: true);
+      }
+
+      [Observation]
+      public void should_register_the_observed_data_not_already_used_by_the_simulation()
+      {
+         A.CallTo(() => _simulation.AddUsedObservedData(_obsData1)).MustHaveHappened();
+         A.CallTo(() => _simulation.AddUsedObservedData(_alreadyUsedObservedData)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_mark_the_simulation_as_changed()
+      {
+         A.CallToSet(() => _simulation.HasChanged).To(true).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_notify_that_observed_data_was_added_to_the_simulation()
+      {
+         A.CallTo(() => _context.PublishEvent(A<ObservedDataAddedToAnalysableEvent>.That.Matches(x => x.ShowData && x.ObservedData.Contains(_obsData1)))).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_observed_data_already_used_by_the_simulation : concern_for_ObservedDataTask
+   {
+      private ISimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<ISimulation>();
+         A.CallTo(() => _simulation.UsesObservedData(_obsData1)).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.AddObservedDataToAnalysable(new[] {_obsData1}, _simulation);
+      }
+
+      [Observation]
+      public void should_not_register_the_observed_data_again()
+      {
+         A.CallTo(() => _simulation.AddUsedObservedData(A<DataRepository>._)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_notify_any_change()
+      {
+         A.CallTo(() => _context.PublishEvent(A<ObservedDataAddedToAnalysableEvent>._)).MustNotHaveHappened();
+      }
+   }
+
    internal class ObservedDataTaskForSpecs : ObservedDataTask
    {
-      public ObservedDataTaskForSpecs(IDialogCreator dialogCreator, IOSPSuiteExecutionContext executionContext, IDataRepositoryExportTask dataRepositoryTask, IContainerTask containerTask, IObjectTypeResolver objectTypeResolver, IConfirmationManager confirmationManager) : base(dialogCreator, executionContext, dataRepositoryTask,
-         containerTask, objectTypeResolver, confirmationManager)
+      public ObservedDataTaskForSpecs(IDialogCreator dialogCreator, IOSPSuiteExecutionContext executionContext, IDataRepositoryExportTask dataRepositoryTask, IContainerTask containerTask, IObjectTypeResolver objectTypeResolver, IConfirmationManager confirmationManager, IOutputMappingMatchingTask outputMappingMatchingTask) : base(dialogCreator, executionContext, dataRepositoryTask,
+         containerTask, objectTypeResolver, confirmationManager, outputMappingMatchingTask)
       {
       }
 

--- a/tests/OSPSuite.Starter/Domain/TestSimulation.cs
+++ b/tests/OSPSuite.Starter/Domain/TestSimulation.cs
@@ -20,6 +20,19 @@ namespace OSPSuite.Starter.Domain
       public OutputMappings OutputMappings { get; set; } = new OutputMappings();
       public DataRepository ResultsDataRepository { get; set; }
 
+      public IEnumerable<UsedObservedData> UsedObservedData
+      {
+         get { yield break; }
+      }
+
+      public void AddUsedObservedData(DataRepository dataRepository)
+      {
+      }
+
+      public void AddUsedObservedData(UsedObservedData usedObservedData)
+      {
+      }
+
       public void RemoveUsedObservedData(DataRepository dataRepository)
       {
       }


### PR DESCRIPTION
Fixes #2930

Moves the observed data usage tracking building blocks from PK-Sim to Core so MoBi can share them (Open-Systems-Pharmacology/MoBi#2474, split from Open-Systems-Pharmacology/MoBi#267):

- `UsedObservedData` members on `ISimulation` (`UsedObservedData`, `AddUsedObservedData` overloads)
- `AddObservedDataToAnalysable` on the `ObservedDataTask` base, lifted from PK-Sim's `CoreObservedDataTask` (now casts to `ISimulation` and marks the simulation as changed); `IOutputMappingMatchingTask` moves into the base constructor
- `UsedObservedDataXmlSerializer` (same element name and mapping as PK-Sim's — existing project XML is unaffected)
- `CreateFor(UsedObservedData)` declared on `ITreeNodeFactory` (implementation unchanged)
- `RemoveUsedObservedDataUICommand` in OSPSuite.Presentation

Follow-up PRs in PK-Sim and MoBi delete the local copies and consume these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for associating observed data with simulations.
  * Added options to add observed data to analysable items, including automatic output mapping.
  * Added the ability to remove selected observed data from simulations.
  * Added persistence and tree-view support for used observed data.

* **Bug Fixes**
  * Prevented duplicate observed data from being added.
  * Simulations now reflect changes and notify the interface when observed data is added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->