### PR TITLE
Fixes #2633 `Autoupdate chart` in chart context menu and in chart editor is not synchronized.

### DIFF
--- a/src/OSPSuite.Assets/UIConstants.cs
+++ b/src/OSPSuite.Assets/UIConstants.cs
@@ -219,7 +219,7 @@ namespace OSPSuite.Assets
       public static readonly string NotDistributed = "Not Distributed";
       public static readonly string DeleteSelected = "Delete Selected Records";
       public static readonly string ModulesFolder = "Modules";
-      public static readonly string ApplyChangesToUpdateChart = "Apply changes to update chart";
+      public static readonly string ApplyUpdatesToRefreshTheChart = "Apply updates to refresh the chart";
       public static readonly string ApplyUpdates = "Apply updates";
       public static readonly string AutoUpdateChart = "Auto-update chart";
       public static readonly string Undefined = "Undefined";
@@ -2412,7 +2412,7 @@ namespace OSPSuite.Assets
    {
       public static readonly string ToolTipForAxis = "Double click to edit axis";
       public static readonly string UseSelectedCurvesToolTip = "Adds or removes all the selected curves at once.";
-      public static readonly string EnableOrDisableAutomaticUpdateOfTheChartForEachEdit = "Enable or Disable automatic update of the chart for each edit.";
+      public static readonly string EnableOrDisableAutomaticUpdateOfTheChartForEachEdit = "Enable or disable automatic update of the chart for each edit.";
       public static readonly string LinkSimulationObservedToolTip = "Links the simulation outputs to their mapped observed data, so that when a simulation output is (de)selected the corresponding observed data gets (de)selected as well.";
       public static readonly string AddUnitMap = "Add new default unit for a specific dimension";
       public static readonly string LoadUnits = "Load default units from file";

--- a/src/OSPSuite.Core/Chart/ChartEvent.cs
+++ b/src/OSPSuite.Core/Chart/ChartEvent.cs
@@ -47,4 +47,11 @@ namespace OSPSuite.Core.Chart
       {
       }
    }
+
+   public class ChartAutoUpdateChangedEvent : ChartEvent
+   {
+      public ChartAutoUpdateChangedEvent(IChart chart) : base(chart)
+      {
+      }
+   }
 }

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartDisplayPresenter.cs
@@ -202,6 +202,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
       /// Applies the watermark to the chart if the chart is in preview mode and auto update is enabled, otherwise does nothing
       /// </summary>
       void UpdateWatermark();
+
+      void UpdateAutoUpdateMode(bool enabled);
    }
 
    public class ChartDisplayPresenter : AbstractPresenter<IChartDisplayView, IChartDisplayPresenter>, IChartDisplayPresenter
@@ -213,6 +215,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
       private readonly ICurveChartExportTask _chartExportTask;
       private readonly IApplicationSettings _applicationSettings;
       private readonly IApplicationController _applicationController;
+      private readonly IEventPublisher _eventPublisher;
       private readonly Cache<AxisTypes, IAxisBinder> _axisBinders;
       private readonly Cache<string, ICurveBinder> _curveBinders;
       private readonly Cache<string, ICurveBinder> _quickCurveBinderCache;
@@ -247,7 +250,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
          ICurveChartExportTask chartExportTask,
          IApplicationSettings applicationSettings,
          IApplicationController applicationController,
-         IDialogCreator dialogCreator)
+         IDialogCreator dialogCreator,
+         IEventPublisher eventPublisher)
          : base(chartDisplayView)
       {
          _curveBinderFactory = curveBinderFactory;
@@ -262,6 +266,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          _displayChartFontAndSizeSettings = new ChartFontAndSizeSettings();
          _applicationController = applicationController;
          _dialogCreator = dialogCreator;
+         _eventPublisher = eventPublisher;
       }
 
       public CurveChart Chart { get; private set; }
@@ -301,6 +306,18 @@ namespace OSPSuite.Presentation.Presenters.Charts
       }
 
       public void Refresh() => updateChart();
