### PR TITLE
Fixes #2933 Add CheckForNegativeValues to the solver settings snapshot

### DIFF
--- a/src/OSPSuite.Core/Snapshots/Mappers/SolverSettingsMapper.cs
+++ b/src/OSPSuite.Core/Snapshots/Mappers/SolverSettingsMapper.cs
@@ -24,6 +24,7 @@ namespace OSPSuite.Core.Snapshots.Mappers
             snapshot.HMin = SnapshotValueFor(solverSettings.HMin, _defaultSolverSettings.HMin);
             snapshot.HMax = SnapshotValueFor(solverSettings.HMax, _defaultSolverSettings.HMax);
             snapshot.MxStep = SnapshotValueFor(solverSettings.MxStep, _defaultSolverSettings.MxStep);
+            snapshot.CheckForNegativeValues = SnapshotValueFor(solverSettings.CheckForNegativeValues, _defaultSolverSettings.CheckForNegativeValues);
          });
       }
 
@@ -40,6 +41,7 @@ namespace OSPSuite.Core.Snapshots.Mappers
          solverSettings.HMin = ModelValueFor(snapshot.HMin, _defaultSolverSettings.HMin);
          solverSettings.HMax = ModelValueFor(snapshot.HMax, _defaultSolverSettings.HMax);
          solverSettings.MxStep = ModelValueFor(snapshot.MxStep, _defaultSolverSettings.MxStep);
+         solverSettings.CheckForNegativeValues = ModelValueFor(snapshot.CheckForNegativeValues, _defaultSolverSettings.CheckForNegativeValues);
 
          return Task.FromResult(solverSettings);
       }

--- a/src/OSPSuite.Core/Snapshots/SolverSettings.cs
+++ b/src/OSPSuite.Core/Snapshots/SolverSettings.cs
@@ -9,5 +9,6 @@
       public double? HMin { get; set; }
       public double? HMax { get; set; }
       public int? MxStep { get; set; }
+      public bool? CheckForNegativeValues { get; set; }
    }
 }

--- a/tests/OSPSuite.Core.Tests/Mappers/SolverSettingsMapperSpecs.cs
+++ b/tests/OSPSuite.Core.Tests/Mappers/SolverSettingsMapperSpecs.cs
@@ -28,7 +28,8 @@ namespace OSPSuite.Core.Mappers
             DomainHelperForSpecs.ConstantParameterWithValue(2.5).WithName(Constants.Parameters.H_MAX),
             DomainHelperForSpecs.ConstantParameterWithValue(100).WithName(Constants.Parameters.MX_STEP),
             DomainHelperForSpecs.ConstantParameterWithValue(1e-5).WithName(Constants.Parameters.REL_TOL),
-            DomainHelperForSpecs.ConstantParameterWithValue(1e-7).WithName(Constants.Parameters.ABS_TOL)
+            DomainHelperForSpecs.ConstantParameterWithValue(1e-7).WithName(Constants.Parameters.ABS_TOL),
+            DomainHelperForSpecs.ConstantParameterWithValue(0).WithName(Constants.Parameters.CHECK_FOR_NEGATIVE_VALUES)
          };
 
          var solverSettings = A.Fake<SolverSettings>();
@@ -39,6 +40,7 @@ namespace OSPSuite.Core.Mappers
          solverSettings.H0 = 5;
          solverSettings.HMax = 6;
          solverSettings.UseJacobian = false;
+         solverSettings.CheckForNegativeValues = true;
          A.CallTo(() => _solverSettingsFactory.CreateCVODE()).Returns(solverSettings);
 
          sut = new Helpers.Snapshots.SolverSettingsMapper(_solverSettingsFactory);
@@ -63,6 +65,7 @@ namespace OSPSuite.Core.Mappers
          _snapshot.HMin.ShouldBeEqualTo(_solverSettings.HMin);
          _snapshot.HMax.ShouldBeEqualTo(_solverSettings.HMax);
          _snapshot.H0.ShouldBeEqualTo(_solverSettings.H0);
+         _snapshot.CheckForNegativeValues.ShouldBeEqualTo(_solverSettings.CheckForNegativeValues);
       }
    }
 
@@ -92,6 +95,7 @@ namespace OSPSuite.Core.Mappers
          _newSolverSettings.MxStep.ShouldBeEqualTo(_snapshot.MxStep.Value);
          _newSolverSettings.HMin.ShouldBeEqualTo(_snapshot.HMin.Value);
          _newSolverSettings.UseJacobian.ShouldBeEqualTo(_snapshot.UseJacobian.Value);
+         _newSolverSettings.CheckForNegativeValues.ShouldBeEqualTo(_snapshot.CheckForNegativeValues.Value);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2933

`SolverSettings.CheckForNegativeValues` was added in #2696 but never made it into the snapshot representation, so the setting was silently lost on any snapshot round-trip: turning the check off, exporting a snapshot and re-importing it gave the check back on.

## Changes

* `Snapshots/SolverSettings.cs` — added `public bool? CheckForNegativeValues { get; set; }`.
* `Snapshots/Mappers/SolverSettingsMapper.cs` — added the matching `SnapshotValueFor` line to `MapToSnapshot` and `ModelValueFor` line to `MapToModel`, alongside the other seven solver settings. This is the shared abstract mapper, so both MoBi and PK-Sim pick up the fix.
* `SolverSettingsMapperSpecs` — the fixture's `SolverSettings` container had no `CHECK_FOR_NEGATIVE_VALUES` parameter (the domain property reads through `this.Parameter(...)`), so it is now added with a non-default value and asserted in both the to-snapshot and the round-trip observations.

No snapshot version bump is needed — the property is nullable and a missing value falls back to the factory default.

Found while investigating Open-Systems-Pharmacology/MoBi#2317.