### PR TITLE
Fix build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Core functionalities of the Open Systems Pharmacology Suite.
 
 ## Code Status
-[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite.Core/build-and-publish_12.3.yml?logo=nuget&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/actions/workflows/build-and-publish_12.3.yml)
+[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite.Core/build-and-publish_v13.yml?branch=develop&logo=nuget&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/actions/workflows/build-and-publish_v13.yml)
 [![Coverage status](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite.Core/branch/develop/graph/badge.svg)](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite.Core)
 
 ## Code of conduct


### PR DESCRIPTION
The build status badge in the README pointed at `build-and-publish_12.3.yml`, a workflow that was renamed to `build-and-publish_v13.yml`. shields.io was returning `Build status: repo or workflow not found`.

### Changes
- Updated the workflow filename in both the image URL and the link target.
- Added `?branch=develop` — that workflow only triggers on pushes to `develop`, so pinning the branch keeps the badge from reporting unrelated runs.

### Verification
Fetched both shields.io URLs directly:

| | title |
|---|---|
| before | `Build status: repo or workflow not found` |
| after | `Build status: passing` |

The adjacent coverage badge was checked as well and is working (returns 77%) — left unchanged.

No production code is touched, so there is no linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)