+
+      public void UpdateAutoUpdateMode(bool enabled)
+      {
+         if (Chart.AutoUpdateEnabled == enabled)
+            return;
+
+         Chart.AutoUpdateEnabled = enabled;
+         _eventPublisher.PublishEvent(new ChartAutoUpdateChangedEvent(Chart));
+
+         if (Chart.AutoUpdateEnabled)
+            Refresh();
+      }
 
       private void rebuildQuickCurveBinderCache()
       {
@@ -582,7 +599,7 @@ namespace OSPSuite.Presentation.Presenters.Charts
          if (!Chart.AutoUpdateEnabled)
          {
             _curveBinders.Each(x => x.HideAllSeries());
-            View.ShowWatermark(Captions.ApplyChangesToUpdateChart);
+            View.ShowWatermark(Captions.ApplyUpdatesToRefreshTheChart);
             return;
          }
 

--- a/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
+++ b/src/OSPSuite.Presentation/Presenters/Charts/ChartEditorPresenter.cs
@@ -27,7 +27,8 @@ namespace OSPSuite.Presentation.Presenters.Charts
    ///    - ChartOptions for editing properties of chartSettings.
    /// </summary>
    public interface IChartEditorPresenter : IPresenter<IChartEditorView>,
-      IListener<ChartUpdatedEvent>
+      IListener<ChartUpdatedEvent>,
+      IListener<ChartAutoUpdateChangedEvent>
    {
       CurveChart Chart { get; }
 
@@ -454,6 +455,9 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
       public void UpdateAutoUpdateChartMode(bool autoMode)
       {
+         if (Chart.AutoUpdateEnabled == autoMode)
+            return;
+
          Chart.AutoUpdateEnabled = autoMode;
          if (Chart.AutoUpdateEnabled)
             UpdateChartDisplay();
@@ -764,6 +768,14 @@ namespace OSPSuite.Presentation.Presenters.Charts
 
          if (chartUpdatedEvent.PropagateChartChangeEvent)
             ChartChanged();
+      }
+
+      public void Handle(ChartAutoUpdateChangedEvent chartAutoUpdateChangedEvent)
+      {
+         if (!canHandle(chartAutoUpdateChangedEvent))
+            return;
+
+         _view.SetAutoUpdateModeCheckBox(Chart.AutoUpdateEnabled);
       }
 
       private void refreshColorGroupingPresenter()

--- a/src/OSPSuite.Presentation/Presenters/ContextMenus/CurveChartContextMenu.cs
+++ b/src/OSPSuite.Presentation/Presenters/ContextMenus/CurveChartContextMenu.cs
@@ -53,20 +53,13 @@ namespace OSPSuite.Presentation.Presenters.ContextMenus
 
          yield return CreateMenuCheckButton.WithCaption(MenuNames.AutoUpdateChart)
             .WithChecked(curveChart.AutoUpdateEnabled)
-            .WithCheckedAction(enabled => updateAutoUpdateMode(curveChart, chartDisplayPresenter, enabled));
+            .WithCheckedAction(chartDisplayPresenter.UpdateAutoUpdateMode);
 
          if (curveChart.IsAnImplementationOf<PredictedVsObservedChart>())
          {
             yield return CreateMenuButton.WithCaption(MenuNames.AddDeviationLines)
                .WithActionCommand(chartDisplayPresenter.AddDeviationLines);
          }
-      }
-
-      private static void updateAutoUpdateMode(CurveChart curveChart, IChartDisplayPresenter chartDisplayPresenter, bool enabled)
-      {
-         curveChart.AutoUpdateEnabled = enabled;
-         if (curveChart.AutoUpdateEnabled)
-            chartDisplayPresenter.Refresh();
       }
    }
 

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartDisplayPresenterSpecs.cs
@@ -14,6 +14,7 @@ using OSPSuite.Presentation.Presenters.Charts;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views.Charts;
+using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Exceptions;
 using DataRow = System.Data.DataRow;
 using DataTable = System.Data.DataTable;
@@ -38,6 +39,7 @@ namespace OSPSuite.Presentation.Presentation
       protected IApplicationSettings _applicationSettings;
       protected IApplicationController _applicationController;
       protected IDialogCreator _dialogCreator;
+      protected IEventPublisher _eventPublisher;
 
       protected override void Context()
       {
@@ -52,8 +54,9 @@ namespace OSPSuite.Presentation.Presentation
          _applicationSettings = A.Fake<IApplicationSettings>();
          _applicationController = A.Fake<IApplicationController>();
          _dialogCreator = A.Fake<IDialogCreator>();
+         _eventPublisher = A.Fake<IEventPublisher>();
 
-         sut = new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactory, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator);
+         sut = new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactory, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator, _eventPublisher);
          var dataRepository = DomainHelperForSpecs.SimulationDataRepositoryFor("Sim");
 
          A.CallTo(() => _dimensionFactory.MergedDimensionFor(A<DataColumn>._)).ReturnsLazily(x => x.GetArgument<DataColumn>(0).Dimension);
@@ -449,6 +452,79 @@ namespace OSPSuite.Presentation.Presentation
       public void should_return_nan()
       {
          double.IsNaN(sut.GetYValueFromDataRow("unknown series", _row)).ShouldBeTrue();
+      }
+   }
+
+   public class When_disabling_the_automatic_update_of_the_displayed_chart : concern_for_ChartDisplayPresenter
+   {
+      protected override void Because()
+      {
+         sut.UpdateAutoUpdateMode(enabled: false);
+      }
+
+      [Observation]
+      public void should_disable_the_automatic_update_of_the_chart()
+      {
+         _curveChart.AutoUpdateEnabled.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_notify_that_the_automatic_update_mode_of_the_chart_has_changed()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ChartAutoUpdateChangedEvent>.That.Matches(x => Equals(x.Chart, _curveChart)))).MustHaveHappened();
+      }
+   }
+
+   public class When_enabling_the_automatic_update_of_the_displayed_chart : concern_for_ChartDisplayPresenter
+   {
+      protected override void SetupChart()
+      {
+         base.SetupChart();
+         _curveChart.AutoUpdateEnabled = false;
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         //the chart was already drawn while editing it, only the calls triggered by the mode change are of interest here
+         Fake.ClearRecordedCalls(_chartDisplayView);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateAutoUpdateMode(enabled: true);
+      }
+
+      [Observation]
+      public void should_enable_the_automatic_update_of_the_chart()
+      {
+         _curveChart.AutoUpdateEnabled.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_notify_that_the_automatic_update_mode_of_the_chart_has_changed()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ChartAutoUpdateChangedEvent>.That.Matches(x => Equals(x.Chart, _curveChart)))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_refresh_the_displayed_chart()
+      {
+         A.CallTo(() => _chartDisplayView.ShowWatermark(A<string>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_setting_the_automatic_update_of_the_displayed_chart_to_its_current_value : concern_for_ChartDisplayPresenter
+   {
+      protected override void Because()
+      {
+         sut.UpdateAutoUpdateMode(enabled: true);
+      }
+
+      [Observation]
+      public void should_not_notify_that_the_automatic_update_mode_of_the_chart_has_changed()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ChartAutoUpdateChangedEvent>._)).MustNotHaveHappened();
       }
    }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/ChartEditorPresenterSpecs.cs
@@ -947,4 +947,78 @@ namespace OSPSuite.Presentation.Presentation
          _colorsForCurveName[_curve3.Id].Equals(_colorsForCurveName[_curve2.Id]).ShouldBeFalse();
       }
    }
+
+   public class When_notified_that_the_automatic_update_mode_of_the_edited_chart_has_changed : concern_for_ChartEditorPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _chart.AutoUpdateEnabled = false;
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ChartAutoUpdateChangedEvent(_chart));
+      }
+
+      [Observation]
+      public void should_update_the_automatic_update_check_box_of_the_view()
+      {
+         A.CallTo(() => _view.SetAutoUpdateModeCheckBox(false)).MustHaveHappened();
+      }
+   }
+
+   public class When_notified_that_the_automatic_update_mode_of_another_chart_has_changed : concern_for_ChartEditorPresenter
+   {
+      protected override void Because()
+      {
+         sut.Handle(new ChartAutoUpdateChangedEvent(new CurveChart { AutoUpdateEnabled = false }));
+      }
+
+      [Observation]
+      public void should_not_update_the_automatic_update_check_box_of_the_view()
+      {
+         A.CallTo(() => _view.SetAutoUpdateModeCheckBox(false)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_setting_the_automatic_update_mode_of_the_edited_chart_to_its_current_value : concern_for_ChartEditorPresenter
+   {
+      protected override void Because()
+      {
+         sut.UpdateAutoUpdateChartMode(autoMode: true);
+      }
+
+      [Observation]
+      public void should_not_trigger_an_update_of_the_chart_display()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ApplyChangesEvent>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_enabling_the_automatic_update_mode_of_the_edited_chart : concern_for_ChartEditorPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _chart.AutoUpdateEnabled = false;
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateAutoUpdateChartMode(autoMode: true);
+      }
+
+      [Observation]
+      public void should_enable_the_automatic_update_of_the_chart()
+      {
+         _chart.AutoUpdateEnabled.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_trigger_an_update_of_the_chart_display()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ApplyChangesEvent>.That.Matches(x => Equals(x.Chart, _chart)))).MustHaveHappened();
+      }
+   }
 }

--- a/tests/OSPSuite.Presentation.Tests/Presentation/CurveChartContextMenuSpecs.cs
+++ b/tests/OSPSuite.Presentation.Tests/Presentation/CurveChartContextMenuSpecs.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters.Charts;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Views.ContextMenus;
+using IContainer = OSPSuite.Utility.Container.IContainer;
+
+namespace OSPSuite.Presentation.Presentation
+{
+   public abstract class concern_for_CurveChartContextMenu : ContextSpecification<CurveChartContextMenu>
+   {
+      protected IContainer _container;
+      protected IContextMenuView _contextMenuView;
+      protected IChartDisplayPresenter _chartDisplayPresenter;
+      protected CurveChart _curveChart;
+      protected List<IMenuBarItem> _allMenuItems;
+
+      protected override void Context()
+      {
+         _container = A.Fake<IContainer>();
+         _contextMenuView = A.Fake<IContextMenuView>();
+         _chartDisplayPresenter = A.Fake<IChartDisplayPresenter>();
+         _curveChart = new CurveChart();
+         _allMenuItems = new List<IMenuBarItem>();
+
+         A.CallTo(() => _container.Resolve<IContextMenuView>()).Returns(_contextMenuView);
+         A.CallTo(() => _contextMenuView.AddMenuItem(A<IMenuBarItem>._))
+            .Invokes(x => _allMenuItems.Add(x.GetArgument<IMenuBarItem>(0)));
+      }
+
+      protected IMenuBarCheckItem AutoUpdateCheckItem =>
+         _allMenuItems.OfType<IMenuBarCheckItem>().First(x => string.Equals(x.Caption, MenuNames.AutoUpdateChart));
+   }
+
+   public class When_creating_the_context_menu_for_a_chart_with_automatic_update_enabled : concern_for_CurveChartContextMenu
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _curveChart.AutoUpdateEnabled = true;
+         sut = new CurveChartContextMenu(_curveChart, _chartDisplayPresenter, _container);
+      }
+
+      [Observation]
+      public void should_show_the_automatic_update_entry_as_checked()
+      {
+         AutoUpdateCheckItem.Checked.ShouldBeTrue();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_a_chart_with_automatic_update_disabled : concern_for_CurveChartContextMenu
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _curveChart.AutoUpdateEnabled = false;
+         sut = new CurveChartContextMenu(_curveChart, _chartDisplayPresenter, _container);
+      }
+
+      [Observation]
+      public void should_show_the_automatic_update_entry_as_unchecked()
+      {
+         AutoUpdateCheckItem.Checked.ShouldBeFalse();
+      }
+   }
+
+   public class When_disabling_the_automatic_update_from_the_chart_context_menu : concern_for_CurveChartContextMenu
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _curveChart.AutoUpdateEnabled = true;
+         sut = new CurveChartContextMenu(_curveChart, _chartDisplayPresenter, _container);
+      }
+
+      protected override void Because()
+      {
+         AutoUpdateCheckItem.Checked = false;
+      }
+
+      [Observation]
+      public void should_let_the_display_presenter_update_the_automatic_update_mode()
+      {
+         A.CallTo(() => _chartDisplayPresenter.UpdateAutoUpdateMode(false)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_update_the_chart_directly()
+      {
+         _curveChart.AutoUpdateEnabled.ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2633

Toggling auto-update in the chart context menu mutated `CurveChart.AutoUpdateEnabled` directly, so the chart editor checkbox never noticed. The context menu now delegates to the display presenter, which publishes a `ChartAutoUpdateChangedEvent`; the chart editor presenter listens for it and updates its checkbox. The reverse direction already worked because the context menu is rebuilt on each popup.

Both presenters skip the update when the value is unchanged, which avoids a redundant chart refresh when the checkbox echoes the event back.

Wording cleanup:
- Chart watermark: `Apply changes to update chart` → `Apply updates to refresh the chart`, matching the `Apply updates` button and context menu entry. Constant renamed to `Captions.ApplyUpdatesToRefreshTheChart`.
- Checkbox tooltip: `Enable or Disable ...` → `Enable or disable ...`

The `Autoupdate`/`Auto-update` hyphenation mismatch from the issue discussion was already fixed by #2653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronized automatic chart-update controls across chart displays, editors, and context menus.
  * Enabling automatic updates now refreshes the chart immediately.
  * Chart editors now reflect automatic-update changes made elsewhere.

* **Bug Fixes**
  * Prevented unnecessary updates and notifications when the selected mode is unchanged.
  * Updated chart instructions and tooltip capitalization for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->